### PR TITLE
OPE-216 add replay cursor fallback semantics

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -10,12 +10,14 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 - Recorder sink integration for audit/debug persistence
 - Webhook sink integration for external fanout
 - SSE stream via `GET /stream/events`
-- Optional SSE replay and filtering via `replay=1`, `task_id`, and `trace_id`
+- Optional SSE replay and filtering via `replay=1`, `after_id`, `Last-Event-ID`, `task_id`, and `trace_id`
+- Replay cursor diagnostics via `X-Replay-*` headers and JSON `cursor` metadata on `GET /events`
 
 ## Validated behaviors
 
 - Published events are retained in replay history.
 - New subscribers can request replayed events before switching to live events.
+- Replay resumes can detect when the available replay window has moved past the requested cursor and fall back to the oldest retained event.
 - Webhook sink receives serialized domain events.
 - SSE streaming can deliver live events.
 - SSE replay can filter to one trace without leaking unrelated events.
@@ -33,5 +35,6 @@ This report summarizes the current event bus reliability evidence for `OPE-183` 
 ## Remaining gaps
 
 - No durable external event log yet; replay is process-local history.
+- Expired cursor detection is bounded by the current in-process replay window; unknown cursors and fully empty windows still need durable backend semantics for stronger guarantees.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -58,8 +58,15 @@ func (s *Server) Handler() http.Handler {
 	})
 	mux.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		afterID := replayCursorFromRequest(r)
 		taskID := r.URL.Query().Get("task_id")
 		traceID := r.URL.Query().Get("trace_id")
+		if s.Bus != nil {
+			replay, cursor := s.Bus.ReplayWindow(limit, afterID, taskID, traceID)
+			writeReplayCursorHeaders(w, cursor)
+			writeJSON(w, http.StatusOK, map[string]any{"events": replay, "cursor": cursor})
+			return
+		}
 		switch {
 		case taskID != "":
 			writeJSON(w, http.StatusOK, map[string]any{"events": s.Recorder.EventsByTask(taskID, limit)})
@@ -300,7 +307,8 @@ func (s *Server) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
-	replay := r.URL.Query().Get("replay") == "1"
+	afterID := replayCursorFromRequest(r)
+	replay := r.URL.Query().Get("replay") == "1" || afterID != ""
 	taskID := r.URL.Query().Get("task_id")
 	traceID := r.URL.Query().Get("trace_id")
 	flusher, ok := w.(http.Flusher)
@@ -314,7 +322,9 @@ func (s *Server) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 	var ch <-chan domain.Event
 	var cancel func()
 	if replay {
-		ch, cancel = s.Bus.SubscribeReplay(128, limit)
+		replayWindow, cursor := s.Bus.ReplayWindow(limit, afterID, taskID, traceID)
+		writeReplayCursorHeaders(w, cursor)
+		ch, cancel = s.Bus.SubscribeReplayWindow(128, replayWindow)
 	} else {
 		ch, cancel = s.Bus.Subscribe(128)
 	}
@@ -345,6 +355,30 @@ func matchesEventStreamFilter(event domain.Event, taskID string, traceID string)
 		return false
 	}
 	return true
+}
+
+func replayCursorFromRequest(r *http.Request) string {
+	if afterID := strings.TrimSpace(r.URL.Query().Get("after_id")); afterID != "" {
+		return afterID
+	}
+	return strings.TrimSpace(r.Header.Get("Last-Event-ID"))
+}
+
+func writeReplayCursorHeaders(w http.ResponseWriter, status events.ReplayCursorStatus) {
+	w.Header().Set("X-Replay-Cursor-Status", status.Status)
+	w.Header().Set("X-Replay-Fallback", status.Fallback)
+	if status.RequestedAfterID != "" {
+		w.Header().Set("X-Replay-Requested-After-ID", status.RequestedAfterID)
+	}
+	if status.OldestEventID != "" {
+		w.Header().Set("X-Replay-Oldest-Event-ID", status.OldestEventID)
+	}
+	if status.NewestEventID != "" {
+		w.Header().Set("X-Replay-Newest-Event-ID", status.NewestEventID)
+	}
+	if status.HistoryTruncated {
+		w.Header().Set("X-Replay-History-Truncated", "true")
+	}
 }
 
 func (s *Server) publish(event domain.Event) {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -245,6 +245,88 @@ func TestStreamEventsSupportsReplayAndFiltersByTrace(t *testing.T) {
 	}
 }
 
