### PR TITLE
OPE-206: plan replicated event-store durability integration

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -57,7 +57,15 @@ func main() {
 	if cfg.BootstrapTasks {
 		seed(context.Background(), q)
 	}
-	server := &api.Server{Recorder: recorder, Queue: q, Executors: registry.Kinds(), Bus: bus, Worker: runtime, Control: controller}
+	server := &api.Server{
+		Recorder:  recorder,
+		Queue:     q,
+		Executors: registry.Kinds(),
+		Bus:       bus,
+		EventPlan: events.NewDurabilityPlan(cfg.EventLogBackend, cfg.EventLogTargetBackend, cfg.EventLogReplicationFactor),
+		Worker:    runtime,
+		Control:   controller,
+	}
 	httpServer := &http.Server{Addr: cfg.HTTPAddr, Handler: server.Handler()}
 	go func() {
 		_ = httpServer.ListenAndServe()

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This report summarizes the current event bus reliability evidence for `OPE-183` / `BIG-GO-008`.
+This report summarizes the current event bus reliability evidence and the next replicated-durability integration plan for `OPE-183` / `BIG-GO-008` and `OPE-206`.
 
 ## Implemented surfaces
 
@@ -23,15 +23,56 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 ## Evidence
 
 - `internal/events/bus.go`
+- `internal/events/durability.go`
 - `internal/events/bus_test.go`
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
+- `cmd/bigclawd/main.go`
+- `internal/config/config.go`
+
+## Current durability shape
+
+- Runtime publish/subscribe remains in-process.
+- Audit/debug persistence is recorder-backed, with optional JSONL sinking.
+- The new `events.DurabilityPlan` surface makes the active backend and the next replicated target explicit in bootstrap and `GET /debug/status`.
+- Default plan is `memory -> broker_replicated` with replication factor `3`, and env overrides now exist for:
+  - `BIGCLAW_EVENT_LOG_BACKEND`
+  - `BIGCLAW_EVENT_LOG_TARGET_BACKEND`
+  - `BIGCLAW_EVENT_LOG_REPLICATION_FACTOR`
+
+## Next backend targets
+
+- `sqlite`: durable single-node append log with monotonic checkpoints but no replica quorum.
+- `http`: shared service-backed append log with single-writer ordering and shared subscriber state.
+- `broker_replicated`: quorum or partition-backed log with shared replay, replicated durability, and publisher ack requirements.
+
+## Repo-native integration points
+
+- `cmd/bigclawd/main.go`: bootstrap backend selection and future broker client wiring.
+- `internal/events/bus.go`: publish path remains the place to insert append/ack behavior ahead of live fanout.
+- `internal/api/server.go`: operational reporting for current and target durability mode.
+- Subscriber checkpoint persistence and replay endpoints: preserve resume semantics while moving state out of process-local memory.
+
+## Migration and compatibility constraints
+
+- Preserve append-only replay semantics across backend cutover.
+- Keep subscriber checkpoints monotonic during dual-write or backfill.
+- Keep `task_id`, `trace_id`, and `event_type` stable so partitioning and replay filters remain compatible.
+- Decouple SSE live fanout from broker consumer lag so replay catch-up does not stall live delivery.
+
+## Implementation-ready follow-up plan
+
+1. Add a concrete event-log interface alongside the in-process bus sink contract so append, replay, and checkpoint operations can be backed by SQLite, HTTP, or broker implementations.
+2. Introduce a dual-write migration phase from the current publish path into the new event-log backend while keeping recorder/audit output unchanged.
+3. Add checkpoint-backed replay endpoints that read from the shared event log instead of recorder-only history.
+4. Add a broker-backed implementation with partition-key rules for `trace_id` and explicit publisher ack / durability error handling.
+5. Validate cutover with replay, checkpoint monotonicity, and SSE handoff regression coverage under shared multi-node conditions.
 
 ## Remaining gaps
 
-- No durable external event log yet; replay is process-local history.
-- No delivery acknowledgement protocol beyond sink-level best effort.
-- No partitioned topic model or cross-process subscriber coordination yet.
+- No concrete external event-log implementation exists yet in this checkout; the new code only defines the plan and integration points.
+- No delivery acknowledgement protocol exists beyond sink-level best effort.
+- No partitioned topic model or broker-backed subscriber coordination exists yet.

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -28,6 +28,7 @@ type Server struct {
 	Queue     queue.Queue
 	Executors []domain.ExecutorKind
 	Bus       *events.Bus
+	EventPlan events.DurabilityPlan
 	Now       func() time.Time
 	Worker    WorkerStatusProvider
 	Control   *control.Controller
@@ -52,6 +53,7 @@ func (s *Server) Handler() http.Handler {
 		writeJSON(w, http.StatusOK, map[string]any{
 			"queue_size":           s.Queue.Size(context.Background()),
 			"events":               s.Recorder.Snapshot(),
+			"event_durability":     s.EventPlan,
 			"trace_count":          len(s.Recorder.TraceSummaries(0)),
 			"registered_executors": s.executorNames(),
 		})
@@ -93,9 +95,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("/debug/traces/", s.handleDebugTrace)
 	mux.HandleFunc("/debug/status", func(w http.ResponseWriter, r *http.Request) {
 		payload := map[string]any{
-			"queue_size":   s.Queue.Size(context.Background()),
-			"audit_events": len(s.Recorder.Logs()),
-			"executors":    s.executorNames(),
+			"queue_size":       s.Queue.Size(context.Background()),
+			"audit_events":     len(s.Recorder.Logs()),
+			"executors":        s.executorNames(),
+			"event_durability": s.EventPlan,
 		}
 		if s.Worker != nil {
 			payload["worker"] = s.Worker.Snapshot()

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -78,7 +78,12 @@ func TestCreateTaskAndQueryStatus(t *testing.T) {
 func TestAuditAndReplayEndpoints(t *testing.T) {
 	recorder := observability.NewRecorder()
 	recorder.Record(domain.Event{ID: "evt-1", Type: domain.EventTaskQueued, TaskID: "task-1", Timestamp: time.Now()})
-	server := &Server{Recorder: recorder, Queue: queue.NewMemoryQueue(), Now: time.Now}
+	server := &Server{
+		Recorder:  recorder,
+		Queue:     queue.NewMemoryQueue(),
+		EventPlan: events.NewDurabilityPlan("http", "broker_replicated", 3),
+		Now:       time.Now,
+	}
 	handler := server.Handler()
 
 	auditRequest := httptest.NewRequest(http.MethodGet, "/audit?limit=10", nil)
@@ -93,6 +98,32 @@ func TestAuditAndReplayEndpoints(t *testing.T) {
 	handler.ServeHTTP(replayResponse, replayRequest)
 	if replayResponse.Code != http.StatusOK {
 		t.Fatalf("expected replay 200, got %d", replayResponse.Code)
+	}
+}
+
+func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
+	recorder := observability.NewRecorder()
+	server := &Server{
+		Recorder:  recorder,
+		Queue:     queue.NewMemoryQueue(),
+		EventPlan: events.NewDurabilityPlan("http", "broker_replicated", 5),
+		Now:       time.Now,
+	}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	if !strings.Contains(response.Body.String(), "\"backend\":\"http\"") {
+		t.Fatalf("expected current backend in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"backend\":\"broker_replicated\"") {
+		t.Fatalf("expected target backend in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"replication_factor\":5") {
+		t.Fatalf("expected replication factor in payload, got %s", response.Body.String())
 	}
 }
 

--- a/bigclaw-go/internal/config/config.go
+++ b/bigclaw-go/internal/config/config.go
@@ -9,6 +9,9 @@ import (
 
 type Config struct {
 	QueueBackend                  string
+	EventLogBackend               string
+	EventLogTargetBackend         string
+	EventLogReplicationFactor     int
 	EventWebhookURLs              []string
 	EventWebhookBearerToken       string
 	EventWebhookTimeout           time.Duration
@@ -42,6 +45,9 @@ type Config struct {
 func Default() Config {
 	return Config{
 		QueueBackend:                  "file",
+		EventLogBackend:               "memory",
+		EventLogTargetBackend:         "broker_replicated",
+		EventLogReplicationFactor:     3,
 		EventWebhookTimeout:           5 * time.Second,
 		QueueSQLitePath:               "./state/queue.db",
 		AuditLogPath:                  "./state/audit.jsonl",
@@ -71,6 +77,9 @@ func Default() Config {
 func LoadFromEnv() Config {
 	cfg := Default()
 	cfg.QueueBackend = getString("BIGCLAW_QUEUE_BACKEND", cfg.QueueBackend)
+	cfg.EventLogBackend = getString("BIGCLAW_EVENT_LOG_BACKEND", cfg.EventLogBackend)
+	cfg.EventLogTargetBackend = getString("BIGCLAW_EVENT_LOG_TARGET_BACKEND", cfg.EventLogTargetBackend)
+	cfg.EventLogReplicationFactor = getInt("BIGCLAW_EVENT_LOG_REPLICATION_FACTOR", cfg.EventLogReplicationFactor)
 	cfg.EventWebhookURLs = splitCSV(getString("BIGCLAW_EVENT_WEBHOOK_URLS", ""))
 	cfg.EventWebhookBearerToken = getString("BIGCLAW_EVENT_WEBHOOK_BEARER_TOKEN", cfg.EventWebhookBearerToken)
 	cfg.EventWebhookTimeout = getDuration("BIGCLAW_EVENT_WEBHOOK_TIMEOUT", cfg.EventWebhookTimeout)

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -1,0 +1,110 @@
+package events
+
+import "strings"
+
+type DurabilityBackend string
+
+const (
+	DurabilityBackendMemory           DurabilityBackend = "memory"
+	DurabilityBackendSQLite           DurabilityBackend = "sqlite"
+	DurabilityBackendHTTP             DurabilityBackend = "http"
+	DurabilityBackendBrokerReplicated DurabilityBackend = "broker_replicated"
+)
+
+type DurabilityProfile struct {
+	Backend             DurabilityBackend `json:"backend"`
+	Shared              bool              `json:"shared"`
+	Replicated          bool              `json:"replicated"`
+	Replay              bool              `json:"replay"`
+	SubscriberState     bool              `json:"subscriber_state"`
+	MonotonicCheckpoint bool              `json:"monotonic_checkpoint"`
+	OrderingScope       string            `json:"ordering_scope"`
+}
+
+type DurabilityPlan struct {
+	Current              DurabilityProfile `json:"current"`
+	Target               DurabilityProfile `json:"target"`
+	ReplicationFactor    int               `json:"replication_factor"`
+	RequiresPublisherAck bool              `json:"requires_publisher_ack"`
+	MigrationConstraints []string          `json:"migration_constraints"`
+	IntegrationPoints    []string          `json:"integration_points"`
+}
+
+func NormalizeDurabilityBackend(value string) DurabilityBackend {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "memory", "in_memory", "in-memory":
+		return DurabilityBackendMemory
+	case "sqlite":
+		return DurabilityBackendSQLite
+	case "http", "remote_http", "remote-http":
+		return DurabilityBackendHTTP
+	case "broker", "broker_replicated", "broker-replicated", "replicated":
+		return DurabilityBackendBrokerReplicated
+	default:
+		return DurabilityBackend(strings.ToLower(strings.TrimSpace(value)))
+	}
+}
+
+func DurabilityProfileForBackend(backend DurabilityBackend) DurabilityProfile {
+	switch backend {
+	case DurabilityBackendSQLite:
+		return DurabilityProfile{
+			Backend:             backend,
+			Replay:              true,
+			SubscriberState:     true,
+			MonotonicCheckpoint: true,
+			OrderingScope:       "single-node append order",
+		}
+	case DurabilityBackendHTTP:
+		return DurabilityProfile{
+			Backend:             backend,
+			Shared:              true,
+			Replay:              true,
+			SubscriberState:     true,
+			MonotonicCheckpoint: true,
+			OrderingScope:       "single-writer service order",
+		}
+	case DurabilityBackendBrokerReplicated:
+		return DurabilityProfile{
+			Backend:             backend,
+			Shared:              true,
+			Replicated:          true,
+			Replay:              true,
+			SubscriberState:     true,
+			MonotonicCheckpoint: true,
+			OrderingScope:       "partition or quorum log order",
+		}
+	default:
+		return DurabilityProfile{
+			Backend:       DurabilityBackendMemory,
+			Replay:        true,
+			OrderingScope: "process-local publish order",
+		}
+	}
+}
+
+func NewDurabilityPlan(currentBackend, targetBackend string, replicationFactor int) DurabilityPlan {
+	if replicationFactor <= 0 {
+		replicationFactor = 3
+	}
+	current := DurabilityProfileForBackend(NormalizeDurabilityBackend(currentBackend))
+	target := DurabilityProfileForBackend(NormalizeDurabilityBackend(targetBackend))
+	return DurabilityPlan{
+		Current:              current,
+		Target:               target,
+		ReplicationFactor:    replicationFactor,
+		RequiresPublisherAck: target.Replicated,
+		MigrationConstraints: []string{
+			"preserve append-only replay semantics across backend cutover",
+			"keep subscriber checkpoints monotonic during dual-write or backfill",
+			"carry task_id, trace_id, and event_type as stable partitioning keys",
+			"avoid coupling live SSE fanout directly to broker consumer lag",
+		},
+		IntegrationPoints: []string{
+			"cmd/bigclawd/main.go bootstrap/backend selection",
+			"internal/api/server.go debug and control-plane reporting",
+			"internal/events bus publish/subscribe path",
+			"subscriber checkpoint persistence and replay endpoints",
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add a typed event durability plan surface for current and target event-log backends
- wire the plan through config, bootstrap, and debug/metrics payloads for operational visibility
- expand the event-bus reliability report with backend targets, migration constraints, and implementation follow-ups

## Validation
- go test ./...
- git rev-parse HEAD
- git rev-parse origin/dcjcloud/ope-206-big-par-019-replicated-event-store-broker-backed-durability
- git log -1 --stat