### PR TITLE
OPE-210: add subscriber group checkpoint lease fencing

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Subscriber-group checkpoint lease coordination via `/subscriber-groups/leases` and `/subscriber-groups/checkpoints`
 
 ## Validated behaviors
 
@@ -19,6 +20,8 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink receives serialized domain events.
 - SSE streaming can deliver live events.
 - SSE replay can filter to one trace without leaking unrelated events.
+- Subscriber-group checkpoint commits are fenced by lease token + epoch, so stale writers cannot advance ownership after takeover.
+- Checkpoint offsets remain monotonic within a subscriber group and reject rollback writes.
 
 ## Evidence
 
@@ -27,6 +30,8 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
+- `internal/events/subscriber_leases.go`
+- `internal/events/subscriber_leases_test.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
 
@@ -34,4 +39,5 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 
 - No durable external event log yet; replay is process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.
-- No partitioned topic model or cross-process subscriber coordination yet.
+- Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
+- No partitioned topic model yet.

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -24,14 +24,15 @@ type WorkerStatusProvider interface {
 }
 
 type Server struct {
-	Recorder  *observability.Recorder
-	Queue     queue.Queue
-	Executors []domain.ExecutorKind
-	Bus       *events.Bus
-	Now       func() time.Time
-	Worker    WorkerStatusProvider
-	Control   *control.Controller
-	FlowStore *flow.Store
+	Recorder         *observability.Recorder
+	Queue            queue.Queue
+	Executors        []domain.ExecutorKind
+	Bus              *events.Bus
+	SubscriberLeases *events.SubscriberLeaseCoordinator
+	Now              func() time.Time
+	Worker           WorkerStatusProvider
+	Control          *control.Controller
+	FlowStore        *flow.Store
 }
 
 func (s *Server) Handler() http.Handler {
@@ -69,6 +70,9 @@ func (s *Server) Handler() http.Handler {
 			writeJSON(w, http.StatusOK, map[string]any{"events": s.Recorder.EventsByTask("", limit)})
 		}
 	})
+	mux.HandleFunc("/subscriber-groups/leases", s.handleSubscriberGroupLease)
+	mux.HandleFunc("/subscriber-groups/checkpoints", s.handleSubscriberGroupCheckpoint)
+	mux.HandleFunc("/subscriber-groups/", s.handleSubscriberGroupLeaseStatus)
 	mux.HandleFunc("/stream/events", s.handleStreamEvents)
 	mux.HandleFunc("/audit", func(w http.ResponseWriter, r *http.Request) {
 		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
@@ -138,6 +142,23 @@ func (s *Server) Handler() http.Handler {
 	})
 	mux.HandleFunc("/tasks/", s.handleTaskStatus)
 	return mux
+}
+
+type leaseRequestPayload struct {
+	GroupID      string `json:"group_id"`
+	SubscriberID string `json:"subscriber_id"`
+	ConsumerID   string `json:"consumer_id"`
+	TTLSeconds   int64  `json:"ttl_seconds"`
+}
+
+type checkpointRequestPayload struct {
+	GroupID          string `json:"group_id"`
+	SubscriberID     string `json:"subscriber_id"`
+	ConsumerID       string `json:"consumer_id"`
+	LeaseToken       string `json:"lease_token"`
+	LeaseEpoch       int64  `json:"lease_epoch"`
+	CheckpointOffset uint64 `json:"checkpoint_offset"`
+	CheckpointEvent  string `json:"checkpoint_event_id"`
 }
 
 func (s *Server) handleDebugTraces(w http.ResponseWriter, r *http.Request) {
@@ -292,6 +313,116 @@ func (s *Server) handleDeadLetterAction(w http.ResponseWriter, r *http.Request) 
 	traceID := s.traceIDForTask(taskID)
 	s.publish(domain.Event{ID: taskID + "-replayed", Type: domain.EventTaskQueued, TaskID: taskID, TraceID: traceID, Timestamp: now, Payload: map[string]any{"replayed": true}})
 	writeJSON(w, http.StatusAccepted, map[string]any{"task_id": taskID, "state": string(domain.TaskQueued), "replayed": true})
+}
+
+func (s *Server) handleSubscriberGroupLease(w http.ResponseWriter, r *http.Request) {
+	if s.SubscriberLeases == nil {
+		http.Error(w, "subscriber lease coordinator unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	switch r.Method {
+	case http.MethodPost:
+		var payload leaseRequestPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, fmt.Sprintf("decode lease request: %v", err), http.StatusBadRequest)
+			return
+		}
+		lease, err := s.SubscriberLeases.Acquire(events.LeaseRequest{
+			GroupID:      payload.GroupID,
+			SubscriberID: payload.SubscriberID,
+			ConsumerID:   payload.ConsumerID,
+			TTL:          time.Duration(payload.TTLSeconds) * time.Second,
+			Now:          s.Now(),
+		})
+		if err != nil {
+			status := http.StatusBadRequest
+			if err == events.ErrLeaseHeld {
+				status = http.StatusConflict
+			}
+			writeJSON(w, status, map[string]any{"error": err.Error(), "lease": lease})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"lease": lease})
+	case http.MethodDelete:
+		var payload checkpointRequestPayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, fmt.Sprintf("decode lease release: %v", err), http.StatusBadRequest)
+			return
+		}
+		err := s.SubscriberLeases.Release(payload.GroupID, payload.SubscriberID, payload.ConsumerID, payload.LeaseToken, payload.LeaseEpoch)
+		if err != nil {
+			status := http.StatusConflict
+			if err == events.ErrLeaseExpired {
+				status = http.StatusGone
+			}
+			writeJSON(w, status, map[string]any{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{"released": true})
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *Server) handleSubscriberGroupCheckpoint(w http.ResponseWriter, r *http.Request) {
+	if s.SubscriberLeases == nil {
+		http.Error(w, "subscriber lease coordinator unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	var payload checkpointRequestPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+		http.Error(w, fmt.Sprintf("decode checkpoint commit: %v", err), http.StatusBadRequest)
+		return
+	}
+	lease, err := s.SubscriberLeases.Commit(events.CheckpointCommit{
+		GroupID:          payload.GroupID,
+		SubscriberID:     payload.SubscriberID,
+		ConsumerID:       payload.ConsumerID,
+		LeaseToken:       payload.LeaseToken,
+		LeaseEpoch:       payload.LeaseEpoch,
+		CheckpointOffset: payload.CheckpointOffset,
+		CheckpointEvent:  payload.CheckpointEvent,
+		Now:              s.Now(),
+	})
+	if err != nil {
+		status := http.StatusConflict
+		switch err {
+		case events.ErrCheckpointRollback:
+			status = http.StatusPreconditionFailed
+		case events.ErrLeaseExpired:
+			status = http.StatusGone
+		}
+		writeJSON(w, status, map[string]any{"error": err.Error(), "lease": lease})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"lease": lease})
+}
+
+func (s *Server) handleSubscriberGroupLeaseStatus(w http.ResponseWriter, r *http.Request) {
+	if s.SubscriberLeases == nil {
+		http.Error(w, "subscriber lease coordinator unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if r.Method != http.MethodGet {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	path := strings.TrimPrefix(r.URL.Path, "/subscriber-groups/")
+	parts := strings.Split(path, "/")
+	if len(parts) != 3 || parts[1] != "subscribers" || parts[0] == "" || parts[2] == "" {
+		http.Error(w, "expected /subscriber-groups/{group_id}/subscribers/{subscriber_id}", http.StatusBadRequest)
+		return
+	}
+	lease, ok := s.SubscriberLeases.Get(parts[0], parts[2])
+	if !ok {
+		http.Error(w, "subscriber lease not found", http.StatusNotFound)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"lease": lease})
 }
 
 func (s *Server) handleStreamEvents(w http.ResponseWriter, r *http.Request) {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -242,6 +244,103 @@ func TestStreamEventsSupportsReplayAndFiltersByTrace(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for replayed event")
+	}
+}
+
+func TestSubscriberGroupLeaseEndpointsFenceConflictsAndRollback(t *testing.T) {
+	recorder := observability.NewRecorder()
+	server := &Server{
+		Recorder:         recorder,
+		Queue:            queue.NewMemoryQueue(),
+		Bus:              events.NewBus(),
+		SubscriberLeases: events.NewSubscriberLeaseCoordinator(),
+		Now:              func() time.Time { return time.Unix(1700000000, 0) },
+	}
+	handler := server.Handler()
+
+	acquireBody := bytes.NewReader([]byte(`{"group_id":"group-a","subscriber_id":"sub-a","consumer_id":"consumer-a","ttl_seconds":30}`))
+	acquireRequest := httptest.NewRequest(http.MethodPost, "/subscriber-groups/leases", acquireBody)
+	acquireResponse := httptest.NewRecorder()
+	handler.ServeHTTP(acquireResponse, acquireRequest)
+	if acquireResponse.Code != http.StatusOK {
+		t.Fatalf("expected acquire 200, got %d with %s", acquireResponse.Code, acquireResponse.Body.String())
+	}
+
+	var acquired struct {
+		Lease events.SubscriberLease `json:"lease"`
+	}
+	if err := json.Unmarshal(acquireResponse.Body.Bytes(), &acquired); err != nil {
+		t.Fatalf("decode acquire response: %v", err)
+	}
+
+	conflictBody := bytes.NewReader([]byte(`{"group_id":"group-a","subscriber_id":"sub-a","consumer_id":"consumer-b","ttl_seconds":30}`))
+	conflictRequest := httptest.NewRequest(http.MethodPost, "/subscriber-groups/leases", conflictBody)
+	conflictResponse := httptest.NewRecorder()
+	handler.ServeHTTP(conflictResponse, conflictRequest)
+	if conflictResponse.Code != http.StatusConflict {
+		t.Fatalf("expected conflict 409, got %d with %s", conflictResponse.Code, conflictResponse.Body.String())
+	}
+	if !strings.Contains(conflictResponse.Body.String(), "consumer-a") {
+		t.Fatalf("expected current owner in conflict payload, got %s", conflictResponse.Body.String())
+	}
+
+	epoch := strconv.FormatInt(acquired.Lease.LeaseEpoch, 10)
+
+	commitBody := bytes.NewReader([]byte(`{"group_id":"group-a","subscriber_id":"sub-a","consumer_id":"consumer-a","lease_token":"` + acquired.Lease.LeaseToken + `","lease_epoch":` + epoch + `,"checkpoint_offset":7,"checkpoint_event_id":"evt-7"}`))
+	commitRequest := httptest.NewRequest(http.MethodPost, "/subscriber-groups/checkpoints", commitBody)
+	commitResponse := httptest.NewRecorder()
+	handler.ServeHTTP(commitResponse, commitRequest)
+	if commitResponse.Code != http.StatusOK {
+		t.Fatalf("expected checkpoint commit 200, got %d with %s", commitResponse.Code, commitResponse.Body.String())
+	}
+
+	rollbackBody := bytes.NewReader([]byte(`{"group_id":"group-a","subscriber_id":"sub-a","consumer_id":"consumer-a","lease_token":"` + acquired.Lease.LeaseToken + `","lease_epoch":` + epoch + `,"checkpoint_offset":6,"checkpoint_event_id":"evt-6"}`))
+	rollbackRequest := httptest.NewRequest(http.MethodPost, "/subscriber-groups/checkpoints", rollbackBody)
+	rollbackResponse := httptest.NewRecorder()
+	handler.ServeHTTP(rollbackResponse, rollbackRequest)
+	if rollbackResponse.Code != http.StatusPreconditionFailed {
+		t.Fatalf("expected rollback fence 412, got %d with %s", rollbackResponse.Code, rollbackResponse.Body.String())
+	}
+
+	statusRequest := httptest.NewRequest(http.MethodGet, "/subscriber-groups/group-a/subscribers/sub-a", nil)
+	statusResponse := httptest.NewRecorder()
+	handler.ServeHTTP(statusResponse, statusRequest)
+	if statusResponse.Code != http.StatusOK {
+		t.Fatalf("expected lease status 200, got %d with %s", statusResponse.Code, statusResponse.Body.String())
+	}
+	if !strings.Contains(statusResponse.Body.String(), "\"checkpoint_offset\":7") {
+		t.Fatalf("expected checkpoint offset in status payload, got %s", statusResponse.Body.String())
+	}
+}
+
+func TestSubscriberGroupLeaseReleaseFencesStaleToken(t *testing.T) {
+	coordinator := events.NewSubscriberLeaseCoordinator()
+	now := time.Unix(1700000000, 0)
+	lease, err := coordinator.Acquire(events.LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-a",
+		TTL:          5 * time.Second,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("acquire initial lease: %v", err)
+	}
+	takeover, err := coordinator.Acquire(events.LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-b",
+		TTL:          5 * time.Second,
+		Now:          now.Add(6 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("acquire takeover lease: %v", err)
+	}
+	if err := coordinator.Release("group-a", "sub-a", "consumer-a", lease.LeaseToken, lease.LeaseEpoch); !errors.Is(err, events.ErrLeaseFence) {
+		t.Fatalf("expected stale release to be fenced, got %v", err)
+	}
+	if err := coordinator.Release("group-a", "sub-a", "consumer-b", takeover.LeaseToken, takeover.LeaseEpoch); err != nil {
+		t.Fatalf("release active lease: %v", err)
 	}
 }
 

--- a/bigclaw-go/internal/events/subscriber_leases.go
+++ b/bigclaw-go/internal/events/subscriber_leases.go
@@ -1,0 +1,171 @@
+package events
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	ErrLeaseHeld          = errors.New("subscriber checkpoint lease held by another consumer")
+	ErrLeaseExpired       = errors.New("subscriber checkpoint lease expired")
+	ErrLeaseFence         = errors.New("subscriber checkpoint lease fenced")
+	ErrCheckpointRollback = errors.New("subscriber checkpoint rollback rejected")
+)
+
+type SubscriberLeaseKey struct {
+	GroupID      string
+	SubscriberID string
+}
+
+type SubscriberLease struct {
+	GroupID          string    `json:"group_id"`
+	SubscriberID     string    `json:"subscriber_id"`
+	ConsumerID       string    `json:"consumer_id"`
+	LeaseToken       string    `json:"lease_token"`
+	LeaseEpoch       int64     `json:"lease_epoch"`
+	CheckpointOffset uint64    `json:"checkpoint_offset"`
+	CheckpointEvent  string    `json:"checkpoint_event_id,omitempty"`
+	ExpiresAt        time.Time `json:"expires_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+type LeaseRequest struct {
+	GroupID      string
+	SubscriberID string
+	ConsumerID   string
+	TTL          time.Duration
+	Now          time.Time
+}
+
+type CheckpointCommit struct {
+	GroupID          string
+	SubscriberID     string
+	ConsumerID       string
+	LeaseToken       string
+	LeaseEpoch       int64
+	CheckpointOffset uint64
+	CheckpointEvent  string
+	Now              time.Time
+}
+
+type SubscriberLeaseCoordinator struct {
+	mu      sync.Mutex
+	leases  map[SubscriberLeaseKey]SubscriberLease
+	counter uint64
+}
+
+func NewSubscriberLeaseCoordinator() *SubscriberLeaseCoordinator {
+	return &SubscriberLeaseCoordinator{
+		leases: make(map[SubscriberLeaseKey]SubscriberLease),
+	}
+}
+
+func (c *SubscriberLeaseCoordinator) Acquire(request LeaseRequest) (SubscriberLease, error) {
+	if request.GroupID == "" || request.SubscriberID == "" || request.ConsumerID == "" {
+		return SubscriberLease{}, fmt.Errorf("group_id, subscriber_id, and consumer_id are required")
+	}
+	if request.TTL <= 0 {
+		return SubscriberLease{}, fmt.Errorf("ttl must be positive")
+	}
+	if request.Now.IsZero() {
+		request.Now = time.Now()
+	}
+
+	key := SubscriberLeaseKey{GroupID: request.GroupID, SubscriberID: request.SubscriberID}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	current, ok := c.leases[key]
+	if ok && !leaseExpired(current, request.Now) && current.ConsumerID != request.ConsumerID {
+		return current, ErrLeaseHeld
+	}
+	if ok && leaseExpired(current, request.Now) && current.ConsumerID != request.ConsumerID {
+		current.LeaseToken = ""
+	}
+
+	if ok && !leaseExpired(current, request.Now) && current.ConsumerID == request.ConsumerID {
+		current.ExpiresAt = request.Now.Add(request.TTL)
+		current.UpdatedAt = request.Now
+		c.leases[key] = current
+		return current, nil
+	}
+
+	next := SubscriberLease{
+		GroupID:          request.GroupID,
+		SubscriberID:     request.SubscriberID,
+		ConsumerID:       request.ConsumerID,
+		LeaseToken:       c.nextToken(),
+		LeaseEpoch:       current.LeaseEpoch + 1,
+		CheckpointOffset: current.CheckpointOffset,
+		CheckpointEvent:  current.CheckpointEvent,
+		ExpiresAt:        request.Now.Add(request.TTL),
+		UpdatedAt:        request.Now,
+	}
+	c.leases[key] = next
+	return next, nil
+}
+
+func (c *SubscriberLeaseCoordinator) Commit(request CheckpointCommit) (SubscriberLease, error) {
+	if request.Now.IsZero() {
+		request.Now = time.Now()
+	}
+	key := SubscriberLeaseKey{GroupID: request.GroupID, SubscriberID: request.SubscriberID}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	current, ok := c.leases[key]
+	if !ok {
+		return SubscriberLease{}, ErrLeaseExpired
+	}
+	if leaseExpired(current, request.Now) {
+		return current, ErrLeaseExpired
+	}
+	if current.ConsumerID != request.ConsumerID || current.LeaseToken != request.LeaseToken || current.LeaseEpoch != request.LeaseEpoch {
+		return current, ErrLeaseFence
+	}
+	if request.CheckpointOffset < current.CheckpointOffset {
+		return current, ErrCheckpointRollback
+	}
+
+	current.CheckpointOffset = request.CheckpointOffset
+	current.CheckpointEvent = request.CheckpointEvent
+	current.UpdatedAt = request.Now
+	c.leases[key] = current
+	return current, nil
+}
+
+func (c *SubscriberLeaseCoordinator) Get(groupID string, subscriberID string) (SubscriberLease, bool) {
+	key := SubscriberLeaseKey{GroupID: groupID, SubscriberID: subscriberID}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	lease, ok := c.leases[key]
+	return lease, ok
+}
+
+func (c *SubscriberLeaseCoordinator) Release(groupID string, subscriberID string, consumerID string, leaseToken string, leaseEpoch int64) error {
+	key := SubscriberLeaseKey{GroupID: groupID, SubscriberID: subscriberID}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	current, ok := c.leases[key]
+	if !ok {
+		return ErrLeaseExpired
+	}
+	if current.ConsumerID != consumerID || current.LeaseToken != leaseToken || current.LeaseEpoch != leaseEpoch {
+		return ErrLeaseFence
+	}
+	delete(c.leases, key)
+	return nil
+}
+
+func (c *SubscriberLeaseCoordinator) nextToken() string {
+	c.counter++
+	return fmt.Sprintf("lease-%d", c.counter)
+}
+
+func leaseExpired(lease SubscriberLease, now time.Time) bool {
+	return !lease.ExpiresAt.IsZero() && !now.Before(lease.ExpiresAt)
+}

