### PR TITLE
OPE-212: define replay checkpoint compaction semantics

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -35,3 +35,4 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - No durable external event log yet; replay is process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.
+- No retention watermark or expired-cursor contract exists in the runtime yet; the target compaction semantics are defined in `docs/reports/replay-retention-semantics-report.md`.

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -37,3 +37,4 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof captured in `docs/reports/multi-node-coordination-report.md`.
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
+- Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -1,0 +1,74 @@
+# Replay Retention and Checkpoint Compaction Semantics
+
+## Scope
+
+This report defines the retention and compaction contract for the replay-capable event surfaces being extended under `OPE-212` / `BIG-PAR-026`.
+
+The current Go runtime still uses in-process replay history in `internal/events/bus.go` and recorder-backed timeline lookup in `internal/api/server.go`. This document defines the durability-safe behavior that a future retained event-log backend must preserve when replay history and subscriber checkpoints age out.
+
+## Current baseline
+
+- `Bus.SubscribeReplay` replays the tail of the in-memory append history before switching the subscriber to live events.
+- `GET /events`, `GET /replay/{id}`, and `GET /stream/events?replay=1` expose replay-oriented views over recorder history.
+- No durable retention watermark, checkpoint expiration signal, or history compaction rule exists yet.
+
+## Retention model
+
+- Replay history is retained as a contiguous suffix of the event log.
+- Compaction may advance the oldest retained boundary, but it must never create holes inside the retained replay window.
+- A backend must expose or be able to derive an oldest retained cursor and newest retained cursor for operator diagnostics.
+- Cursor validity is determined against the retained window, not only by syntactic shape. A well-formed cursor may still be expired if it points before the oldest retained boundary.
+
+## Compaction boundaries
+
+- History may only be compacted on prefix boundaries where every removed event is older than the new oldest retained cursor.
+- Compaction must not discard an event while still claiming that the event's cursor can be resumed.
+- Checkpoint cleanup and history compaction are related but distinct operations: compacting history advances replay availability, while checkpoint cleanup removes stale subscriber metadata.
+- Backends should prefer monotonic compaction watermarks so repeated resume attempts observe stable or forward-only retention behavior.
+
+## Checkpoint interaction
+
+- A subscriber checkpoint represents the last fully processed event cursor for that subscriber identity or lease domain.
+- A checkpoint is resumable only when its cursor is still within the retained replay window.
+- If a checkpoint points before the oldest retained cursor, the backend must reject resume as expired instead of silently starting from an arbitrary later event.
+- If a checkpoint points inside the retained window but the exact event has been compacted incorrectly, that is a backend correctness bug rather than a fallback case.
+- Active subscriber checkpoints should be retained even when the subscriber is idle; cleanup eligibility should be driven by inactivity policy, lease expiry, or explicit deletion, not by compaction alone.
+
+## Expired cursor fallback contract
+
+- Resume requests against aged-out checkpoints must surface an explicit expired-cursor result.
+- The result should include the subscriber or lease identity, the requested checkpoint cursor, and the oldest/newest retained cursors that were available at evaluation time.
+- Operator-facing diagnostics should describe whether recovery can restart from the earliest retained event, from the latest live edge, or requires manual checkpoint reset.
+- Automatic fallback must be policy-driven. The default safe behavior is fail-closed with diagnostics rather than silently skipping truncated history.
+
+## Cleanup path
+
+- Retention-aware checkpoint cleanup should only remove checkpoints that are both inactive and no longer useful for replay recovery.
+- Cleanup should record enough metadata to explain why a checkpoint disappeared, including inactivity age, lease status, and retention watermark at deletion time.
+- A future durable backend should separate:
+  - history retention policy,
+  - checkpoint inactivity TTL,
+  - operator override/reset actions.
+- This separation lets operators keep short replay windows without forcing immediate loss of subscriber ownership metadata.
+
+## Required operator signals
+
+- Current oldest retained cursor
+- Current newest retained cursor
+- Subscriber checkpoint cursor and last update time
+- Resume failure reason: expired cursor, unknown subscriber, or backend mismatch
+- Suggested recovery action: restart from earliest retained, reset checkpoint, or investigate backend corruption
+
+## Forward path
+
+- `OPE-212` establishes the compaction and retention contract.
+- `OPE-216` can build the concrete API/error surface for expired replay cursors and truncated-history fallback.
+- Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
+
+## Repo evidence
+
+- `internal/events/bus.go`
+- `internal/events/bus_test.go`
+- `internal/api/server.go`
+- `internal/api/server_test.go`
+- `docs/reports/event-bus-reliability-report.md`

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -1,0 +1,34 @@
+# OpenClaw Parallel Gap Analysis
+
+## Replay and checkpoint durability track
+
+The current BigClaw Go event plane has replay-capable APIs, but the implementation remains process-local and does not yet define how replay history ages out without breaking subscriber recovery.
+
+### Closed baseline
+
+- `OPE-199` introduced a durable-event-log direction, but the current checkout still exposes replay primarily through recorder history and in-memory bus subscriptions.
+- `OPE-203` added subscriber checkpoint and resume semantics at the issue-planning level, while `OPE-205` tightened monotonic checkpoint expectations.
+- `OPE-210` defined subscriber-group lease coordination so stale writers cannot move shared progress backward.
+
+### Active gap closed by `OPE-212`
+
+- Replay history needs a retention contract that preserves a contiguous replay window.
+- Subscriber checkpoints need an explicit validity rule once older history is compacted away.
+- Resume failures caused by aged-out checkpoints must produce diagnostics instead of silently fast-forwarding consumers.
+
+### Remaining follow-on slices
+
+- `OPE-213`: define backend capability matrix and config validation for durable event-log providers.
+- `OPE-214`: expose backend capability probe and operator-facing retention support visibility.
+- `OPE-215`: define dedup-ledger backend/key semantics for replay-safe consumers.
+- `OPE-216`: define the concrete expired-cursor and truncated-history fallback surface.
+- `OPE-217`: define multi-subscriber takeover fault-injection and audit evidence.
+
+## Outcome
+
+`OPE-212` should be treated as the contract slice that prevents future durable backends from inventing incompatible compaction behavior. The implementation bar for later slices is now:
+
+- compact only on prefix boundaries,
+- reject expired checkpoints explicitly,
+- keep checkpoint cleanup separate from history retention,
+- surface retention watermarks for operators and future automation.

