### PR TITLE
OPE-209: Add replay-safe consumer dedup contract

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,8 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Replay-safe consumer delivery metadata via `EventDelivery`
+- Consumer dedup ledger/result contract covering duplicate, retryable-failure, and already-applied outcomes
 
 ## Validated behaviors
 
@@ -24,6 +26,10 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 
 - `internal/events/bus.go`
 - `internal/events/bus_test.go`
+- `internal/events/delivery.go`
+- `internal/events/delivery_test.go`
+- `internal/domain/consumer_dedup.go`
+- `internal/domain/consumer_dedup_test.go`
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
@@ -33,5 +39,6 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 ## Remaining gaps
 
 - No durable external event log yet; replay is process-local history.
+- Dedup ledger semantics are defined, but there is no persistent ledger store or handler middleware enforcing them yet.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.

--- a/bigclaw-go/internal/domain/consumer_dedup.go
+++ b/bigclaw-go/internal/domain/consumer_dedup.go
@@ -1,0 +1,137 @@
+package domain
+
+import (
+	"strings"
+	"time"
+)
+
+type ConsumerLedgerState string
+
+const (
+	ConsumerLedgerStateReceived         ConsumerLedgerState = "received"
+	ConsumerLedgerStateApplied          ConsumerLedgerState = "applied"
+	ConsumerLedgerStateDuplicate        ConsumerLedgerState = "duplicate"
+	ConsumerLedgerStateAlreadyApplied   ConsumerLedgerState = "already_applied"
+	ConsumerLedgerStateRetryableFailure ConsumerLedgerState = "retryable_failure"
+	ConsumerLedgerStateTerminalFailure  ConsumerLedgerState = "terminal_failure"
+)
+
+type ConsumerHandleResult struct {
+	State             ConsumerLedgerState `json:"state"`
+	Attempt           int                 `json:"attempt,omitempty"`
+	CompletedAt       time.Time           `json:"completed_at,omitempty"`
+	SideEffectKey     string              `json:"side_effect_key,omitempty"`
+	SideEffectApplied bool                `json:"side_effect_applied,omitempty"`
+	Outcome           string              `json:"outcome,omitempty"`
+	Error             string              `json:"error,omitempty"`
+}
+
+type ConsumerDedupLedgerEntry struct {
+	LedgerKey         string              `json:"ledger_key"`
+	ConsumerGroup     string              `json:"consumer_group"`
+	Handler           string              `json:"handler"`
+	EventID           string              `json:"event_id"`
+	IdempotencyKey    string              `json:"idempotency_key"`
+	EventType         EventType           `json:"event_type"`
+	TaskID            string              `json:"task_id,omitempty"`
+	TraceID           string              `json:"trace_id,omitempty"`
+	RunID             string              `json:"run_id,omitempty"`
+	DeliveryMode      EventDeliveryMode   `json:"delivery_mode,omitempty"`
+	FirstSeenAt       time.Time           `json:"first_seen_at"`
+	LastSeenAt        time.Time           `json:"last_seen_at"`
+	Attempt           int                 `json:"attempt"`
+	State             ConsumerLedgerState `json:"state"`
+	CompletedAt       time.Time           `json:"completed_at,omitempty"`
+	SideEffectKey     string              `json:"side_effect_key,omitempty"`
+	SideEffectApplied bool                `json:"side_effect_applied,omitempty"`
+	Outcome           string              `json:"outcome,omitempty"`
+	Error             string              `json:"error,omitempty"`
+}
+
+func NewConsumerDedupLedgerEntry(consumerGroup, handler string, event Event, seenAt time.Time) ConsumerDedupLedgerEntry {
+	idempotencyKey := EventIdempotencyKey(event)
+	return ConsumerDedupLedgerEntry{
+		LedgerKey:      ConsumerDedupLedgerKey(consumerGroup, handler, idempotencyKey),
+		ConsumerGroup:  consumerGroup,
+		Handler:        handler,
+		EventID:        event.ID,
+		IdempotencyKey: idempotencyKey,
+		EventType:      event.Type,
+		TaskID:         event.TaskID,
+		TraceID:        event.TraceID,
+		RunID:          event.RunID,
+		DeliveryMode:   EventDeliveryModeFor(event),
+		FirstSeenAt:    seenAt,
+		LastSeenAt:     seenAt,
+		Attempt:        1,
+		State:          ConsumerLedgerStateReceived,
+	}
+}
+
+func ConsumerDedupLedgerKey(consumerGroup, handler, idempotencyKey string) string {
+	parts := []string{
+		strings.TrimSpace(consumerGroup),
+		strings.TrimSpace(handler),
+		strings.TrimSpace(idempotencyKey),
+	}
+	return strings.Join(parts, "::")
+}
+
+func EventIdempotencyKey(event Event) string {
+	if event.Delivery != nil && strings.TrimSpace(event.Delivery.IdempotencyKey) != "" {
+		return strings.TrimSpace(event.Delivery.IdempotencyKey)
+	}
+	return strings.TrimSpace(event.ID)
+}
+
+func EventDeliveryModeFor(event Event) EventDeliveryMode {
+	if event.Delivery == nil {
+		return ""
+	}
+	return event.Delivery.Mode
+}
+
+func (entry ConsumerDedupLedgerEntry) WithResult(result ConsumerHandleResult) ConsumerDedupLedgerEntry {
+	updated := entry
+	if result.Attempt > 0 {
+		updated.Attempt = result.Attempt
+	}
+	if updated.Attempt <= 0 {
+		updated.Attempt = 1
+	}
+	updated.State = result.State
+	updated.CompletedAt = result.CompletedAt
+	updated.LastSeenAt = timestampOrFallback(result.CompletedAt, updated.LastSeenAt)
+	updated.SideEffectKey = result.SideEffectKey
+	updated.SideEffectApplied = result.SideEffectApplied
+	updated.Outcome = result.Outcome
+	updated.Error = result.Error
+	return updated
+}
+
+func (entry ConsumerDedupLedgerEntry) NextAttempt(seenAt time.Time) ConsumerDedupLedgerEntry {
+	updated := entry
+	updated.Attempt++
+	updated.LastSeenAt = seenAt
+	updated.State = ConsumerLedgerStateReceived
+	updated.CompletedAt = time.Time{}
+	updated.Outcome = ""
+	updated.Error = ""
+	return updated
+}
+
+func (entry ConsumerDedupLedgerEntry) IsTerminal() bool {
+	switch entry.State {
+	case ConsumerLedgerStateApplied, ConsumerLedgerStateDuplicate, ConsumerLedgerStateAlreadyApplied, ConsumerLedgerStateTerminalFailure:
+		return true
+	default:
+		return false
+	}
+}
+
+func timestampOrFallback(value, fallback time.Time) time.Time {
+	if value.IsZero() {
+		return fallback
+	}
+	return value
+}