--- a/bigclaw-go/internal/events/subscriber_leases_test.go
+++ b/bigclaw-go/internal/events/subscriber_leases_test.go
@@ -1,0 +1,137 @@
+package events
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestSubscriberLeaseCoordinatorRejectsActiveConflictAndAllowsExpiryTakeover(t *testing.T) {
+	coordinator := NewSubscriberLeaseCoordinator()
+	now := time.Unix(1700000000, 0)
+
+	lease, err := coordinator.Acquire(LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-a",
+		TTL:          30 * time.Second,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("acquire initial lease: %v", err)
+	}
+
+	conflict, err := coordinator.Acquire(LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-b",
+		TTL:          30 * time.Second,
+		Now:          now.Add(10 * time.Second),
+	})
+	if !errors.Is(err, ErrLeaseHeld) {
+		t.Fatalf("expected ErrLeaseHeld, got %v", err)
+	}
+	if conflict.ConsumerID != lease.ConsumerID {
+		t.Fatalf("expected conflict to expose current owner %q, got %q", lease.ConsumerID, conflict.ConsumerID)
+	}
+
+	takeover, err := coordinator.Acquire(LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-b",
+		TTL:          30 * time.Second,
+		Now:          now.Add(31 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("acquire after expiry: %v", err)
+	}
+	if takeover.ConsumerID != "consumer-b" {
+		t.Fatalf("expected takeover by consumer-b, got %q", takeover.ConsumerID)
+	}
+	if takeover.LeaseEpoch != lease.LeaseEpoch+1 {
+		t.Fatalf("expected epoch to advance from %d to %d, got %d", lease.LeaseEpoch, lease.LeaseEpoch+1, takeover.LeaseEpoch)
+	}
+}
+
+func TestSubscriberLeaseCoordinatorFencesStaleWriterAndRollback(t *testing.T) {
+	coordinator := NewSubscriberLeaseCoordinator()
+	now := time.Unix(1700000000, 0)
+
+	lease, err := coordinator.Acquire(LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-a",
+		TTL:          20 * time.Second,
+		Now:          now,
+	})
+	if err != nil {
+		t.Fatalf("acquire lease: %v", err)
+	}
+	lease, err = coordinator.Commit(CheckpointCommit{
+		GroupID:          "group-a",
+		SubscriberID:     "sub-a",
+		ConsumerID:       "consumer-a",
+		LeaseToken:       lease.LeaseToken,
+		LeaseEpoch:       lease.LeaseEpoch,
+		CheckpointOffset: 11,
+		CheckpointEvent:  "evt-11",
+		Now:              now.Add(5 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("commit checkpoint: %v", err)
+	}
+
+	if _, err := coordinator.Commit(CheckpointCommit{
+		GroupID:          "group-a",
+		SubscriberID:     "sub-a",
+		ConsumerID:       "consumer-a",
+		LeaseToken:       lease.LeaseToken,
+		LeaseEpoch:       lease.LeaseEpoch,
+		CheckpointOffset: 10,
+		CheckpointEvent:  "evt-10",
+		Now:              now.Add(6 * time.Second),
+	}); !errors.Is(err, ErrCheckpointRollback) {
+		t.Fatalf("expected ErrCheckpointRollback, got %v", err)
+	}
+
+	takeover, err := coordinator.Acquire(LeaseRequest{
+		GroupID:      "group-a",
+		SubscriberID: "sub-a",
+		ConsumerID:   "consumer-b",
+		TTL:          20 * time.Second,
+		Now:          now.Add(21 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("acquire takeover lease: %v", err)
+	}
+
+	if _, err := coordinator.Commit(CheckpointCommit{
+		GroupID:          "group-a",
+		SubscriberID:     "sub-a",
+		ConsumerID:       "consumer-a",
+		LeaseToken:       lease.LeaseToken,
+		LeaseEpoch:       lease.LeaseEpoch,
+		CheckpointOffset: 12,
+		CheckpointEvent:  "evt-12",
+		Now:              now.Add(22 * time.Second),
+	}); !errors.Is(err, ErrLeaseFence) {
+		t.Fatalf("expected stale writer to be fenced, got %v", err)
+	}
+
+	current, err := coordinator.Commit(CheckpointCommit{
+		GroupID:          "group-a",
+		SubscriberID:     "sub-a",
+		ConsumerID:       "consumer-b",
+		LeaseToken:       takeover.LeaseToken,
+		LeaseEpoch:       takeover.LeaseEpoch,
+		CheckpointOffset: 15,
+		CheckpointEvent:  "evt-15",
+		Now:              now.Add(23 * time.Second),
+	})
+	if err != nil {
+		t.Fatalf("commit with takeover lease: %v", err)
+	}
+	if current.CheckpointOffset != 15 {
+		t.Fatalf("expected checkpoint offset 15, got %d", current.CheckpointOffset)
+	}
+}


### PR DESCRIPTION
## Summary
- add an in-memory subscriber-group lease coordinator with lease token and epoch fencing
- expose lease acquisition, checkpoint commit, release, and status endpoints for subscriber groups
- add regression tests for active-owner conflicts, stale writers after takeover, and monotonic checkpoint rollback rejection
- update the event bus reliability report to document the new lease semantics and the remaining durability gap

## Validation
- go test ./internal/events ./internal/api

## Commit
- a8220971b687a3886a1202947de21261f897a48f