+func TestEventsEndpointReturnsCursorFallbackMetadataWhenReplayWindowExpired(t *testing.T) {
+	recorder := observability.NewRecorder()
+	bus := events.NewBusWithHistoryLimit(2)
+	bus.AddSink(events.RecorderSink{Recorder: recorder})
+	bus.Publish(domain.Event{ID: "evt-old-1", Type: domain.EventTaskQueued, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	bus.Publish(domain.Event{ID: "evt-old-2", Type: domain.EventTaskStarted, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	bus.Publish(domain.Event{ID: "evt-old-3", Type: domain.EventTaskCompleted, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	server := &Server{Recorder: recorder, Queue: queue.NewMemoryQueue(), Bus: bus, Now: time.Now}
+
+	request := httptest.NewRequest(http.MethodGet, "/events?task_id=task-a&after_id=evt-old-1&limit=10", nil)
+	response := httptest.NewRecorder()
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	if got := response.Header().Get("X-Replay-Cursor-Status"); got != "expired" {
+		t.Fatalf("expected expired cursor header, got %q", got)
+	}
+	if got := response.Header().Get("X-Replay-Fallback"); got != "resume_from_oldest" {
+		t.Fatalf("expected fallback header, got %q", got)
+	}
+	if !strings.Contains(response.Body.String(), "\"status\":\"expired\"") || !strings.Contains(response.Body.String(), "\"evt-old-2\"") {
+		t.Fatalf("expected cursor metadata and fallback events, got %s", response.Body.String())
+	}
+}
+
+func TestStreamEventsUsesLastEventIDForExpiredCursorFallback(t *testing.T) {
+	recorder := observability.NewRecorder()
+	bus := events.NewBusWithHistoryLimit(2)
+	bus.AddSink(events.RecorderSink{Recorder: recorder})
+	bus.Publish(domain.Event{ID: "evt-old-1", Type: domain.EventTaskQueued, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	bus.Publish(domain.Event{ID: "evt-old-2", Type: domain.EventTaskStarted, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	bus.Publish(domain.Event{ID: "evt-old-3", Type: domain.EventTaskCompleted, TaskID: "task-a", TraceID: "trace-a", Timestamp: time.Now()})
+	server := &Server{Recorder: recorder, Queue: queue.NewMemoryQueue(), Bus: bus, Now: time.Now}
+	ts := httptest.NewServer(server.Handler())
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/stream/events?limit=10&task_id=task-a", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	request.Header.Set("Last-Event-ID", "evt-old-1")
+
+	type streamResult struct {
+		line   string
+		header http.Header
+		err    error
+	}
+	resultCh := make(chan streamResult, 1)
+	go func() {
+		response, err := http.DefaultClient.Do(request)
+		if err != nil {
+			resultCh <- streamResult{err: err}
+			return
+		}
+		defer response.Body.Close()
+		reader := bufio.NewReader(response.Body)
+		line, err := reader.ReadString('\n')
+		resultCh <- streamResult{line: strings.TrimSpace(line), header: response.Header.Clone(), err: err}
+	}()
+
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("stream read: %v", result.err)
+		}
+		if got := result.header.Get("X-Replay-Cursor-Status"); got != "expired" {
+			t.Fatalf("expected expired cursor header, got %q", got)
+		}
+		if got := result.header.Get("X-Replay-Fallback"); got != "resume_from_oldest" {
+			t.Fatalf("expected fallback header, got %q", got)
+		}
+		if !strings.Contains(result.line, "evt-old-2") {
+			t.Fatalf("expected fallback replay to start at oldest available event, got %q", result.line)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for replayed event")
+	}
+}
+
 func TestDebugStatusIncludesWorkerSnapshot(t *testing.T) {
 	recorder := observability.NewRecorder()
 	bus := events.NewBus()

--- a/bigclaw-go/internal/events/bus.go
+++ b/bigclaw-go/internal/events/bus.go
@@ -12,15 +12,31 @@ type Sink interface {
 }
 
 type Bus struct {
-	mu          sync.RWMutex
-	history     []domain.Event
-	subscribers map[int]chan domain.Event
-	sinks       []Sink
-	nextID      int
+	mu             sync.RWMutex
+	history        []domain.Event
+	subscribers    map[int]chan domain.Event
+	sinks          []Sink
+	nextID         int
+	historyLimit   int
+	historyDropped bool
 }
 
 func NewBus() *Bus {
-	return &Bus{subscribers: make(map[int]chan domain.Event)}
+	return NewBusWithHistoryLimit(0)
+}
+
+func NewBusWithHistoryLimit(limit int) *Bus {
+	return &Bus{subscribers: make(map[int]chan domain.Event), historyLimit: limit}
+}
+
+type ReplayCursorStatus struct {
+	RequestedAfterID string `json:"requested_after_id,omitempty"`
+	OldestEventID    string `json:"oldest_event_id,omitempty"`
+	NewestEventID    string `json:"newest_event_id,omitempty"`
+	ReplayWindowSize int    `json:"replay_window_size"`
+	Status           string `json:"status"`
+	Fallback         string `json:"fallback"`
+	HistoryTruncated bool   `json:"history_truncated"`
 }
 
 func (b *Bus) AddSink(sink Sink) {
@@ -32,6 +48,11 @@ func (b *Bus) AddSink(sink Sink) {
 func (b *Bus) Publish(event domain.Event) {
 	b.mu.Lock()
 	b.history = append(b.history, event)
+	if b.historyLimit > 0 && len(b.history) > b.historyLimit {
+		drop := len(b.history) - b.historyLimit
+		b.history = append([]domain.Event(nil), b.history[drop:]...)
+		b.historyDropped = true
+	}
 	subs := make([]chan domain.Event, 0, len(b.subscribers))
 	for _, ch := range b.subscribers {
 		subs = append(subs, ch)
@@ -55,9 +76,11 @@ func (b *Bus) Subscribe(buffer int) (<-chan domain.Event, func()) {
 }
 
 func (b *Bus) SubscribeReplay(buffer int, limit int) (<-chan domain.Event, func()) {
-	b.mu.RLock()
-	replay := lastEvents(b.history, limit)
-	b.mu.RUnlock()
+	replay, _ := b.ReplayWindow(limit, "", "", "")
+	return b.subscribe(buffer, replay)
+}
+
+func (b *Bus) SubscribeReplayWindow(buffer int, replay []domain.Event) (<-chan domain.Event, func()) {
 	return b.subscribe(buffer, replay)
 }
 
@@ -98,6 +121,66 @@ func lastEvents(events []domain.Event, limit int) []domain.Event {
 	out := make([]domain.Event, limit)
 	copy(out, events[start:])
 	return out
+}
+
+func leadingEvents(events []domain.Event, limit int) []domain.Event {
+	if limit <= 0 || len(events) <= limit {
+		out := make([]domain.Event, len(events))
+		copy(out, events)
+		return out
+	}
+	out := make([]domain.Event, limit)
+	copy(out, events[:limit])
+	return out
+}
+
+func (b *Bus) ReplayWindow(limit int, afterID string, taskID string, traceID string) ([]domain.Event, ReplayCursorStatus) {
+	b.mu.RLock()
+	filtered := make([]domain.Event, 0, len(b.history))
+	for _, event := range b.history {
+		if taskID != "" && event.TaskID != taskID {
+			continue
+		}
+		if traceID != "" && event.TraceID != traceID {
+			continue
+		}
+		filtered = append(filtered, event)
+	}
+	truncated := b.historyDropped
+	b.mu.RUnlock()
+
+	status := ReplayCursorStatus{
+		RequestedAfterID: afterID,
+		ReplayWindowSize: len(filtered),
+		Status:           "ok",
+		Fallback:         "none",
+		HistoryTruncated: truncated,
+	}
+	if len(filtered) > 0 {
+		status.OldestEventID = filtered[0].ID
+		status.NewestEventID = filtered[len(filtered)-1].ID
+	}
+	if afterID == "" {
+		return lastEvents(filtered, limit), status
+	}
+	for index, event := range filtered {
+		if event.ID != afterID {
+			continue
+		}
+		return leadingEvents(filtered[index+1:], limit), status
+	}
+	if len(filtered) == 0 {
+		status.Status = "empty"
+		status.Fallback = "empty"
+		return nil, status
+	}
+	status.Fallback = "resume_from_oldest"
+	if truncated {
+		status.Status = "expired"
+	} else {
+		status.Status = "not_found"
+	}
+	return leadingEvents(filtered, limit), status
 }
 
 func (b *Bus) Replay() []domain.Event {

--- a/bigclaw-go/internal/events/bus_test.go
+++ b/bigclaw-go/internal/events/bus_test.go
@@ -46,3 +46,27 @@ func TestBusSubscribeReplayReturnsHistoryAndLiveEvents(t *testing.T) {
 		t.Fatalf("expected live event %s, got %s", third.ID, live.ID)
 	}
 }
+
+func TestBusReplayWindowFallsBackToOldestAvailableEventWhenCursorExpires(t *testing.T) {
+	bus := NewBusWithHistoryLimit(2)
+	first := domain.Event{ID: "evt-1", Type: domain.EventTaskQueued, TaskID: "task-1", TraceID: "trace-1", Timestamp: time.Now()}
+	second := domain.Event{ID: "evt-2", Type: domain.EventTaskStarted, TaskID: "task-1", TraceID: "trace-1", Timestamp: time.Now()}
+	third := domain.Event{ID: "evt-3", Type: domain.EventTaskCompleted, TaskID: "task-1", TraceID: "trace-1", Timestamp: time.Now()}
+	bus.Publish(first)
+	bus.Publish(second)
+	bus.Publish(third)
+
+	replay, status := bus.ReplayWindow(10, first.ID, "task-1", "trace-1")
+	if status.Status != "expired" {
+		t.Fatalf("expected expired status, got %s", status.Status)
+	}
+	if status.Fallback != "resume_from_oldest" {
+		t.Fatalf("expected resume_from_oldest fallback, got %s", status.Fallback)
+	}
+	if !status.HistoryTruncated {
+		t.Fatal("expected history_truncated to be true")
+	}
+	if len(replay) != 2 || replay[0].ID != second.ID || replay[1].ID != third.ID {
+		t.Fatalf("expected fallback replay window [evt-2 evt-3], got %#v", replay)
+	}
+}


### PR DESCRIPTION
## Summary
- add bounded replay-window cursor semantics to the in-process event bus, including expired/not-found fallback diagnostics
- support `after_id` and `Last-Event-ID` replay recovery in `/events` and `/stream/events`
- cover expired cursor fallback with API/event-bus tests and document the operator-visible replay headers

## Validation
- `go test ./internal/events ./internal/api`
- `go test ./...`