--- a/bigclaw-go/internal/domain/consumer_dedup_test.go
+++ b/bigclaw-go/internal/domain/consumer_dedup_test.go
@@ -1,0 +1,132 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewConsumerDedupLedgerEntryUsesDeliveryIdempotencyKey(t *testing.T) {
+	seenAt := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	event := Event{
+		ID:      "evt-1",
+		Type:    EventTaskCompleted,
+		TaskID:  "task-1",
+		TraceID: "trace-1",
+		RunID:   "run-1",
+		Delivery: &EventDelivery{
+			Mode:           EventDeliveryModeReplay,
+			Replay:         true,
+			IdempotencyKey: "task-1::task.completed::seq-9",
+		},
+	}
+
+	entry := NewConsumerDedupLedgerEntry("billing-projection", "applyInvoice", event, seenAt)
+
+	if entry.IdempotencyKey != "task-1::task.completed::seq-9" {
+		t.Fatalf("expected delivery idempotency key, got %q", entry.IdempotencyKey)
+	}
+	if entry.LedgerKey != "billing-projection::applyInvoice::task-1::task.completed::seq-9" {
+		t.Fatalf("unexpected ledger key %q", entry.LedgerKey)
+	}
+	if entry.DeliveryMode != EventDeliveryModeReplay {
+		t.Fatalf("expected replay delivery mode, got %q", entry.DeliveryMode)
+	}
+	if entry.State != ConsumerLedgerStateReceived {
+		t.Fatalf("expected received state, got %q", entry.State)
+	}
+	if entry.Attempt != 1 {
+		t.Fatalf("expected first attempt, got %d", entry.Attempt)
+	}
+}
+
+func TestConsumerDedupLedgerEntryTracksRetryableFailuresAndRetries(t *testing.T) {
+	seenAt := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	entry := NewConsumerDedupLedgerEntry("search-index", "applyDocument", Event{
+		ID:   "evt-2",
+		Type: EventTaskStarted,
+	}, seenAt)
+
+	failedAt := seenAt.Add(2 * time.Minute)
+	entry = entry.WithResult(ConsumerHandleResult{
+		State:       ConsumerLedgerStateRetryableFailure,
+		Attempt:     1,
+		CompletedAt: failedAt,
+		Error:       "transient upstream timeout",
+	})
+	if entry.State != ConsumerLedgerStateRetryableFailure {
+		t.Fatalf("expected retryable failure state, got %q", entry.State)
+	}
+	if entry.IsTerminal() {
+		t.Fatalf("retryable failure should not be terminal")
+	}
+	if entry.LastSeenAt != failedAt {
+		t.Fatalf("expected last seen to follow completed time")
+	}
+
+	retriedAt := failedAt.Add(30 * time.Second)
+	entry = entry.NextAttempt(retriedAt)
+	if entry.Attempt != 2 {
+		t.Fatalf("expected second attempt, got %d", entry.Attempt)
+	}
+	if entry.State != ConsumerLedgerStateReceived {
+		t.Fatalf("expected retry to move back to received, got %q", entry.State)
+	}
+	if !entry.CompletedAt.IsZero() {
+		t.Fatalf("retry should clear completed time")
+	}
+}
+
+func TestConsumerDedupLedgerEntryRepresentsAlreadyAppliedSideEffects(t *testing.T) {
+	seenAt := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	entry := NewConsumerDedupLedgerEntry("audit-fanout", "publishWebhook", Event{
+		ID:   "evt-3",
+		Type: EventTaskCompleted,
+	}, seenAt)
+
+	completedAt := seenAt.Add(time.Minute)
+	entry = entry.WithResult(ConsumerHandleResult{
+		State:             ConsumerLedgerStateAlreadyApplied,
+		Attempt:           1,
+		CompletedAt:       completedAt,
+		SideEffectKey:     "webhook-delivery-9",
+		SideEffectApplied: true,
+		Outcome:           "remote sink already reflected this event",
+	})
+	if entry.State != ConsumerLedgerStateAlreadyApplied {
+		t.Fatalf("expected already applied state, got %q", entry.State)
+	}
+	if !entry.SideEffectApplied {
+		t.Fatalf("expected already applied side effect marker")
+	}
+	if entry.SideEffectKey != "webhook-delivery-9" {
+		t.Fatalf("unexpected side effect key %q", entry.SideEffectKey)
+	}
+	if !entry.IsTerminal() {
+		t.Fatalf("already applied should be terminal")
+	}
+}
+
+func TestConsumerDedupLedgerEntryRepresentsDuplicateDelivery(t *testing.T) {
+	seenAt := time.Date(2026, 3, 15, 12, 0, 0, 0, time.UTC)
+	entry := NewConsumerDedupLedgerEntry("projection", "applySummary", Event{
+		ID:   "evt-4",
+		Type: EventTaskCompleted,
+	}, seenAt)
+
+	duplicateAt := seenAt.Add(10 * time.Second)
+	entry = entry.WithResult(ConsumerHandleResult{
+		State:       ConsumerLedgerStateDuplicate,
+		Attempt:     1,
+		CompletedAt: duplicateAt,
+		Outcome:     "ledger entry already completed for this event",
+	})
+	if entry.State != ConsumerLedgerStateDuplicate {
+		t.Fatalf("expected duplicate state, got %q", entry.State)
+	}
+	if !entry.IsTerminal() {
+		t.Fatalf("duplicate should be terminal")
+	}
+	if entry.LastSeenAt != duplicateAt {
+		t.Fatalf("expected duplicate timestamp to be persisted")
+	}
+}

