### PR TITLE
OPE-214: add event-log backend capability probe

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -11,6 +11,8 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Runtime capability probe for event-log backend publish/replay/checkpoint/filtering/retention support
+- Control-center and debug payload exposure for the active event-log backend capability set
 
 ## Validated behaviors
 
@@ -19,6 +21,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Webhook sink receives serialized domain events.
 - SSE streaming can deliver live events.
 - SSE replay can filter to one trace without leaking unrelated events.
+- Operators can inspect backend capability support before dispatching replay-oriented operations.
 
 ## Evidence
 
@@ -27,6 +30,7 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - `internal/events/webhook.go`
 - `internal/events/webhook_test.go`
 - `internal/events/recorder_sink.go`
+- `internal/events/capabilities.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
 

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -96,6 +96,7 @@ func (s *Server) Handler() http.Handler {
 			"queue_size":   s.Queue.Size(context.Background()),
 			"audit_events": len(s.Recorder.Logs()),
 			"executors":    s.executorNames(),
+			"event_log":    s.eventLogCapabilities(r.Context()),
 		}
 		if s.Worker != nil {
 			payload["worker"] = s.Worker.Snapshot()
@@ -345,6 +346,13 @@ func matchesEventStreamFilter(event domain.Event, taskID string, traceID string)
 		return false
 	}
 	return true
+}
+
+func (s *Server) eventLogCapabilities(ctx context.Context) events.BackendCapabilities {
+	if s.Bus != nil {
+		return s.Bus.Capabilities(ctx)
+	}
+	return events.UnavailableCapabilities()
 }
 
 func (s *Server) publish(event domain.Event) {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -255,7 +255,7 @@ func TestDebugStatusIncludesWorkerSnapshot(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("expected debug status 200, got %d", response.Code)
 	}
-	if !strings.Contains(response.Body.String(), "worker-a") || !strings.Contains(response.Body.String(), "successful_runs") {
+	if !strings.Contains(response.Body.String(), "worker-a") || !strings.Contains(response.Body.String(), "successful_runs") || !strings.Contains(response.Body.String(), "event_log") || !strings.Contains(response.Body.String(), "in_memory_history") || !strings.Contains(response.Body.String(), "checkpoint") {
 		t.Fatalf("expected worker snapshot in debug payload, got %s", response.Body.String())
 	}
 }
@@ -1190,7 +1190,7 @@ func TestV2ControlCenterSummariesFiltersAndAudit(t *testing.T) {
 		t.Fatalf("expected control center 200, got %d", centerResponse.Code)
 	}
 	centerBody := centerResponse.Body.String()
-	for _, want := range []string{"queue_budget_cents_total", "600", "high_risk_runs", "premium_runs", "active_takeovers", "worker_pool", "idle_workers", "task-control-1", "effective_state", "blocked", "Manual validation required", "queue_by_project", "queue_by_team", "alpha", "platform", "recent_actions", "audit_summary", "notes_timeline"} {
+	for _, want := range []string{"queue_budget_cents_total", "600", "high_risk_runs", "premium_runs", "active_takeovers", "worker_pool", "idle_workers", "task-control-1", "effective_state", "blocked", "Manual validation required", "queue_by_project", "queue_by_team", "alpha", "platform", "recent_actions", "audit_summary", "notes_timeline", "event_log", "in_memory_history", "process_local", "\"checkpoint\":{\"supported\":false", "\"filtering\":{\"supported\":true"} {
 		if !strings.Contains(centerBody, want) {
 			t.Fatalf("expected %q in control center payload, got %s", want, centerBody)
 		}

--- a/bigclaw-go/internal/api/v2.go
+++ b/bigclaw-go/internal/api/v2.go
@@ -1089,6 +1089,7 @@ func (s *Server) handleV2ControlCenter(w http.ResponseWriter, r *http.Request) {
 			"audit_limit": filters.AuditLimit,
 		},
 		"control":          s.Control.Snapshot(),
+		"event_log":        s.eventLogCapabilities(r.Context()),
 		"summary":          summarizeControlCenter(queueTasks, filteredDeadLetters),
 		"queue":            map[string]any{"size": s.Queue.Size(context.Background()), "filtered_size": len(queueTasks), "dead_letters": len(filteredDeadLetters), "tasks": returnedQueueTasks, "cancellable": supportsQueueCancel(s.Queue)},
 		"queue_by_project": sortedDashboardBreakdowns(queueByProject),

--- a/bigclaw-go/internal/events/bus.go
+++ b/bigclaw-go/internal/events/bus.go
@@ -17,16 +17,44 @@ type Bus struct {
 	subscribers map[int]chan domain.Event
 	sinks       []Sink
 	nextID      int
+	provider    CapabilityProvider
+	capability  BackendCapabilities
 }
 
 func NewBus() *Bus {
-	return &Bus{subscribers: make(map[int]chan domain.Event)}
+	return &Bus{
+		subscribers: make(map[int]chan domain.Event),
+		capability:  defaultBusCapabilities(),
+	}
 }
 
 func (b *Bus) AddSink(sink Sink) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	b.sinks = append(b.sinks, sink)
+}
+
+func (b *Bus) SetCapabilityProvider(provider CapabilityProvider) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.provider = provider
+}
+
+func (b *Bus) SetCapabilities(capability BackendCapabilities) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.capability = capability
+}
+
+func (b *Bus) Capabilities(ctx context.Context) BackendCapabilities {
+	b.mu.RLock()
+	provider := b.provider
+	capability := b.capability
+	b.mu.RUnlock()
+	if provider != nil {
+		return provider.Capabilities(ctx)
+	}
+	return capability
 }
 
 func (b *Bus) Publish(event domain.Event) {

--- a/bigclaw-go/internal/events/bus_test.go
+++ b/bigclaw-go/internal/events/bus_test.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -44,5 +45,41 @@ func TestBusSubscribeReplayReturnsHistoryAndLiveEvents(t *testing.T) {
 	live := <-ch
 	if live.ID != third.ID {
 		t.Fatalf("expected live event %s, got %s", third.ID, live.ID)
+	}
+}
+
+type staticCapabilityProvider struct {
+	capability BackendCapabilities
+}
+
+func (p staticCapabilityProvider) Capabilities(context.Context) BackendCapabilities {
+	return p.capability
+}
+
+func TestBusCapabilitiesDefaultAndOverride(t *testing.T) {
+	bus := NewBus()
+	capability := bus.Capabilities(context.Background())
+	if capability.Backend != "in_memory_history" {
+		t.Fatalf("expected default backend in_memory_history, got %s", capability.Backend)
+	}
+	if !capability.Replay.Supported || capability.Checkpoint.Supported {
+		t.Fatalf("unexpected default capability set: %+v", capability)
+	}
+
+	override := BackendCapabilities{
+		Backend: "broker_adapter",
+		Scope:   "shared_cluster",
+		Publish: FeatureSupport{Supported: true, Mode: "replicated"},
+		Replay:  FeatureSupport{Supported: true, Mode: "durable"},
+		Checkpoint: FeatureSupport{
+			Supported: true,
+			Mode:      "lease_aware",
+		},
+		Filtering: FeatureSupport{Supported: true, Mode: "server_side"},
+		Retention: FeatureSupport{Supported: true, Mode: "ttl"},
+	}
+	bus.SetCapabilityProvider(staticCapabilityProvider{capability: override})
+	if got := bus.Capabilities(context.Background()); got.Backend != "broker_adapter" || !got.Checkpoint.Supported || got.Retention.Mode != "ttl" {
+		t.Fatalf("expected provider override, got %+v", got)
 	}
 }

--- a/bigclaw-go/internal/events/capabilities.go
+++ b/bigclaw-go/internal/events/capabilities.go
@@ -1,0 +1,81 @@
+package events
+
+import "context"
+
+type FeatureSupport struct {
+	Supported bool   `json:"supported"`
+	Mode      string `json:"mode,omitempty"`
+	Detail    string `json:"detail,omitempty"`
+}
+
+type BackendCapabilities struct {
+	Backend    string         `json:"backend"`
+	Scope      string         `json:"scope,omitempty"`
+	Publish    FeatureSupport `json:"publish"`
+	Replay     FeatureSupport `json:"replay"`
+	Checkpoint FeatureSupport `json:"checkpoint"`
+	Filtering  FeatureSupport `json:"filtering"`
+	Retention  FeatureSupport `json:"retention"`
+}
+
+type CapabilityProvider interface {
+	Capabilities(context.Context) BackendCapabilities
+}
+
+func defaultBusCapabilities() BackendCapabilities {
+	return BackendCapabilities{
+		Backend: "in_memory_history",
+		Scope:   "process_local",
+		Publish: FeatureSupport{
+			Supported: true,
+			Mode:      "live_fanout",
+			Detail:    "Publishes to in-process subscribers and configured sinks.",
+		},
+		Replay: FeatureSupport{
+			Supported: true,
+			Mode:      "memory_history",
+			Detail:    "Replay is served from process memory and resets on restart.",
+		},
+		Checkpoint: FeatureSupport{
+			Supported: false,
+			Detail:    "No durable subscriber checkpoint backend is configured.",
+		},
+		Filtering: FeatureSupport{
+			Supported: true,
+			Mode:      "task_id,trace_id",
+			Detail:    "Runtime filtering is available on replay and live SSE requests.",
+		},
+		Retention: FeatureSupport{
+			Supported: true,
+			Mode:      "process_memory",
+			Detail:    "Retention lasts only for the current process lifetime.",
+		},
+	}
+}
+
+func UnavailableCapabilities() BackendCapabilities {
+	return BackendCapabilities{
+		Backend: "unavailable",
+		Scope:   "disabled",
+		Publish: FeatureSupport{
+			Supported: false,
+			Detail:    "No event bus backend is configured.",
+		},
+		Replay: FeatureSupport{
+			Supported: false,
+			Detail:    "Replay requires an active event bus backend.",
+		},
+		Checkpoint: FeatureSupport{
+			Supported: false,
+			Detail:    "No event bus backend is configured.",
+		},
+		Filtering: FeatureSupport{
+			Supported: false,
+			Detail:    "No event bus backend is configured.",
+		},
+		Retention: FeatureSupport{
+			Supported: false,
+			Detail:    "No event bus backend is configured.",
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- add an event-log backend capability contract for publish, replay, checkpoint, filtering, and retention support
- expose the active capability probe in `/debug/status` and `/v2/control-center`
- extend tests and the event-bus reliability report for the new operator-facing payload

## Validation
- go test ./internal/events ./internal/api
- go test ./...