--- a/reports/OPE-212-validation.md
+++ b/reports/OPE-212-validation.md
@@ -1,0 +1,21 @@
+# Issue Validation Report
+
+- Issue ID: OPE-212
+- Title: BIG-PAR-026 replay checkpoint compaction / retention 语义
+- 测试环境: local-go
+- 生成时间: 2026-03-15T17:45:00+0800
+
+## 结论
+
+Delivered the `BIG-PAR-026` retention/compaction contract as repo-native documentation for the BigClaw Go replay path. The repo now defines how replay windows compact on prefix boundaries, how subscriber checkpoints become invalid when they fall behind the oldest retained cursor, and which operator-visible diagnostics/fallback constraints future durable backends must preserve.
+
+## 变更
+
+- Added `bigclaw-go/docs/reports/replay-retention-semantics-report.md` with the replay retention model, compaction boundaries, checkpoint interaction rules, expired-cursor behavior, and cleanup path.
+- Added `docs/openclaw-parallel-gap-analysis.md` so the Linear repo-evidence path exists in this checkout and records the follow-on durability slices around retention, fallback, capabilities, and takeover validation.
+- Updated `bigclaw-go/docs/reports/event-bus-reliability-report.md` and `bigclaw-go/docs/reports/issue-coverage.md` to point existing event-bus evidence at the new retention contract.
+
+## Validation Evidence
+
+- `cd bigclaw-go && go test ./internal/events ./internal/api` -> `ok  	bigclaw-go/internal/events	0.012s` and `ok  	bigclaw-go/internal/api	0.134s`
+- `rg -n "OPE-212|BIG-PAR-026|retention|expired-cursor|compaction" bigclaw-go/docs/reports/replay-retention-semantics-report.md docs/openclaw-parallel-gap-analysis.md reports/OPE-212-validation.md bigclaw-go/docs/reports/event-bus-reliability-report.md bigclaw-go/docs/reports/issue-coverage.md` -> confirmed issue ID, ticket title, retention rules, expired-cursor semantics, and traceability references across the new and updated artifacts


### PR DESCRIPTION
## Summary
- add a replay retention and checkpoint compaction semantics report for the BigClaw Go event plane
- add docs/openclaw-parallel-gap-analysis.md as the missing traceability artifact for the parallel durability track
- link the existing event-bus and issue-coverage reports to the new retention contract

## Validation
- cd bigclaw-go && go test ./internal/events ./internal/api
- rg -n "OPE-212|BIG-PAR-026|retention|expired-cursor|compaction" bigclaw-go/docs/reports/replay-retention-semantics-report.md docs/openclaw-parallel-gap-analysis.md reports/OPE-212-validation.md bigclaw-go/docs/reports/event-bus-reliability-report.md bigclaw-go/docs/reports/issue-coverage.md