### PR TITLE
OPE-213: add durability capability matrix and backend config validation

### DIFF
--- a/bigclaw-go/README.md
+++ b/bigclaw-go/README.md
@@ -36,6 +36,16 @@ This bootstrap now covers an MVP slice for all current Go rewrite planning ticke
 
 ## Real integration configuration
 
+### Event durability contract
+
+- `BIGCLAW_EVENT_BACKEND` with `memory`, `sqlite`, `http`, or `broker`
+- `BIGCLAW_EVENT_LOG_DSN` for durable event-log backends
+- `BIGCLAW_EVENT_CHECKPOINT_DSN` when checkpoint support is required
+- `BIGCLAW_EVENT_RETENTION` for durable replay history retention
+- `BIGCLAW_EVENT_REQUIRE_REPLAY`
+- `BIGCLAW_EVENT_REQUIRE_CHECKPOINT`
+- `BIGCLAW_EVENT_REQUIRE_FILTERING`
+
 ### Kubernetes
 
 - `BIGCLAW_KUBECONFIG` or `KUBECONFIG`

--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -24,6 +24,9 @@ import (
 
 func main() {
 	cfg := config.LoadFromEnv()
+	if err := validateEventBackend(cfg); err != nil {
+		panic(err)
+	}
 	q, err := buildQueue(cfg)
 	if err != nil {
 		panic(err)
@@ -140,4 +143,17 @@ func buildRegistry(cfg config.Config) *executor.Registry {
 
 func seed(ctx context.Context, q queue.Queue) {
 	_ = q.Enqueue(ctx, domain.Task{ID: "bootstrap-local", Title: "bootstrap local task", Priority: 1, RiskLevel: domain.RiskLow, BudgetCents: 100, Entrypoint: "echo hello from local", CreatedAt: time.Now(), UpdatedAt: time.Now()})
+}
+
+func validateEventBackend(cfg config.Config) error {
+	report := events.ValidateBackendConfig(events.BackendConfig{
+		Backend:           events.BackendKind(cfg.EventBackend),
+		LogDSN:            cfg.EventLogDSN,
+		CheckpointDSN:     cfg.EventCheckpointDSN,
+		Retention:         cfg.EventRetention,
+		RequireReplay:     cfg.EventRequireReplay,
+		RequireCheckpoint: cfg.EventRequireCheckpoint,
+		RequireFiltering:  cfg.EventRequireFiltering,
+	})
+	return report.Error()
 }

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Event backend capability and config-validation contract via `internal/events/backend_contract.go`
 
 ## Validated behaviors
 
@@ -23,15 +24,36 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 ## Evidence
 
 - `internal/events/bus.go`
+- `internal/events/backend_contract.go`
+- `internal/events/backend_contract_test.go`
 - `internal/events/bus_test.go`
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
+- `cmd/bigclawd/main.go`
+- `internal/config/config.go`
+
+## Durability capability matrix
+
+| Backend | Implemented in bootstrap | Durable history | Publish | Replay | Checkpoint | Filtering | Required config |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `memory` | yes | no | native | native | unsupported | native | none |
+| `sqlite` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
+| `http` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
+| `broker` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
+
+## Validation contract
+
+- Startup validates `BIGCLAW_EVENT_BACKEND` against the backend catalog before queue/bootstrap wiring begins.
+- Durable backends must provide explicit event-log DSN, checkpoint DSN, and positive retention.
+- `BIGCLAW_EVENT_REQUIRE_REPLAY`, `BIGCLAW_EVENT_REQUIRE_CHECKPOINT`, and `BIGCLAW_EVENT_REQUIRE_FILTERING` express the runtime features operators expect from the selected backend.
+- Unsupported combinations fail fast with field-specific errors instead of silently downgrading runtime behavior.
+- Backends declared in the matrix but not yet wired into the bootstrap runtime are rejected explicitly so planning assumptions cannot masquerade as implemented support.
 
 ## Remaining gaps
 
-- No durable external event log yet; replay is process-local history.
+- No durable external event log is wired into the runtime yet; replay is still process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.

--- a/bigclaw-go/internal/config/config.go
+++ b/bigclaw-go/internal/config/config.go
@@ -9,6 +9,13 @@ import (
 
 type Config struct {
 	QueueBackend                  string
+	EventBackend                  string
+	EventLogDSN                   string
+	EventCheckpointDSN            string
+	EventRetention                time.Duration
+	EventRequireReplay            bool
+	EventRequireCheckpoint        bool
+	EventRequireFiltering         bool
 	EventWebhookURLs              []string
 	EventWebhookBearerToken       string
 	EventWebhookTimeout           time.Duration
@@ -42,6 +49,11 @@ type Config struct {
 func Default() Config {
 	return Config{
 		QueueBackend:                  "file",
+		EventBackend:                  "memory",
+		EventRetention:                0,
+		EventRequireReplay:            true,
+		EventRequireCheckpoint:        false,
+		EventRequireFiltering:         true,
 		EventWebhookTimeout:           5 * time.Second,
 		QueueSQLitePath:               "./state/queue.db",
 		AuditLogPath:                  "./state/audit.jsonl",
@@ -71,6 +83,13 @@ func Default() Config {
 func LoadFromEnv() Config {
 	cfg := Default()
 	cfg.QueueBackend = getString("BIGCLAW_QUEUE_BACKEND", cfg.QueueBackend)
+	cfg.EventBackend = getString("BIGCLAW_EVENT_BACKEND", cfg.EventBackend)
+	cfg.EventLogDSN = getString("BIGCLAW_EVENT_LOG_DSN", cfg.EventLogDSN)
+	cfg.EventCheckpointDSN = getString("BIGCLAW_EVENT_CHECKPOINT_DSN", cfg.EventCheckpointDSN)
+	cfg.EventRetention = getDuration("BIGCLAW_EVENT_RETENTION", cfg.EventRetention)
+	cfg.EventRequireReplay = getBool("BIGCLAW_EVENT_REQUIRE_REPLAY", cfg.EventRequireReplay)
+	cfg.EventRequireCheckpoint = getBool("BIGCLAW_EVENT_REQUIRE_CHECKPOINT", cfg.EventRequireCheckpoint)
+	cfg.EventRequireFiltering = getBool("BIGCLAW_EVENT_REQUIRE_FILTERING", cfg.EventRequireFiltering)
 	cfg.EventWebhookURLs = splitCSV(getString("BIGCLAW_EVENT_WEBHOOK_URLS", ""))
 	cfg.EventWebhookBearerToken = getString("BIGCLAW_EVENT_WEBHOOK_BEARER_TOKEN", cfg.EventWebhookBearerToken)
 	cfg.EventWebhookTimeout = getDuration("BIGCLAW_EVENT_WEBHOOK_TIMEOUT", cfg.EventWebhookTimeout)

--- a/bigclaw-go/internal/events/backend_contract.go
+++ b/bigclaw-go/internal/events/backend_contract.go
@@ -1,0 +1,220 @@
+package events
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type BackendKind string
+
+const (
+	BackendMemory BackendKind = "memory"
+	BackendSQLite BackendKind = "sqlite"
+	BackendHTTP   BackendKind = "http"
+	BackendBroker BackendKind = "broker"
+)
+
+type SupportLevel string
+
+const (
+	SupportUnsupported SupportLevel = "unsupported"
+	SupportDerived     SupportLevel = "derived"
+	SupportNative      SupportLevel = "native"
+)
+
+type CapabilityMatrix struct {
+	Publish     SupportLevel
+	Replay      SupportLevel
+	Checkpoints SupportLevel
+	Filtering   SupportLevel
+}
+
+type BackendProfile struct {
+	Backend               BackendKind
+	Implemented           bool
+	Durable               bool
+	RequiresLogDSN        bool
+	RequiresCheckpointDSN bool
+	Capabilities          CapabilityMatrix
+}
+
+type BackendConfig struct {
+	Backend           BackendKind
+	LogDSN            string
+	CheckpointDSN     string
+	Retention         time.Duration
+	RequireReplay     bool
+	RequireCheckpoint bool
+	RequireFiltering  bool
+}
+
+type ValidationIssue struct {
+	Level   string
+	Field   string
+	Message string
+}
+
+type ValidationReport struct {
+	Profile BackendProfile
+	Issues  []ValidationIssue
+}
+
+func Catalog() map[BackendKind]BackendProfile {
+	return map[BackendKind]BackendProfile{
+		BackendMemory: {
+			Backend:     BackendMemory,
+			Implemented: true,
+			Durable:     false,
+			Capabilities: CapabilityMatrix{
+				Publish:     SupportNative,
+				Replay:      SupportNative,
+				Checkpoints: SupportUnsupported,
+				Filtering:   SupportNative,
+			},
+		},
+		BackendSQLite: {
+			Backend:               BackendSQLite,
+			Implemented:           false,
+			Durable:               true,
+			RequiresLogDSN:        true,
+			RequiresCheckpointDSN: true,
+			Capabilities: CapabilityMatrix{
+				Publish:     SupportNative,
+				Replay:      SupportNative,
+				Checkpoints: SupportNative,
+				Filtering:   SupportDerived,
+			},
+		},
+		BackendHTTP: {
+			Backend:               BackendHTTP,
+			Implemented:           false,
+			Durable:               true,
+			RequiresLogDSN:        true,
+			RequiresCheckpointDSN: true,
+			Capabilities: CapabilityMatrix{
+				Publish:     SupportNative,
+				Replay:      SupportNative,
+				Checkpoints: SupportNative,
+				Filtering:   SupportDerived,
+			},
+		},
+		BackendBroker: {
+			Backend:               BackendBroker,
+			Implemented:           false,
+			Durable:               true,
+			RequiresLogDSN:        true,
+			RequiresCheckpointDSN: true,
+			Capabilities: CapabilityMatrix{
+				Publish:     SupportNative,
+				Replay:      SupportNative,
+				Checkpoints: SupportNative,
+				Filtering:   SupportDerived,
+			},
+		},
+	}
+}
+
+func ValidateBackendConfig(cfg BackendConfig) ValidationReport {
+	profile, ok := Catalog()[cfg.Backend]
+	report := ValidationReport{}
+	if !ok {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "backend",
+			Message: fmt.Sprintf("unsupported event backend %q", cfg.Backend),
+		})
+		return report
+	}
+	report.Profile = profile
+
+	if !profile.Implemented {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "backend",
+			Message: fmt.Sprintf("event backend %q is defined in the durability matrix but not wired into the bootstrap runtime", cfg.Backend),
+		})
+	}
+	if profile.RequiresLogDSN && strings.TrimSpace(cfg.LogDSN) == "" {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "log_dsn",
+			Message: "durable event backend requires BIGCLAW_EVENT_LOG_DSN",
+		})
+	}
+	if !profile.RequiresLogDSN && strings.TrimSpace(cfg.LogDSN) != "" {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "log_dsn",
+			Message: fmt.Sprintf("event backend %q does not accept BIGCLAW_EVENT_LOG_DSN", cfg.Backend),
+		})
+	}
+	if profile.Durable && cfg.Retention <= 0 {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "retention",
+			Message: "durable event backend requires BIGCLAW_EVENT_RETENTION to be greater than zero",
+		})
+	}
+	if !profile.Durable && cfg.Retention < 0 {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "retention",
+			Message: "event retention cannot be negative",
+		})
+	}
+	if cfg.RequireReplay && report.Profile.Capabilities.Replay == SupportUnsupported {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "require_replay",
+			Message: fmt.Sprintf("event backend %q does not support replay", cfg.Backend),
+		})
+	}
+	if cfg.RequireCheckpoint {
+		if report.Profile.Capabilities.Checkpoints == SupportUnsupported {
+			report.Issues = append(report.Issues, ValidationIssue{
+				Level:   "error",
+				Field:   "require_checkpoint",
+				Message: fmt.Sprintf("event backend %q does not support checkpoints", cfg.Backend),
+			})
+		}
+		if profile.RequiresCheckpointDSN && strings.TrimSpace(cfg.CheckpointDSN) == "" {
+			report.Issues = append(report.Issues, ValidationIssue{
+				Level:   "error",
+				Field:   "checkpoint_dsn",
+				Message: "checkpoint-capable backends require BIGCLAW_EVENT_CHECKPOINT_DSN when checkpoint support is required",
+			})
+		}
+	}
+	if cfg.RequireFiltering && report.Profile.Capabilities.Filtering == SupportUnsupported {
+		report.Issues = append(report.Issues, ValidationIssue{
+			Level:   "error",
+			Field:   "require_filtering",
+			Message: fmt.Sprintf("event backend %q does not support server-side filtering", cfg.Backend),
+		})
+	}
+	return report
+}
+
+func (r ValidationReport) HasErrors() bool {
+	for _, issue := range r.Issues {
+		if issue.Level == "error" {
+			return true
+		}
+	}
+	return false
+}
+
+func (r ValidationReport) Error() error {
+	if !r.HasErrors() {
+		return nil
+	}
+	parts := make([]string, 0, len(r.Issues))
+	for _, issue := range r.Issues {
+		if issue.Level != "error" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %s", issue.Field, issue.Message))
+	}
+	return fmt.Errorf("event backend validation failed: %s", strings.Join(parts, "; "))
+}