--- a/bigclaw-go/internal/domain/task.go
+++ b/bigclaw-go/internal/domain/task.go
@@ -100,6 +100,20 @@ type Event struct {
 	RunID     string         `json:"run_id,omitempty"`
 	Timestamp time.Time      `json:"timestamp"`
 	Payload   map[string]any `json:"payload,omitempty"`
+	Delivery  *EventDelivery `json:"delivery,omitempty"`
+}
+
+type EventDeliveryMode string
+
+const (
+	EventDeliveryModeLive   EventDeliveryMode = "live"
+	EventDeliveryModeReplay EventDeliveryMode = "replay"
+)
+
+type EventDelivery struct {
+	Mode           EventDeliveryMode `json:"mode,omitempty"`
+	Replay         bool              `json:"replay,omitempty"`
+	IdempotencyKey string            `json:"idempotency_key,omitempty"`
 }
 
 func TaskStateFromEventType(eventType EventType) (TaskState, bool) {

--- a/bigclaw-go/internal/events/delivery.go
+++ b/bigclaw-go/internal/events/delivery.go
@@ -1,0 +1,24 @@
+package events
+
+import "bigclaw-go/internal/domain"
+
+func WithDelivery(event domain.Event, mode domain.EventDeliveryMode) domain.Event {
+	annotated := event
+	annotated.Delivery = &domain.EventDelivery{
+		Mode:           mode,
+		Replay:         mode == domain.EventDeliveryModeReplay,
+		IdempotencyKey: domain.EventIdempotencyKey(event),
+	}
+	return annotated
+}
+
+func WithDeliveryBatch(items []domain.Event, mode domain.EventDeliveryMode) []domain.Event {
+	if len(items) == 0 {
+		return nil
+	}
+	annotated := make([]domain.Event, len(items))
+	for index, item := range items {
+		annotated[index] = WithDelivery(item, mode)
+	}
+	return annotated
+}

--- a/bigclaw-go/internal/events/delivery_test.go
+++ b/bigclaw-go/internal/events/delivery_test.go
@@ -1,0 +1,45 @@
+package events
+
+import (
+	"testing"
+
+	"bigclaw-go/internal/domain"
+)
+
+func TestWithDeliveryAnnotatesReplayMetadata(t *testing.T) {
+	event := domain.Event{ID: "evt-1", Type: domain.EventTaskQueued}
+
+	annotated := WithDelivery(event, domain.EventDeliveryModeReplay)
+
+	if annotated.Delivery == nil {
+		t.Fatalf("expected delivery metadata")
+	}
+	if annotated.Delivery.Mode != domain.EventDeliveryModeReplay {
+		t.Fatalf("expected replay mode, got %q", annotated.Delivery.Mode)
+	}
+	if !annotated.Delivery.Replay {
+		t.Fatalf("expected replay marker")
+	}
+	if annotated.Delivery.IdempotencyKey != "evt-1" {
+		t.Fatalf("expected fallback idempotency key, got %q", annotated.Delivery.IdempotencyKey)
+	}
+}
+
+func TestWithDeliveryBatchPreservesEventOrder(t *testing.T) {
+	items := []domain.Event{
+		{ID: "evt-1", Type: domain.EventTaskQueued},
+		{ID: "evt-2", Type: domain.EventTaskStarted},
+	}
+
+	annotated := WithDeliveryBatch(items, domain.EventDeliveryModeLive)
+
+	if len(annotated) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(annotated))
+	}
+	if annotated[0].ID != "evt-1" || annotated[1].ID != "evt-2" {
+		t.Fatalf("expected batch order to be preserved")
+	}
+	if annotated[0].Delivery == nil || annotated[1].Delivery == nil {
+		t.Fatalf("expected delivery metadata on every event")
+	}
+}

