### PR TITLE
OPE-215: add consumer dedup ledger backend contract

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Replay-safe consumer dedup ledger contract with stable storage key and result semantics
 
 ## Validated behaviors
 
@@ -23,15 +24,28 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 ## Evidence
 
 - `internal/events/bus.go`
+- `internal/events/dedup_ledger.go`
+- `internal/events/dedup_ledger_test.go`
 - `internal/events/bus_test.go`
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
+- `internal/domain/dedup.go`
+- `internal/domain/dedup_test.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
 
 ## Remaining gaps
 
 - No durable external event log yet; replay is process-local history.
+- No durable consumer dedup backend yet; only the backend abstraction, stable key layout, and reference in-memory semantics are implemented.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.
+
+## Consumer dedup ledger contract
+
+- Stable storage keys use `v1/<consumer_id>/<event_id>` so durable backends can share one persistence layout while still rejecting conflicting event metadata for the same consumer/event tuple.
+- Collision protection uses a fingerprint over `consumer_id`, `event_id`, `event_type`, `task_id`, `trace_id`, and `run_id`; the same storage key cannot be reused for a different event payload shape.
+- Reservation semantics distinguish first-writer `reserved`, repeated in-flight `duplicate`, and terminal `already_applied` outcomes.
+- Applied side effects persist `handler`, `applied_at`, `effect_id`, `effect_sequence`, `effect_fingerprint`, `summary`, and stable metadata so duplicate deliveries can return the prior applied result instead of replaying the side effect.
+- Once a record reaches `applied`, backends must treat a different result fingerprint as a conflict instead of silently overwriting the prior side effect evidence.

--- a/bigclaw-go/internal/domain/dedup.go
+++ b/bigclaw-go/internal/domain/dedup.go
@@ -1,0 +1,161 @@
+package domain
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+)
+
+const ConsumerDedupKeyVersion = "v1"
+
+type ConsumerDedupRecordState string
+
+const (
+	ConsumerDedupStatePending ConsumerDedupRecordState = "pending"
+	ConsumerDedupStateApplied ConsumerDedupRecordState = "applied"
+)
+
+type ConsumerDedupReserveOutcome string
+
+const (
+	ConsumerDedupOutcomeReserved       ConsumerDedupReserveOutcome = "reserved"
+	ConsumerDedupOutcomeDuplicate      ConsumerDedupReserveOutcome = "duplicate"
+	ConsumerDedupOutcomeAlreadyApplied ConsumerDedupReserveOutcome = "already_applied"
+	ConsumerDedupOutcomeConflict       ConsumerDedupReserveOutcome = "conflict"
+)
+
+type ConsumerDedupKey struct {
+	Version    string    `json:"version,omitempty"`
+	ConsumerID string    `json:"consumer_id"`
+	EventID    string    `json:"event_id"`
+	EventType  EventType `json:"event_type,omitempty"`
+	TaskID     string    `json:"task_id,omitempty"`
+	TraceID    string    `json:"trace_id,omitempty"`
+	RunID      string    `json:"run_id,omitempty"`
+}
+
+func NewConsumerDedupKey(consumerID string, event Event) ConsumerDedupKey {
+	return ConsumerDedupKey{
+		Version:    ConsumerDedupKeyVersion,
+		ConsumerID: consumerID,
+		EventID:    event.ID,
+		EventType:  event.Type,
+		TaskID:     event.TaskID,
+		TraceID:    event.TraceID,
+		RunID:      event.RunID,
+	}
+}
+
+func (k ConsumerDedupKey) Normalize() ConsumerDedupKey {
+	k.Version = strings.TrimSpace(k.Version)
+	if k.Version == "" {
+		k.Version = ConsumerDedupKeyVersion
+	}
+	k.ConsumerID = strings.TrimSpace(k.ConsumerID)
+	k.EventID = strings.TrimSpace(k.EventID)
+	k.EventType = EventType(strings.TrimSpace(string(k.EventType)))
+	k.TaskID = strings.TrimSpace(k.TaskID)
+	k.TraceID = strings.TrimSpace(k.TraceID)
+	k.RunID = strings.TrimSpace(k.RunID)
+	return k
+}
+
+func (k ConsumerDedupKey) StorageKey() string {
+	key := k.Normalize()
+	return fmt.Sprintf("%s/%s/%s", key.Version, key.ConsumerID, key.EventID)
+}
+
+func (k ConsumerDedupKey) Fingerprint() string {
+	key := k.Normalize()
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		key.Version,
+		key.ConsumerID,
+		key.EventID,
+		string(key.EventType),
+		key.TaskID,
+		key.TraceID,
+		key.RunID,
+	}, "\x1f")))
+	return hex.EncodeToString(sum[:])
+}
+
+func (k ConsumerDedupKey) Validate() error {
+	key := k.Normalize()
+	if key.ConsumerID == "" {
+		return fmt.Errorf("consumer dedup key requires consumer_id")
+	}
+	if key.EventID == "" {
+		return fmt.Errorf("consumer dedup key requires event_id")
+	}
+	return nil
+}
+
+type ConsumerDedupResult struct {
+	State             ConsumerDedupRecordState `json:"state"`
+	Handler           string                   `json:"handler,omitempty"`
+	AppliedAt         time.Time                `json:"applied_at,omitempty"`
+	EffectID          string                   `json:"effect_id,omitempty"`
+	EffectSequence    int64                    `json:"effect_sequence,omitempty"`
+	EffectFingerprint string                   `json:"effect_fingerprint,omitempty"`
+	Summary           string                   `json:"summary,omitempty"`
+	Metadata          map[string]string        `json:"metadata,omitempty"`
+}
+
+func (r ConsumerDedupResult) Normalize() ConsumerDedupResult {
+	r.State = ConsumerDedupRecordState(strings.TrimSpace(string(r.State)))
+	if r.State == "" {
+		r.State = ConsumerDedupStateApplied
+	}
+	r.Handler = strings.TrimSpace(r.Handler)
+	r.EffectID = strings.TrimSpace(r.EffectID)
+	r.EffectFingerprint = strings.TrimSpace(r.EffectFingerprint)
+	r.Summary = strings.TrimSpace(r.Summary)
+	if r.Metadata == nil {
+		return r
+	}
+	cloned := make(map[string]string, len(r.Metadata))
+	for key, value := range r.Metadata {
+		cloned[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+	r.Metadata = cloned
+	return r
+}
+
+func (r ConsumerDedupResult) StableFingerprint() string {
+	normalized := r.Normalize()
+	pairs := make([]string, 0, len(normalized.Metadata))
+	for key, value := range normalized.Metadata {
+		pairs = append(pairs, key+"="+value)
+	}
+	if len(pairs) > 1 {
+		slices.Sort(pairs)
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		string(normalized.State),
+		normalized.Handler,
+		normalized.EffectID,
+		fmt.Sprintf("%d", normalized.EffectSequence),
+		normalized.EffectFingerprint,
+		normalized.Summary,
+		normalized.AppliedAt.UTC().Format(time.RFC3339Nano),
+		strings.Join(pairs, "\x1e"),
+	}, "\x1f")))
+	return hex.EncodeToString(sum[:])
+}
+
+type ConsumerDedupRecord struct {
+	Key               ConsumerDedupKey         `json:"key"`
+	StorageKey        string                   `json:"storage_key"`
+	Fingerprint       string                   `json:"fingerprint"`
+	State             ConsumerDedupRecordState `json:"state"`
+	CreatedAt         time.Time                `json:"created_at"`
+	UpdatedAt         time.Time                `json:"updated_at"`
+	LastAttemptAt     time.Time                `json:"last_attempt_at"`
+	AttemptCount      int                      `json:"attempt_count"`
+	CompletedAt       time.Time                `json:"completed_at,omitempty"`
+	AppliedResult     ConsumerDedupResult      `json:"applied_result,omitempty"`
+	ResultFingerprint string                   `json:"result_fingerprint,omitempty"`
+}

--- a/bigclaw-go/internal/domain/dedup_test.go
+++ b/bigclaw-go/internal/domain/dedup_test.go
@@ -1,0 +1,69 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewConsumerDedupKeyProducesStableStorageKeyAndFingerprint(t *testing.T) {
+	event := Event{
+		ID:        "evt-42",
+		Type:      EventTaskCompleted,
+		TaskID:    "task-1",
+		TraceID:   "trace-1",
+		RunID:     "run-1",
+		Timestamp: time.Unix(1700000000, 0).UTC(),
+	}
+
+	key := NewConsumerDedupKey(" consumer-a ", event)
+	if got, want := key.StorageKey(), "v1/consumer-a/evt-42"; got != want {
+		t.Fatalf("expected storage key %q, got %q", want, got)
+	}
+
+	if got := key.Fingerprint(); got == "" {
+		t.Fatalf("expected non-empty fingerprint")
+	}
+
+	normalized := ConsumerDedupKey{
+		ConsumerID: "consumer-a",
+		EventID:    "evt-42",
+		EventType:  EventTaskCompleted,
+		TaskID:     "task-1",
+		TraceID:    "trace-1",
+		RunID:      "run-1",
+	}
+	if got, want := key.Fingerprint(), normalized.Fingerprint(); got != want {
+		t.Fatalf("expected normalized fingerprint %q, got %q", want, got)
+	}
+}
+
+func TestConsumerDedupResultStableFingerprintIgnoresMetadataOrder(t *testing.T) {
+	first := ConsumerDedupResult{
+		Handler:           "audit-sink",
+		AppliedAt:         time.Unix(1700000100, 0).UTC(),
+		EffectID:          "effect-1",
+		EffectSequence:    2,
+		EffectFingerprint: "fp-1",
+		Summary:           "applied",
+		Metadata: map[string]string{
+			"tenant": "alpha",
+			"mode":   "replay",
+		},
+	}
+	second := ConsumerDedupResult{
+		Handler:           "audit-sink",
+		AppliedAt:         time.Unix(1700000100, 0).UTC(),
+		EffectID:          "effect-1",
+		EffectSequence:    2,
+		EffectFingerprint: "fp-1",
+		Summary:           "applied",
+		Metadata: map[string]string{
+			"mode":   "replay",
+			"tenant": "alpha",
+		},
+	}
+
+	if got, want := first.StableFingerprint(), second.StableFingerprint(); got != want {
+		t.Fatalf("expected equal stable fingerprints, got %q and %q", got, want)
+	}
+}

--- a/bigclaw-go/internal/events/dedup_ledger.go
+++ b/bigclaw-go/internal/events/dedup_ledger.go
@@ -1,0 +1,149 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"bigclaw-go/internal/domain"
+)
+
+var ErrConsumerDedupConflict = errors.New("consumer dedup ledger conflict")
+
+type ConsumerDedupLedger interface {
+	Get(context.Context, domain.ConsumerDedupKey) (domain.ConsumerDedupRecord, bool, error)
+	Reserve(context.Context, domain.ConsumerDedupKey, time.Time) (domain.ConsumerDedupRecord, domain.ConsumerDedupReserveOutcome, error)
+	MarkApplied(context.Context, domain.ConsumerDedupKey, domain.ConsumerDedupResult, time.Time) (domain.ConsumerDedupRecord, domain.ConsumerDedupReserveOutcome, error)
+}
+
+type MemoryConsumerDedupLedger struct {
+	mu      sync.Mutex
+	records map[string]domain.ConsumerDedupRecord
+}
+
+func NewMemoryConsumerDedupLedger() *MemoryConsumerDedupLedger {
+	return &MemoryConsumerDedupLedger{records: make(map[string]domain.ConsumerDedupRecord)}
+}
+
+func (l *MemoryConsumerDedupLedger) Get(_ context.Context, key domain.ConsumerDedupKey) (domain.ConsumerDedupRecord, bool, error) {
+	normalized, storageKey, fingerprint, err := normalizeConsumerDedupKey(key)
+	if err != nil {
+		return domain.ConsumerDedupRecord{}, false, err
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	record, ok := l.records[storageKey]
+	if !ok {
+		return domain.ConsumerDedupRecord{}, false, nil
+	}
+	if record.Fingerprint != fingerprint {
+		return domain.ConsumerDedupRecord{}, false, ErrConsumerDedupConflict
+	}
+	record.Key = normalized
+	return record, true, nil
+}
+
+func (l *MemoryConsumerDedupLedger) Reserve(_ context.Context, key domain.ConsumerDedupKey, now time.Time) (domain.ConsumerDedupRecord, domain.ConsumerDedupReserveOutcome, error) {
+	normalized, storageKey, fingerprint, err := normalizeConsumerDedupKey(key)
+	if err != nil {
+		return domain.ConsumerDedupRecord{}, "", err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	record, ok := l.records[storageKey]
+	if !ok {
+		record = domain.ConsumerDedupRecord{
+			Key:           normalized,
+			StorageKey:    storageKey,
+			Fingerprint:   fingerprint,
+			State:         domain.ConsumerDedupStatePending,
+			CreatedAt:     now,
+			UpdatedAt:     now,
+			LastAttemptAt: now,
+			AttemptCount:  1,
+		}
+		l.records[storageKey] = record
+		return record, domain.ConsumerDedupOutcomeReserved, nil
+	}
+	if record.Fingerprint != fingerprint {
+		return domain.ConsumerDedupRecord{}, domain.ConsumerDedupOutcomeConflict, ErrConsumerDedupConflict
+	}
+
+	record.LastAttemptAt = now
+	record.UpdatedAt = now
+	record.AttemptCount++
+	l.records[storageKey] = record
+	if record.State == domain.ConsumerDedupStateApplied {
+		return record, domain.ConsumerDedupOutcomeAlreadyApplied, nil
+	}
+	return record, domain.ConsumerDedupOutcomeDuplicate, nil
+}
+
+func (l *MemoryConsumerDedupLedger) MarkApplied(_ context.Context, key domain.ConsumerDedupKey, result domain.ConsumerDedupResult, now time.Time) (domain.ConsumerDedupRecord, domain.ConsumerDedupReserveOutcome, error) {
+	normalized, storageKey, fingerprint, err := normalizeConsumerDedupKey(key)
+	if err != nil {
+		return domain.ConsumerDedupRecord{}, "", err
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	normalizedResult := result.Normalize()
+	if normalizedResult.AppliedAt.IsZero() {
+		normalizedResult.AppliedAt = now
+	}
+	resultFingerprint := normalizedResult.StableFingerprint()
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	record, ok := l.records[storageKey]
+	if !ok {
+		record = domain.ConsumerDedupRecord{
+			Key:          normalized,
+			StorageKey:   storageKey,
+			Fingerprint:  fingerprint,
+			State:        domain.ConsumerDedupStatePending,
+			CreatedAt:    now,
+			AttemptCount: 0,
+		}
+	}
+	if record.Fingerprint != fingerprint {
+		return domain.ConsumerDedupRecord{}, domain.ConsumerDedupOutcomeConflict, ErrConsumerDedupConflict
+	}
+	if record.State == domain.ConsumerDedupStateApplied {
+		if record.ResultFingerprint != resultFingerprint {
+			return domain.ConsumerDedupRecord{}, domain.ConsumerDedupOutcomeConflict, ErrConsumerDedupConflict
+		}
+		return record, domain.ConsumerDedupOutcomeAlreadyApplied, nil
+	}
+
+	record.Key = normalized
+	record.State = domain.ConsumerDedupStateApplied
+	record.AppliedResult = normalizedResult
+	record.ResultFingerprint = resultFingerprint
+	record.LastAttemptAt = now
+	record.UpdatedAt = now
+	record.CompletedAt = normalizedResult.AppliedAt
+	if record.AttemptCount == 0 {
+		record.AttemptCount = 1
+	}
+	l.records[storageKey] = record
+	return record, domain.ConsumerDedupOutcomeReserved, nil
+}
+
+func normalizeConsumerDedupKey(key domain.ConsumerDedupKey) (domain.ConsumerDedupKey, string, string, error) {
+	normalized := key.Normalize()
+	if err := normalized.Validate(); err != nil {
+		return domain.ConsumerDedupKey{}, "", "", err
+	}
+	return normalized, normalized.StorageKey(), normalized.Fingerprint(), nil
+}

--- a/bigclaw-go/internal/events/dedup_ledger_test.go
+++ b/bigclaw-go/internal/events/dedup_ledger_test.go
@@ -1,0 +1,140 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"bigclaw-go/internal/domain"
+)
+
+func TestMemoryConsumerDedupLedgerReserveAndApply(t *testing.T) {
+	ledger := NewMemoryConsumerDedupLedger()
+	key := domain.NewConsumerDedupKey("consumer-a", domain.Event{
+		ID:      "evt-1",
+		Type:    domain.EventTaskCompleted,
+		TaskID:  "task-1",
+		TraceID: "trace-1",
+		RunID:   "run-1",
+	})
+	now := time.Unix(1700000000, 0).UTC()
+
+	record, outcome, err := ledger.Reserve(context.Background(), key, now)
+	if err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+	if outcome != domain.ConsumerDedupOutcomeReserved {
+		t.Fatalf("expected reserved outcome, got %s", outcome)
+	}
+	if record.State != domain.ConsumerDedupStatePending {
+		t.Fatalf("expected pending record, got %s", record.State)
+	}
+	if record.AttemptCount != 1 {
+		t.Fatalf("expected first attempt count, got %d", record.AttemptCount)
+	}
+
+	record, outcome, err = ledger.Reserve(context.Background(), key, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("duplicate reserve failed: %v", err)
+	}
+	if outcome != domain.ConsumerDedupOutcomeDuplicate {
+		t.Fatalf("expected duplicate outcome, got %s", outcome)
+	}
+	if record.AttemptCount != 2 {
+		t.Fatalf("expected duplicate attempt count, got %d", record.AttemptCount)
+	}
+
+	applied := domain.ConsumerDedupResult{
+		Handler:           "projection",
+		AppliedAt:         now.Add(2 * time.Second),
+		EffectID:          "effect-1",
+		EffectSequence:    7,
+		EffectFingerprint: "fp-1",
+		Summary:           "projection updated",
+	}
+	record, outcome, err = ledger.MarkApplied(context.Background(), key, applied, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("mark applied failed: %v", err)
+	}
+	if outcome != domain.ConsumerDedupOutcomeReserved {
+		t.Fatalf("expected reserved outcome on first apply, got %s", outcome)
+	}
+	if record.State != domain.ConsumerDedupStateApplied {
+		t.Fatalf("expected applied state, got %s", record.State)
+	}
+	if record.ResultFingerprint == "" {
+		t.Fatalf("expected recorded result fingerprint")
+	}
+
+	record, outcome, err = ledger.Reserve(context.Background(), key, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("already applied reserve failed: %v", err)
+	}
+	if outcome != domain.ConsumerDedupOutcomeAlreadyApplied {
+		t.Fatalf("expected already_applied outcome, got %s", outcome)
+	}
+	if record.AppliedResult.EffectID != "effect-1" {
+		t.Fatalf("expected stored result to survive duplicate read")
+	}
+}
+
+func TestMemoryConsumerDedupLedgerRejectsStorageKeyCollision(t *testing.T) {
+	ledger := NewMemoryConsumerDedupLedger()
+	now := time.Unix(1700000000, 0).UTC()
+
+	first := domain.ConsumerDedupKey{
+		ConsumerID: "consumer-a",
+		EventID:    "evt-1",
+		EventType:  domain.EventTaskQueued,
+		TaskID:     "task-1",
+	}
+	second := domain.ConsumerDedupKey{
+		ConsumerID: "consumer-a",
+		EventID:    "evt-1",
+		EventType:  domain.EventTaskCompleted,
+		TaskID:     "task-2",
+	}
+
+	if _, _, err := ledger.Reserve(context.Background(), first, now); err != nil {
+		t.Fatalf("reserve failed: %v", err)
+	}
+	if _, outcome, err := ledger.Reserve(context.Background(), second, now.Add(time.Second)); !errors.Is(err, ErrConsumerDedupConflict) {
+		t.Fatalf("expected conflict error, got %v", err)
+	} else if outcome != domain.ConsumerDedupOutcomeConflict {
+		t.Fatalf("expected conflict outcome, got %s", outcome)
+	}
+}
+
+func TestMemoryConsumerDedupLedgerRejectsOverwritingAppliedResult(t *testing.T) {
+	ledger := NewMemoryConsumerDedupLedger()
+	key := domain.NewConsumerDedupKey("consumer-a", domain.Event{
+		ID:      "evt-1",
+		Type:    domain.EventTaskCompleted,
+		TaskID:  "task-1",
+		TraceID: "trace-1",
+	})
+	now := time.Unix(1700000000, 0).UTC()
+
+	if _, _, err := ledger.MarkApplied(context.Background(), key, domain.ConsumerDedupResult{
+		Handler:        "projection",
+		AppliedAt:      now,
+		EffectID:       "effect-1",
+		EffectSequence: 1,
+		Summary:        "first",
+	}, now); err != nil {
+		t.Fatalf("initial apply failed: %v", err)
+	}
+
+	if _, outcome, err := ledger.MarkApplied(context.Background(), key, domain.ConsumerDedupResult{
+		Handler:        "projection",
+		AppliedAt:      now.Add(time.Second),
+		EffectID:       "effect-2",
+		EffectSequence: 2,
+		Summary:        "second",
+	}, now.Add(time.Second)); !errors.Is(err, ErrConsumerDedupConflict) {
+		t.Fatalf("expected overwrite conflict, got %v", err)
+	} else if outcome != domain.ConsumerDedupOutcomeConflict {
+		t.Fatalf("expected conflict outcome, got %s", outcome)
+	}
+}


### PR DESCRIPTION
## Summary
- add a replay-safe consumer dedup ledger contract with a stable `v1/<consumer_id>/<event_id>` storage key model
- add a reference in-memory backend that enforces duplicate, already-applied, and collision semantics
- document the new ledger contract and durable-backend follow-up in the event bus reliability report

## Validation
- go test ./internal/domain ./internal/events
- go test ./...