### PR TITLE
OPE-79: Add orchestration canvas artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ BigClaw is a Symphony/Codex workflow project scaffolded from `workflow.md`.
   - persistent priority queue
   - risk/tool based scheduler
   - worker runtime with sandbox profiles and auditable tool gateway
-  - workflow DSL plus workflow engine with workpad journal, orchestration artifacts, entitlement-aware policy, and acceptance gate
+  - workflow DSL plus workflow engine with workpad journal, orchestration artifacts/canvas, entitlement-aware policy, and acceptance gate
   - observability ledger with logs/trace/artifact/audit capture
   - queue-to-scheduler execution recording with audit reports
   - auto triage center for failed, pending-approval, and replay-needed runs

--- a/src/bigclaw/__init__.py
+++ b/src/bigclaw/__init__.py
@@ -13,6 +13,7 @@ from .orchestration import (
     OrchestrationPlan,
     OrchestrationPolicyDecision,
     PremiumOrchestrationPolicy,
+    render_orchestration_canvas,
     render_orchestration_plan,
 )
 from .runtime import (
@@ -97,6 +98,7 @@ __all__ = [
     "OrchestrationPlan",
     "OrchestrationPolicyDecision",
     "PremiumOrchestrationPolicy",
+    "render_orchestration_canvas",
     "render_orchestration_plan",
     "ClawWorkerRuntime",
     "SandboxProfile",

--- a/src/bigclaw/orchestration.py
+++ b/src/bigclaw/orchestration.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from html import escape
 from typing import Dict, List, Optional, Sequence, Tuple
 
 from .models import RiskLevel, Task
@@ -260,3 +261,89 @@ def render_orchestration_plan(
             )
 
     return "\n".join(lines) + "\n"
+
+
+def render_orchestration_canvas(
+    task: Task,
+    plan: OrchestrationPlan,
+    policy_decision: Optional[OrchestrationPolicyDecision] = None,
+    handoff_request: Optional[HandoffRequest] = None,
+) -> str:
+    handoff_cards = "".join(
+        f"""
+        <section class=\"card handoff\">
+          <div class=\"eyebrow\">Lane {index}</div>
+          <h2>{escape(handoff.department)}</h2>
+          <p>{escape(handoff.reason)}</p>
+          <dl>
+            <div><dt>Tools</dt><dd>{escape(', '.join(handoff.required_tools) if handoff.required_tools else 'none')}</dd></div>
+            <div><dt>Approvals</dt><dd>{escape(', '.join(handoff.approvals) if handoff.approvals else 'none')}</dd></div>
+          </dl>
+        </section>
+        """
+        for index, handoff in enumerate(plan.handoffs, start=1)
+    ) or "<section class=\"card handoff\"><h2>No handoffs</h2><p>This task stays within a single delivery lane.</p></section>"
+
+    acceptance_items = "".join(f"<li>{escape(item)}</li>" for item in task.acceptance_criteria) or "<li>none</li>"
+    validation_items = "".join(f"<li>{escape(item)}</li>" for item in task.validation_plan) or "<li>none</li>"
+    label_items = escape(", ".join(task.labels) if task.labels else "none")
+    tool_items = escape(", ".join(task.required_tools) if task.required_tools else "none")
+    approval_items = escape(", ".join(plan.required_approvals) if plan.required_approvals else "none")
+    tier = policy_decision.tier if policy_decision is not None else "standard"
+    upgrade_required = policy_decision.upgrade_required if policy_decision is not None else False
+    blocked_departments = (
+        escape(", ".join(policy_decision.blocked_departments))
+        if policy_decision is not None and policy_decision.blocked_departments
+        else "none"
+    )
+    handoff_team = handoff_request.target_team if handoff_request is not None else "none"
+    handoff_reason = handoff_request.reason if handoff_request is not None else "No manual handoff required"
+
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>Orchestration Canvas · {escape(task.task_id)}</title>
+  <style>
+    :root {{ color-scheme: light dark; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }}
+    body {{ margin: 2rem auto; max-width: 1100px; padding: 0 1rem 3rem; line-height: 1.5; }}
+    .grid {{ display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); }}
+    .canvas {{ display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); margin-top: 1rem; }}
+    .card {{ border: 1px solid #cbd5e1; border-radius: 14px; padding: 1rem; background: rgba(148, 163, 184, 0.08); }}
+    .handoff {{ position: relative; }}
+    .handoff::after {{ content: "→"; position: absolute; right: -0.7rem; top: 50%; transform: translateY(-50%); font-size: 1.4rem; opacity: 0.45; }}
+    .handoff:last-child::after {{ content: ""; }}
+    .eyebrow {{ text-transform: uppercase; letter-spacing: 0.08em; font-size: 0.75rem; opacity: 0.7; }}
+    dl {{ margin: 0; }}
+    dt {{ font-weight: 600; margin-top: 0.75rem; }}
+    dd {{ margin: 0.15rem 0 0; }}
+    ul {{ padding-left: 1.2rem; }}
+  </style>
+</head>
+<body>
+  <h1>Orchestration Canvas</h1>
+  <p><strong>{escape(task.task_id)}</strong> · {escape(task.title)}</p>
+  <div class=\"grid\">
+    <section class=\"card\"><div class=\"eyebrow\">Mode</div><strong>{escape(plan.collaboration_mode)}</strong></section>
+    <section class=\"card\"><div class=\"eyebrow\">Departments</div><strong>{escape(str(plan.department_count))}</strong><br>{escape(', '.join(plan.departments) if plan.departments else 'none')}</section>
+    <section class=\"card\"><div class=\"eyebrow\">Required approvals</div><strong>{approval_items}</strong></section>
+    <section class=\"card\"><div class=\"eyebrow\">Task profile</div>Labels: {label_items}<br>Tools: {tool_items}</section>
+    <section class=\"card\"><div class=\"eyebrow\">Tier</div><strong>{escape(tier)}</strong><br>Upgrade Required: {escape(str(upgrade_required))}</section>
+    <section class=\"card\"><div class=\"eyebrow\">Blocked departments</div>{blocked_departments}</section>
+    <section class=\"card\"><div class=\"eyebrow\">Human handoff</div><strong>{escape(handoff_team)}</strong><br>{escape(handoff_reason)}</section>
+  </div>
+  <h2>Delivery lanes</h2>
+  <div class=\"canvas\">{handoff_cards}</div>
+  <div class=\"grid\" style=\"margin-top: 1rem;\">
+    <section class=\"card\">
+      <h2>Acceptance</h2>
+      <ul>{acceptance_items}</ul>
+    </section>
+    <section class=\"card\">
+      <h2>Validation</h2>
+      <ul>{validation_items}</ul>
+    </section>
+  </div>
+</body>
+</html>
+"""

--- a/src/bigclaw/workflow.py
+++ b/src/bigclaw/workflow.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional, Sequence
 from .dsl import WorkflowDefinition
 from .models import RiskLevel, Task
 from .observability import ObservabilityLedger, utc_now
-from .orchestration import render_orchestration_plan
+from .orchestration import render_orchestration_canvas, render_orchestration_plan
 from .reports import PilotScorecard, render_pilot_scorecard, write_report
 from .scheduler import ExecutionRecord, Scheduler
 
@@ -123,6 +123,7 @@ class WorkflowRunResult:
     journal: WorkpadJournal
     journal_path: Optional[str]
     orchestration_report_path: Optional[str] = None
+    orchestration_canvas_path: Optional[str] = None
     pilot_report_path: Optional[str] = None
 
 
@@ -162,24 +163,64 @@ class WorkflowEngine:
         )
 
         resolved_orchestration_report_path = None
+        resolved_orchestration_canvas_path = None
         if execution.orchestration_plan is not None and orchestration_report_path:
             resolved_orchestration_report_path = str(Path(orchestration_report_path))
-            write_report(
-                resolved_orchestration_report_path,
-                render_orchestration_plan(
-                    execution.orchestration_plan,
-                    execution.orchestration_policy,
-                    execution.handoff_request,
-                ),
-            )
-            execution.run.register_artifact(
-                "cross-department-orchestration",
-                "report",
-                resolved_orchestration_report_path,
-                format="markdown",
-                collaboration_mode=execution.orchestration_plan.collaboration_mode,
-                departments=execution.orchestration_plan.departments,
-            )
+            orchestration_file = Path(resolved_orchestration_report_path)
+            if orchestration_file.suffix.lower() == ".html":
+                resolved_orchestration_canvas_path = resolved_orchestration_report_path
+                write_report(
+                    resolved_orchestration_canvas_path,
+                    render_orchestration_canvas(
+                        task,
+                        execution.orchestration_plan,
+                        execution.orchestration_policy,
+                        execution.handoff_request,
+                    ),
+                )
+                execution.run.register_artifact(
+                    "orchestration-canvas",
+                    "page",
+                    resolved_orchestration_canvas_path,
+                    format="html",
+                    collaboration_mode=execution.orchestration_plan.collaboration_mode,
+                    departments=execution.orchestration_plan.departments,
+                )
+            else:
+                write_report(
+                    resolved_orchestration_report_path,
+                    render_orchestration_plan(
+                        execution.orchestration_plan,
+                        execution.orchestration_policy,
+                        execution.handoff_request,
+                    ),
+                )
+                execution.run.register_artifact(
+                    "cross-department-orchestration",
+                    "report",
+                    resolved_orchestration_report_path,
+                    format="markdown",
+                    collaboration_mode=execution.orchestration_plan.collaboration_mode,
+                    departments=execution.orchestration_plan.departments,
+                )
+                resolved_orchestration_canvas_path = str(orchestration_file.with_suffix(".html"))
+                write_report(
+                    resolved_orchestration_canvas_path,
+                    render_orchestration_canvas(
+                        task,
+                        execution.orchestration_plan,
+                        execution.orchestration_policy,
+                        execution.handoff_request,
+                    ),
+                )
+                execution.run.register_artifact(
+                    "orchestration-canvas",
+                    "page",
+                    resolved_orchestration_canvas_path,
+                    format="html",
+                    collaboration_mode=execution.orchestration_plan.collaboration_mode,
+                    departments=execution.orchestration_plan.departments,
+                )
             ledger.upsert(execution.run)
             journal.record(
                 "orchestration",
@@ -189,6 +230,7 @@ class WorkflowEngine:
                 tier=execution.orchestration_policy.tier if execution.orchestration_policy else "standard",
                 upgrade_required=execution.orchestration_policy.upgrade_required if execution.orchestration_policy else False,
                 handoff_team=execution.handoff_request.target_team if execution.handoff_request else "none",
+                canvas_path=resolved_orchestration_canvas_path,
             )
 
         resolved_pilot_report_path = None
@@ -236,6 +278,7 @@ class WorkflowEngine:
             journal=journal,
             journal_path=resolved_journal_path,
             orchestration_report_path=resolved_orchestration_report_path,
+            orchestration_canvas_path=resolved_orchestration_canvas_path,
             pilot_report_path=resolved_pilot_report_path,
         )
 

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -5,6 +5,7 @@ from bigclaw.observability import ObservabilityLedger
 from bigclaw.orchestration import (
     CrossDepartmentOrchestrator,
     PremiumOrchestrationPolicy,
+    render_orchestration_canvas,
     render_orchestration_plan,
 )
 from bigclaw.scheduler import Scheduler
@@ -70,6 +71,30 @@ def test_render_orchestration_plan_lists_handoffs_and_policy() -> None:
     assert "- Tier: standard" in content
     assert "- Blocked Departments: data, customer-success" in content
     assert "- Human Handoff Team:" not in content
+
+def test_render_orchestration_canvas_highlights_delivery_lanes() -> None:
+    task = Task(
+        task_id="BIG-1001",
+        source="linear",
+        title="Launch orchestration canvas",
+        description="Coordinate rollout with customer and analytics workstreams",
+        labels=["customer", "data", "ops"],
+        required_tools=["browser", "sql"],
+        acceptance_criteria=["canvas-reviewed"],
+        validation_plan=["pytest", "ux-walkthrough"],
+    )
+
+    raw_plan = CrossDepartmentOrchestrator().plan(task)
+    plan, policy = PremiumOrchestrationPolicy().apply(task, raw_plan)
+    page = render_orchestration_canvas(task, plan, policy)
+
+    assert "Orchestration Canvas" in page
+    assert "Launch orchestration canvas" in page
+    assert "Upgrade Required: True" in page
+    assert "operations" in page
+    assert "canvas-reviewed" in page
+    assert "ux-walkthrough" in page
+
 
 
 def test_scheduler_execution_records_orchestration_plan_and_policy(tmp_path: Path) -> None:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -56,6 +56,7 @@ def test_workflow_engine_records_journal_and_accepts_complete_evidence(tmp_path:
     assert result.acceptance.status == "accepted"
     assert result.journal_path is not None
     assert result.orchestration_report_path is not None
+    assert result.orchestration_canvas_path is not None
 
     journal = json.loads(Path(result.journal_path).read_text())
     assert [entry["step"] for entry in journal["entries"]] == ["intake", "execution", "orchestration", "acceptance"]
@@ -191,15 +192,53 @@ def test_workflow_engine_writes_orchestration_report_without_duplicating_ledger_
     )
 
     assert result.orchestration_report_path is not None
+    assert result.orchestration_canvas_path is not None
     assert Path(result.orchestration_report_path).exists()
+    assert Path(result.orchestration_canvas_path).exists()
     report = Path(result.orchestration_report_path).read_text()
+    canvas = Path(result.orchestration_canvas_path).read_text()
     assert "- customer-success:" not in report
     assert "Upgrade Required: True" in report
     assert "Human Handoff Team: operations" in report
+    assert "Orchestration Canvas" in canvas
+    assert "Upgrade Required: True" in canvas
+    assert "operations" in canvas
 
     entries = ledger.load()
     assert len(entries) == 1
-    assert entries[0]["artifacts"][0]["name"] == "cross-department-orchestration"
+    assert {artifact["name"] for artifact in entries[0]["artifacts"]} == {
+        "cross-department-orchestration",
+        "orchestration-canvas",
+    }
 
     journal = json.loads(Path(result.journal_path).read_text())
     assert journal["entries"][2]["step"] == "orchestration"
+
+
+def test_workflow_engine_can_write_orchestration_canvas_directly(tmp_path: Path):
+    ledger = ObservabilityLedger(str(tmp_path / "ledger.json"))
+    task = Task(
+        task_id="OPE-79-html",
+        source="linear",
+        title="Direct canvas export",
+        description="Cross-team launch readiness",
+        labels=["customer", "ops"],
+        acceptance_criteria=["canvas-shared"],
+        validation_plan=["pytest"],
+    )
+
+    result = WorkflowEngine().run(
+        task,
+        run_id="run-wf-ope-79-html",
+        ledger=ledger,
+        orchestration_report_path=str(tmp_path / "reports" / "ope-79-canvas.html"),
+        validation_evidence=["pytest", "canvas-shared"],
+    )
+
+    assert result.orchestration_report_path is not None
+    assert result.orchestration_canvas_path == result.orchestration_report_path
+    assert Path(result.orchestration_canvas_path).exists()
+    assert "Orchestration Canvas" in Path(result.orchestration_canvas_path).read_text()
+
+    artifacts = ledger.load()[0]["artifacts"]
+    assert [artifact["name"] for artifact in artifacts] == ["orchestration-canvas"]


### PR DESCRIPTION
## Summary
- add an HTML orchestration canvas renderer for cross-team lanes, approvals, tools, acceptance, and validation
- wire workflow runs to emit the canvas artifact alongside the Markdown orchestration plan or directly to HTML outputs
- add exports, README updates, and regression coverage for Markdown + HTML orchestration artifacts

## Validation
- python3 -m pytest tests/test_orchestration.py tests/test_workflow.py
- python3 -m pytest