### PR TITLE
OPE-207: add replay-safe consumer contract metadata

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Additive delivery metadata for replay-safe downstream consumption via `delivery.mode`, `delivery.replay`, and `delivery.idempotency_key`
 
 ## Validated behaviors
 
@@ -19,6 +20,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink receives serialized domain events.
 - SSE streaming can deliver live events.
 - SSE replay can filter to one trace without leaking unrelated events.
+- Replay and live deliveries preserve the original event id while exposing an explicit delivery mode and stable downstream idempotency key.
 
 ## Evidence
 
@@ -35,3 +37,4 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - No durable external event log yet; replay is process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.
+- Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -62,11 +62,11 @@ func (s *Server) Handler() http.Handler {
 		traceID := r.URL.Query().Get("trace_id")
 		switch {
 		case taskID != "":
-			writeJSON(w, http.StatusOK, map[string]any{"events": s.Recorder.EventsByTask(taskID, limit)})
+			writeJSON(w, http.StatusOK, replayEventResponse("task", taskID, s.Recorder.EventsByTask(taskID, limit)))
 		case traceID != "":
-			writeJSON(w, http.StatusOK, map[string]any{"events": s.Recorder.EventsByTrace(traceID, limit)})
+			writeJSON(w, http.StatusOK, replayEventResponse("trace", traceID, s.Recorder.EventsByTrace(traceID, limit)))
 		default:
-			writeJSON(w, http.StatusOK, map[string]any{"events": s.Recorder.EventsByTask("", limit)})
+			writeJSON(w, http.StatusOK, replayEventResponse("all", "", s.Recorder.EventsByTask("", limit)))
 		}
 	})
 	mux.HandleFunc("/stream/events", s.handleStreamEvents)
@@ -84,8 +84,12 @@ func (s *Server) Handler() http.Handler {
 			http.Error(w, "missing task id", http.StatusBadRequest)
 			return
 		}
-		events := s.Recorder.EventsByTask(taskID, 1000)
-		writeJSON(w, http.StatusOK, map[string]any{"task_id": taskID, "timeline": events})
+		recorded := s.Recorder.EventsByTask(taskID, 1000)
+		writeJSON(w, http.StatusOK, map[string]any{
+			"task_id":           taskID,
+			"timeline":          events.WithDeliveryBatch(recorded, domain.EventDeliveryModeReplay),
+			"consumer_contract": replayConsumerContract(),
+		})
 	})
 	mux.HandleFunc("/deadletters", s.handleDeadLetters)
 	mux.HandleFunc("/deadletters/", s.handleDeadLetterAction)
@@ -138,6 +142,31 @@ func (s *Server) Handler() http.Handler {
 	})
 	mux.HandleFunc("/tasks/", s.handleTaskStatus)
 	return mux