--- a/docs/issue-plan.md
+++ b/docs/issue-plan.md
@@ -108,6 +108,17 @@
 - Record orchestration policy, handoff requests, and execution traces in the observability ledger so every cross-team run can be replayed and audited.
 - Render orchestration plans, per-run canvases, portfolio rollups, and overview pages from ledger-backed artifacts rather than maintaining a separate reporting store.
 
+### Issue `OPE-209` / `BIG-PAR-022`: replay-safe consumer dedup ledger 与处理结果语义
+
+#### Goal
+- Define the minimum persisted contract that lets downstream consumers recognize replayed or duplicated events without claiming global exactly-once execution.
+
+#### Delivery shape
+- Persist a dedup ledger key built from consumer scope plus event idempotency metadata so duplicate deliveries can be classified deterministically.
+- Persist enough event metadata to correlate replays and retries across `event_id`, `event_type`, `task_id`, `trace_id`, `run_id`, and delivery mode.
+- Persist handler result semantics that distinguish `applied`, `duplicate`, `already_applied`, `retryable_failure`, and `terminal_failure` so implementation can retry safely without hiding already-materialized side effects.
+- Keep the contract code-backed in `bigclaw-go/internal/domain` and `bigclaw-go/internal/events` so future middleware/storage work can attach to one stable shape.
+
 ### Epic 11: 产品化 UI 与控制台 (`OPE-86`)
 
 #### Goal


### PR DESCRIPTION
## Summary
- add replay-safe event delivery metadata and helper annotations for downstream consumers
- add a consumer dedup ledger/result-semantics contract covering duplicate, retryable, and already-applied outcomes
- update the issue plan and event bus reliability report with the new contract surface

## Validation
- cd bigclaw-go && go test ./...
- cd bigclaw-go && go test ./internal/domain ./internal/events