--- a/bigclaw-go/internal/events/backend_contract_test.go
+++ b/bigclaw-go/internal/events/backend_contract_test.go
@@ -1,0 +1,69 @@
+package events
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestValidateBackendConfigMemoryDefaults(t *testing.T) {
+	report := ValidateBackendConfig(BackendConfig{
+		Backend:          BackendMemory,
+		RequireReplay:    true,
+		RequireFiltering: true,
+	})
+	if report.HasErrors() {
+		t.Fatalf("expected memory backend validation to pass, got %+v", report.Issues)
+	}
+}
+
+func TestValidateBackendConfigRejectsCheckpointOnMemory(t *testing.T) {
+	report := ValidateBackendConfig(BackendConfig{
+		Backend:           BackendMemory,
+		RequireReplay:     true,
+		RequireFiltering:  true,
+		RequireCheckpoint: true,
+	})
+	if !report.HasErrors() {
+		t.Fatal("expected checkpoint requirement on memory backend to fail")
+	}
+	if err := report.Error(); err == nil || !strings.Contains(err.Error(), "does not support checkpoints") {
+		t.Fatalf("expected checkpoint validation error, got %v", err)
+	}
+}
+
+func TestValidateBackendConfigRejectsUnwiredDurableBackend(t *testing.T) {
+	report := ValidateBackendConfig(BackendConfig{
+		Backend:           BackendSQLite,
+		LogDSN:            "file:events.db",
+		CheckpointDSN:     "file:checkpoints.db",
+		Retention:         time.Hour,
+		RequireReplay:     true,
+		RequireFiltering:  true,
+		RequireCheckpoint: true,
+	})
+	if !report.HasErrors() {
+		t.Fatal("expected unwired sqlite backend to fail")
+	}
+	if err := report.Error(); err == nil || !strings.Contains(err.Error(), "not wired into the bootstrap runtime") {
+		t.Fatalf("expected bootstrap runtime validation error, got %v", err)
+	}
+}
+
+func TestValidateBackendConfigRequiresDurableFields(t *testing.T) {
+	report := ValidateBackendConfig(BackendConfig{
+		Backend:           BackendBroker,
+		RequireReplay:     true,
+		RequireFiltering:  true,
+		RequireCheckpoint: true,
+	})
+	if !report.HasErrors() {
+		t.Fatal("expected broker backend to require durable config fields")
+	}
+	errText := report.Error().Error()
+	for _, fragment := range []string{"BIGCLAW_EVENT_LOG_DSN", "BIGCLAW_EVENT_CHECKPOINT_DSN", "BIGCLAW_EVENT_RETENTION"} {
+		if !strings.Contains(errText, fragment) {
+			t.Fatalf("expected %q in validation error, got %s", fragment, errText)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add an event backend capability catalog and validation contract for memory, sqlite, http, and broker backends
- validate event backend requirements during startup so unsupported replay/checkpoint/filtering combinations fail fast
- document the durability matrix and required config in the reliability report and README

## Validation
- go test ./internal/events ./internal/config ./cmd/bigclawd
- go test ./...