+}
+
+func replayEventResponse(scope string, value string, recorded []domain.Event) map[string]any {
+	response := map[string]any{
+		"events":            events.WithDeliveryBatch(recorded, domain.EventDeliveryModeReplay),
+		"consumer_contract": replayConsumerContract(),
+	}
+	switch scope {
+	case "task":
+		response["task_id"] = value
+	case "trace":
+		response["trace_id"] = value
+	}
+	return response
+}
+
+func replayConsumerContract() map[string]any {
+	return map[string]any{
+		"event_id_field":         "id",
+		"idempotency_key_field":  "delivery.idempotency_key",
+		"replay_indicator_field": "delivery.replay",
+		"delivery_mode_field":    "delivery.mode",
+		"replay_mode":            string(domain.EventDeliveryModeReplay),
+		"live_mode":              string(domain.EventDeliveryModeLive),
+	}
 }
 
 func (s *Server) handleDebugTraces(w http.ResponseWriter, r *http.Request) {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -73,6 +73,15 @@ func TestCreateTaskAndQueryStatus(t *testing.T) {
 	if !strings.Contains(eventsResponse.Body.String(), "task-api-1-queued") {
 		t.Fatalf("expected queued event via trace lookup, got %s", eventsResponse.Body.String())
 	}
+	var eventsDecoded struct {
+		Events []domain.Event `json:"events"`
+	}
+	if err := json.Unmarshal(eventsResponse.Body.Bytes(), &eventsDecoded); err != nil {
+		t.Fatalf("decode events response: %v", err)
+	}
+	if len(eventsDecoded.Events) != 1 || eventsDecoded.Events[0].Delivery == nil || eventsDecoded.Events[0].Delivery.Mode != domain.EventDeliveryModeReplay || eventsDecoded.Events[0].Delivery.IdempotencyKey != "task-api-1-queued" {
+		t.Fatalf("expected replay-safe event metadata on history endpoint, got %+v", eventsDecoded.Events)
+	}
 }
 
 func TestAuditAndReplayEndpoints(t *testing.T) {
@@ -93,6 +102,28 @@ func TestAuditAndReplayEndpoints(t *testing.T) {
 	handler.ServeHTTP(replayResponse, replayRequest)
 	if replayResponse.Code != http.StatusOK {
 		t.Fatalf("expected replay 200, got %d", replayResponse.Code)
+	}
+	var replayDecoded struct {
+		TaskID           string         `json:"task_id"`
+		Timeline         []domain.Event `json:"timeline"`
+		ConsumerContract struct {
+			EventIDField         string `json:"event_id_field"`
+			IdempotencyKeyField  string `json:"idempotency_key_field"`
+			ReplayIndicatorField string `json:"replay_indicator_field"`
+			DeliveryModeField    string `json:"delivery_mode_field"`
+		} `json:"consumer_contract"`
+	}
+	if err := json.Unmarshal(replayResponse.Body.Bytes(), &replayDecoded); err != nil {
+		t.Fatalf("decode replay response: %v", err)
+	}
+	if replayDecoded.TaskID != "task-1" || len(replayDecoded.Timeline) != 1 {
+		t.Fatalf("expected replay timeline for task-1, got %+v", replayDecoded)
+	}
+	if replayDecoded.Timeline[0].Delivery == nil || replayDecoded.Timeline[0].Delivery.Mode != domain.EventDeliveryModeReplay || replayDecoded.Timeline[0].Delivery.IdempotencyKey != "evt-1" {
+		t.Fatalf("expected replay delivery metadata, got %+v", replayDecoded.Timeline[0].Delivery)
+	}
+	if replayDecoded.ConsumerContract.IdempotencyKeyField != "delivery.idempotency_key" || replayDecoded.ConsumerContract.ReplayIndicatorField != "delivery.replay" || replayDecoded.ConsumerContract.DeliveryModeField != "delivery.mode" || replayDecoded.ConsumerContract.EventIDField != "id" {
+		t.Fatalf("unexpected consumer contract: %+v", replayDecoded.ConsumerContract)
 	}
 }
 
@@ -239,6 +270,13 @@ func TestStreamEventsSupportsReplayAndFiltersByTrace(t *testing.T) {
 		}
 		if strings.Contains(line, "evt-old-2") {
 			t.Fatalf("expected trace filter to exclude evt-old-2, got %q", line)
+		}
+		var envelope domain.Event
+		if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &envelope); err != nil {
+			t.Fatalf("decode replayed stream event: %v", err)
+		}
+		if envelope.Delivery == nil || envelope.Delivery.Mode != domain.EventDeliveryModeReplay || !envelope.Delivery.Replay || envelope.Delivery.IdempotencyKey != "evt-old-1" {
+			t.Fatalf("expected replay delivery contract in stream event, got %+v", envelope.Delivery)
 		}
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for replayed event")

--- a/bigclaw-go/internal/domain/task.go
+++ b/bigclaw-go/internal/domain/task.go
@@ -100,6 +100,20 @@ type Event struct {
 	RunID     string         `json:"run_id,omitempty"`
 	Timestamp time.Time      `json:"timestamp"`
 	Payload   map[string]any `json:"payload,omitempty"`
+	Delivery  *EventDelivery `json:"delivery,omitempty"`
+}
+
+type EventDeliveryMode string
+
+const (
+	EventDeliveryModeLive   EventDeliveryMode = "live"
+	EventDeliveryModeReplay EventDeliveryMode = "replay"
+)
+
+type EventDelivery struct {
+	Mode           EventDeliveryMode `json:"mode,omitempty"`
+	Replay         bool              `json:"replay,omitempty"`
+	IdempotencyKey string            `json:"idempotency_key,omitempty"`
 }
 
 func TaskStateFromEventType(eventType EventType) (TaskState, bool) {

--- a/bigclaw-go/internal/events/bus.go
+++ b/bigclaw-go/internal/events/bus.go
@@ -41,7 +41,7 @@ func (b *Bus) Publish(event domain.Event) {
 
 	for _, ch := range subs {
 		select {
-		case ch <- event:
+		case ch <- WithDelivery(event, domain.EventDeliveryModeLive):
 		default:
 		}
 	}
@@ -75,7 +75,7 @@ func (b *Bus) subscribe(buffer int, replay []domain.Event) (<-chan domain.Event,
 	}
 	ch := make(chan domain.Event, capacity)
 	for _, event := range replay {
-		ch <- event
+		ch <- WithDelivery(event, domain.EventDeliveryModeReplay)
 	}
 	b.subscribers[id] = ch
 	return ch, func() {

--- a/bigclaw-go/internal/events/bus_test.go
+++ b/bigclaw-go/internal/events/bus_test.go
@@ -19,6 +19,9 @@ func TestBusReplayAndSubscribe(t *testing.T) {
 	if got.ID != event.ID {
 		t.Fatalf("expected %s, got %s", event.ID, got.ID)
 	}
+	if got.Delivery == nil || got.Delivery.Mode != domain.EventDeliveryModeLive || got.Delivery.IdempotencyKey != event.ID {
+		t.Fatalf("expected live delivery metadata with stable idempotency key, got %+v", got.Delivery)
+	}
 	if len(bus.Replay()) != 1 {
 		t.Fatalf("expected 1 event in replay")
 	}
@@ -38,11 +41,17 @@ func TestBusSubscribeReplayReturnsHistoryAndLiveEvents(t *testing.T) {
 	if replayed.ID != second.ID {
 		t.Fatalf("expected replayed event %s, got %s", second.ID, replayed.ID)
 	}
+	if replayed.Delivery == nil || replayed.Delivery.Mode != domain.EventDeliveryModeReplay || !replayed.Delivery.Replay || replayed.Delivery.IdempotencyKey != second.ID {
+		t.Fatalf("expected replay delivery metadata with stable idempotency key, got %+v", replayed.Delivery)
+	}
 
 	third := domain.Event{ID: "evt-3", Type: domain.EventTaskCompleted, TaskID: "task-1", TraceID: "trace-1", Timestamp: time.Now()}
 	bus.Publish(third)
 	live := <-ch
 	if live.ID != third.ID {
 		t.Fatalf("expected live event %s, got %s", third.ID, live.ID)
+	}
+	if live.Delivery == nil || live.Delivery.Mode != domain.EventDeliveryModeLive || live.Delivery.IdempotencyKey != third.ID {
+		t.Fatalf("expected live delivery metadata after replay handoff, got %+v", live.Delivery)
 	}
 }

--- a/bigclaw-go/internal/events/delivery.go
+++ b/bigclaw-go/internal/events/delivery.go
@@ -1,0 +1,24 @@
+package events
+
+import "bigclaw-go/internal/domain"
+
+func WithDelivery(event domain.Event, mode domain.EventDeliveryMode) domain.Event {
+	annotated := event
+	annotated.Delivery = &domain.EventDelivery{
+		Mode:           mode,
+		Replay:         mode == domain.EventDeliveryModeReplay,
+		IdempotencyKey: event.ID,
+	}
+	return annotated
+}
+
+func WithDeliveryBatch(items []domain.Event, mode domain.EventDeliveryMode) []domain.Event {
+	if len(items) == 0 {
+		return nil
+	}
+	annotated := make([]domain.Event, len(items))
+	for index, item := range items {
+		annotated[index] = WithDelivery(item, mode)
+	}
+	return annotated
+}


### PR DESCRIPTION
## Summary
- add explicit live/replay delivery metadata and stable idempotency keys to event deliveries
- expose replay consumer contract fields on history and replay API responses
- add regression coverage for replay-safe SSE and API payloads

## Validation
- go test ./internal/events ./internal/api
- go test ./...