### PR TITLE
OPE-219 Add repo sync workflow audit reporting

### DIFF
--- a/reports/OPE-219-validation.md
+++ b/reports/OPE-219-validation.md
@@ -1,0 +1,20 @@
+# OPE-219 Validation
+
+## Summary
+
+Implemented structured repo sync telemetry in workflow closeout, added a reusable repo sync / PR freshness audit report and CLI command, and recorded audit artifacts in the workflow ledger.
+
+## Validation Evidence
+
+- `PYTHONPATH=src python -m py_compile src/bigclaw/observability.py src/bigclaw/reports.py src/bigclaw/workflow.py src/bigclaw/__main__.py tests/test_observability.py tests/test_workflow.py`
+  - Result: passed
+- `PYTHONPATH=src python - <<'PY' ... WorkflowEngine/RepoSyncAudit validation harness ... PY`
+  - Result: passed
+  - Evidence: generated repo sync report, journal, and ledger entry; confirmed `divergence` failure category and `drifted` PR body state.
+- `PYTHONPATH=src python - <<'PY' ... bigclaw repo-sync-audit CLI validation harness ... PY`
+  - Result: passed
+  - Evidence: rendered markdown audit report from JSON input and confirmed `auth` failure category plus `drifted` PR body state.
+
+## Environment Notes
+
+- `pytest` crashed the Python interpreter with `Segmentation fault: 11` in this environment before producing test output, so validation used direct module execution and compile checks instead of the full pytest runner.

--- a/src/bigclaw/__init__.py
+++ b/src/bigclaw/__init__.py
@@ -116,7 +116,7 @@ from .audit_events import (
     get_audit_event_spec,
     missing_required_fields,
 )
-from .observability import ObservabilityLedger, RunCloseout, TaskRun
+from .observability import GitSyncTelemetry, ObservabilityLedger, PullRequestFreshness, RepoSyncAudit, RunCloseout, TaskRun
 from .orchestration import (
     CrossDepartmentOrchestrator,
     DepartmentHandoff,
@@ -214,6 +214,7 @@ from .reports import (
     render_takeover_queue_report,
     render_pilot_portfolio_report,
     render_pilot_scorecard,
+    render_repo_sync_audit_report,
     render_task_run_detail_page,
     render_task_run_report,
     validation_report_exists,
@@ -407,6 +408,9 @@ __all__ = [
     "get_audit_event_spec",
     "missing_required_fields",
     "ObservabilityLedger",
+    "GitSyncTelemetry",
+    "PullRequestFreshness",
+    "RepoSyncAudit",
     "RunCloseout",
     "TaskRun",
     "CrossDepartmentOrchestrator",
@@ -497,6 +501,7 @@ __all__ = [
     "render_takeover_queue_report",
     "render_pilot_portfolio_report",
     "render_pilot_scorecard",
+    "render_repo_sync_audit_report",
     "render_task_run_detail_page",
     "render_task_run_report",
     "validation_report_exists",

--- a/src/bigclaw/__main__.py
+++ b/src/bigclaw/__main__.py
@@ -1,5 +1,9 @@
 import argparse
+import json
+from pathlib import Path
 
+from .observability import RepoSyncAudit
+from .reports import render_repo_sync_audit_report, write_report
 from .service import run_server
 
 
@@ -12,10 +16,20 @@ def main() -> None:
     serve.add_argument("--port", type=int, default=8008)
     serve.add_argument("--dir", default="reports")
 
+    repo_sync_audit = sub.add_parser("repo-sync-audit", help="Render a repo sync and PR freshness audit report")
+    repo_sync_audit.add_argument("--input", required=True, help="Path to JSON payload for RepoSyncAudit")
+    repo_sync_audit.add_argument("--output", required=True, help="Path to markdown report output")
+
     args = parser.parse_args()
 
     if args.command == "serve":
         run_server(host=args.host, port=args.port, directory=args.dir)
+        return
+
+    if args.command == "repo-sync-audit":
+        payload = json.loads(Path(args.input).read_text())
+        audit = RepoSyncAudit.from_dict(payload)
+        write_report(args.output, render_repo_sync_audit_report(audit))
         return
 
     parser.print_help()

--- a/src/bigclaw/observability.py
+++ b/src/bigclaw/observability.py
@@ -138,11 +138,138 @@ class AuditEntry:
 
 
 @dataclass
+class GitSyncTelemetry:
+    status: str = "unknown"
+    failure_category: str = ""
+    summary: str = ""
+    branch: str = ""
+    remote: str = "origin"
+    remote_ref: str = ""
+    ahead_by: int = 0
+    behind_by: int = 0
+    dirty_paths: List[str] = field(default_factory=list)
+    auth_target: str = ""
+    timestamp: str = field(default_factory=utc_now)
+
+    @property
+    def ok(self) -> bool:
+        return self.status == "synced"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "failure_category": self.failure_category,
+            "summary": self.summary,
+            "branch": self.branch,
+            "remote": self.remote,
+            "remote_ref": self.remote_ref,
+            "ahead_by": self.ahead_by,
+            "behind_by": self.behind_by,
+            "dirty_paths": list(self.dirty_paths),
+            "auth_target": self.auth_target,
+            "timestamp": self.timestamp,
+            "ok": self.ok,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "GitSyncTelemetry":
+        return cls(
+            status=str(data.get("status", "unknown")),
+            failure_category=str(data.get("failure_category", "")),
+            summary=str(data.get("summary", "")),
+            branch=str(data.get("branch", "")),
+            remote=str(data.get("remote", "origin")),
+            remote_ref=str(data.get("remote_ref", "")),
+            ahead_by=int(data.get("ahead_by", 0)),
+            behind_by=int(data.get("behind_by", 0)),
+            dirty_paths=[str(item) for item in data.get("dirty_paths", [])],
+            auth_target=str(data.get("auth_target", "")),
+            timestamp=data.get("timestamp", utc_now()),
+        )
+
+
+@dataclass
+class PullRequestFreshness:
+    pr_number: Optional[int] = None
+    pr_url: str = ""
+    branch_state: str = "unknown"
+    body_state: str = "unknown"
+    branch_head_sha: str = ""
+    pr_head_sha: str = ""
+    expected_body_digest: str = ""
+    actual_body_digest: str = ""
+    checked_at: str = field(default_factory=utc_now)
+
+    @property
+    def fresh(self) -> bool:
+        return self.branch_state == "in-sync" and self.body_state == "fresh"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "pr_number": self.pr_number,
+            "pr_url": self.pr_url,
+            "branch_state": self.branch_state,
+            "body_state": self.body_state,
+            "branch_head_sha": self.branch_head_sha,
+            "pr_head_sha": self.pr_head_sha,
+            "expected_body_digest": self.expected_body_digest,
+            "actual_body_digest": self.actual_body_digest,
+            "checked_at": self.checked_at,
+            "fresh": self.fresh,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PullRequestFreshness":
+        pr_number = data.get("pr_number")
+        return cls(
+            pr_number=int(pr_number) if pr_number is not None else None,
+            pr_url=str(data.get("pr_url", "")),
+            branch_state=str(data.get("branch_state", "unknown")),
+            body_state=str(data.get("body_state", "unknown")),
+            branch_head_sha=str(data.get("branch_head_sha", "")),
+            pr_head_sha=str(data.get("pr_head_sha", "")),
+            expected_body_digest=str(data.get("expected_body_digest", "")),
+            actual_body_digest=str(data.get("actual_body_digest", "")),
+            checked_at=data.get("checked_at", utc_now()),
+        )
+
+
+@dataclass
+class RepoSyncAudit:
+    sync: GitSyncTelemetry = field(default_factory=GitSyncTelemetry)
+    pull_request: PullRequestFreshness = field(default_factory=PullRequestFreshness)
+
+    @property
+    def summary(self) -> str:
+        parts = [f"sync={self.sync.status}"]
+        if self.sync.failure_category:
+            parts.append(f"failure={self.sync.failure_category}")
+        parts.append(f"pr-branch={self.pull_request.branch_state}")
+        parts.append(f"pr-body={self.pull_request.body_state}")
+        return ", ".join(parts)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "sync": self.sync.to_dict(),
+            "pull_request": self.pull_request.to_dict(),
+            "summary": self.summary,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RepoSyncAudit":
+        return cls(
+            sync=GitSyncTelemetry.from_dict(data.get("sync", {})),
+            pull_request=PullRequestFreshness.from_dict(data.get("pull_request", {})),
+        )
+
+
+@dataclass
 class RunCloseout:
     validation_evidence: List[str] = field(default_factory=list)
     git_push_succeeded: bool = False
     git_push_output: str = ""
     git_log_stat_output: str = ""
+    repo_sync_audit: Optional[RepoSyncAudit] = None
     run_commit_links: List[RunCommitLink] = field(default_factory=list)
     accepted_commit_hash: str = ""
     timestamp: str = field(default_factory=utc_now)
@@ -157,6 +284,7 @@ class RunCloseout:
             "git_push_succeeded": self.git_push_succeeded,
             "git_push_output": self.git_push_output,
             "git_log_stat_output": self.git_log_stat_output,
+            "repo_sync_audit": self.repo_sync_audit.to_dict() if self.repo_sync_audit else None,
             "run_commit_links": [link.to_dict() for link in self.run_commit_links],
             "accepted_commit_hash": self.accepted_commit_hash,
             "timestamp": self.timestamp,
@@ -170,6 +298,7 @@ class RunCloseout:
             git_push_succeeded=data.get("git_push_succeeded", False),
             git_push_output=data.get("git_push_output", ""),
             git_log_stat_output=data.get("git_log_stat_output", ""),
+            repo_sync_audit=RepoSyncAudit.from_dict(data["repo_sync_audit"]) if data.get("repo_sync_audit") else None,
             run_commit_links=[RunCommitLink.from_dict(item) for item in data.get("run_commit_links", [])],
             accepted_commit_hash=str(data.get("accepted_commit_hash", "")),
             timestamp=data.get("timestamp", utc_now()),
@@ -324,6 +453,7 @@ class TaskRun:
         git_push_succeeded: bool,
         git_push_output: str = "",
         git_log_stat_output: str = "",
+        repo_sync_audit: Optional[RepoSyncAudit] = None,
         run_commit_links: Optional[List[RunCommitLink]] = None,
     ) -> None:
         links = list(run_commit_links or [])
@@ -333,6 +463,7 @@ class TaskRun:
             git_push_succeeded=git_push_succeeded,
             git_push_output=git_push_output,
             git_log_stat_output=git_log_stat_output,
+            repo_sync_audit=repo_sync_audit,
             run_commit_links=links,
             accepted_commit_hash=binding.accepted_commit_hash if binding else "",
         )

--- a/src/bigclaw/reports.py
+++ b/src/bigclaw/reports.py
@@ -12,7 +12,7 @@ from .collaboration import (
     render_collaboration_lines,
     render_collaboration_panel_html,
 )
-from .observability import TaskRun
+from .observability import RepoSyncAudit, TaskRun
 from .orchestration import HandoffRequest, OrchestrationPlan, OrchestrationPolicyDecision
 from .run_detail import (
     RunDetailEvent,
@@ -2064,6 +2064,43 @@ def _similarity_reason(run: TaskRun, candidate: TaskRun) -> str:
     return ", ".join(reasons) or "similar execution trail"
 
 
+def render_repo_sync_audit_report(audit: RepoSyncAudit) -> str:
+    lines = [
+        "# Repo Sync Audit",
+        "",
+        "## Sync Status",
+        "",
+        f"- Status: {audit.sync.status}",
+        f"- Failure Category: {audit.sync.failure_category or 'none'}",
+        f"- Summary: {audit.sync.summary or 'none'}",
+        f"- Branch: {audit.sync.branch or 'unknown'}",
+        f"- Remote: {audit.sync.remote}",
+        f"- Remote Ref: {audit.sync.remote_ref or 'unknown'}",
+        f"- Ahead By: {audit.sync.ahead_by}",
+        f"- Behind By: {audit.sync.behind_by}",
+        f"- Dirty Paths: {', '.join(audit.sync.dirty_paths) if audit.sync.dirty_paths else 'none'}",
+        f"- Auth Target: {audit.sync.auth_target or 'none'}",
+        f"- Checked At: {audit.sync.timestamp}",
+        "",
+        "## Pull Request Freshness",
+        "",
+        f"- PR Number: {audit.pull_request.pr_number if audit.pull_request.pr_number is not None else 'unknown'}",
+        f"- PR URL: {audit.pull_request.pr_url or 'none'}",
+        f"- Branch State: {audit.pull_request.branch_state}",
+        f"- Body State: {audit.pull_request.body_state}",
+        f"- Branch Head SHA: {audit.pull_request.branch_head_sha or 'unknown'}",
+        f"- PR Head SHA: {audit.pull_request.pr_head_sha or 'unknown'}",
+        f"- Expected Body Digest: {audit.pull_request.expected_body_digest or 'unknown'}",
+        f"- Actual Body Digest: {audit.pull_request.actual_body_digest or 'unknown'}",
+        f"- Checked At: {audit.pull_request.checked_at}",
+        "",
+        "## Summary",
+        "",
+        f"- {audit.summary}",
+    ]
+    return "\n".join(lines) + "\n"
+
+
 def render_task_run_report(run: TaskRun) -> str:
     actions = build_console_actions(
         run.run_id,
@@ -2136,6 +2173,14 @@ def render_task_run_report(run: TaskRun) -> str:
     lines.append(f"- Git Push Succeeded: {run.closeout.git_push_succeeded}")
     lines.append(f"- Git Push Output: {run.closeout.git_push_output or 'None'}")
     lines.append(f"- Git Log -1 --stat Output: {run.closeout.git_log_stat_output or 'None'}")
+    if run.closeout.repo_sync_audit is not None:
+        lines.append(f"- Repo Sync Status: {run.closeout.repo_sync_audit.sync.status}")
+        lines.append(
+            "- Repo Sync Failure Category: "
+            + (run.closeout.repo_sync_audit.sync.failure_category or "none")
+        )
+        lines.append(f"- PR Branch State: {run.closeout.repo_sync_audit.pull_request.branch_state}")
+        lines.append(f"- PR Body State: {run.closeout.repo_sync_audit.pull_request.body_state}")
     lines.extend(["", "## Actions", "", f"- {render_console_actions(actions)}"])
     lines.extend(render_collaboration_lines(collaboration))
 

--- a/src/bigclaw/workflow.py
+++ b/src/bigclaw/workflow.py
@@ -6,9 +6,16 @@ from typing import Any, Dict, List, Optional, Sequence
 from .audit_events import APPROVAL_RECORDED_EVENT
 from .dsl import WorkflowDefinition
 from .models import RiskLevel, Task
-from .observability import ObservabilityLedger, utc_now
+from .observability import ObservabilityLedger, RepoSyncAudit, utc_now
 from .orchestration import render_orchestration_plan
-from .reports import build_orchestration_canvas, PilotScorecard, render_orchestration_canvas, render_pilot_scorecard, write_report
+from .reports import (
+    build_orchestration_canvas,
+    PilotScorecard,
+    render_orchestration_canvas,
+    render_pilot_scorecard,
+    render_repo_sync_audit_report,
+    write_report,
+)
 from .scheduler import ExecutionRecord, Scheduler
 
 
@@ -126,6 +133,7 @@ class WorkflowRunResult:
     orchestration_report_path: Optional[str] = None
     orchestration_canvas_path: Optional[str] = None
     pilot_report_path: Optional[str] = None
+    repo_sync_report_path: Optional[str] = None
 
 
 class WorkflowEngine:
@@ -146,6 +154,8 @@ class WorkflowEngine:
         pilot_report_path: Optional[str] = None,
         orchestration_report_path: Optional[str] = None,
         orchestration_canvas_path: Optional[str] = None,
+        repo_sync_audit: Optional[RepoSyncAudit] = None,
+        repo_sync_report_path: Optional[str] = None,
         git_push_succeeded: bool = False,
         git_push_output: str = "",
         git_log_stat_output: str = "",
@@ -235,6 +245,53 @@ class WorkflowEngine:
                 annualized_roi=round(pilot_scorecard.annualized_roi, 1),
             )
 
+        resolved_repo_sync_report_path = None
+        if repo_sync_audit is not None:
+            execution.run.audit(
+                "repo.sync",
+                "workflow-engine",
+                repo_sync_audit.sync.status,
+                failure_category=repo_sync_audit.sync.failure_category,
+                summary=repo_sync_audit.sync.summary,
+                branch=repo_sync_audit.sync.branch,
+                remote_ref=repo_sync_audit.sync.remote_ref,
+                ahead_by=repo_sync_audit.sync.ahead_by,
+                behind_by=repo_sync_audit.sync.behind_by,
+                dirty_paths=repo_sync_audit.sync.dirty_paths,
+                auth_target=repo_sync_audit.sync.auth_target,
+            )
+            execution.run.audit(
+                "repo.pr-freshness",
+                "workflow-engine",
+                "fresh" if repo_sync_audit.pull_request.fresh else "stale",
+                pr_number=repo_sync_audit.pull_request.pr_number,
+                pr_url=repo_sync_audit.pull_request.pr_url,
+                branch_state=repo_sync_audit.pull_request.branch_state,
+                body_state=repo_sync_audit.pull_request.body_state,
+                branch_head_sha=repo_sync_audit.pull_request.branch_head_sha,
+                pr_head_sha=repo_sync_audit.pull_request.pr_head_sha,
+            )
+            journal.record(
+                "repo-sync",
+                repo_sync_audit.sync.status,
+                failure_category=repo_sync_audit.sync.failure_category,
+                branch_state=repo_sync_audit.pull_request.branch_state,
+                body_state=repo_sync_audit.pull_request.body_state,
+            )
+            if repo_sync_report_path:
+                resolved_repo_sync_report_path = str(Path(repo_sync_report_path))
+                write_report(resolved_repo_sync_report_path, render_repo_sync_audit_report(repo_sync_audit))
+                execution.run.register_artifact(
+                    "repo-sync-audit",
+                    "report",
+                    resolved_repo_sync_report_path,
+                    format="markdown",
+                    sync_status=repo_sync_audit.sync.status,
+                    pr_branch_state=repo_sync_audit.pull_request.branch_state,
+                    pr_body_state=repo_sync_audit.pull_request.body_state,
+                )
+                ledger.upsert(execution.run)
+
         acceptance = self.gate.evaluate(
             task,
             execution,
@@ -265,6 +322,7 @@ class WorkflowEngine:
             git_push_succeeded=git_push_succeeded,
             git_push_output=git_push_output,
             git_log_stat_output=git_log_stat_output,
+            repo_sync_audit=repo_sync_audit,
         )
         ledger.upsert(execution.run)
         journal.record(
@@ -273,6 +331,8 @@ class WorkflowEngine:
             validation_evidence=list(validation_evidence or []),
             git_push_succeeded=git_push_succeeded,
             git_log_stat_captured=bool(git_log_stat_output.strip()),
+            repo_sync_status=repo_sync_audit.sync.status if repo_sync_audit else "none",
+            repo_sync_failure_category=repo_sync_audit.sync.failure_category if repo_sync_audit else "",
         )
 
         resolved_journal_path = None
@@ -287,6 +347,7 @@ class WorkflowEngine:
             orchestration_report_path=resolved_orchestration_report_path,
             orchestration_canvas_path=resolved_orchestration_canvas_path,
             pilot_report_path=resolved_pilot_report_path,
+            repo_sync_report_path=resolved_repo_sync_report_path,
         )
 
     def run_definition(

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -3,8 +3,8 @@ from pathlib import Path
 
 from bigclaw.collaboration import build_collaboration_thread_from_audits
 from bigclaw.models import Priority, Task
-from bigclaw.observability import ObservabilityLedger, TaskRun
-from bigclaw.reports import render_task_run_detail_page, render_task_run_report
+from bigclaw.observability import GitSyncTelemetry, ObservabilityLedger, PullRequestFreshness, RepoSyncAudit, TaskRun
+from bigclaw.reports import render_repo_sync_audit_report, render_task_run_detail_page, render_task_run_report
 from bigclaw.repo_plane import RunCommitLink
 
 
@@ -44,6 +44,46 @@ def test_task_run_captures_logs_trace_artifacts_and_audits(tmp_path: Path):
     assert entries[0]["artifacts"][0]["sha256"] == expected_digest
     assert entries[0]["audits"][0]["action"] == "scheduler.approved"
     assert entries[0]["closeout"]["complete"] is True
+
+
+def test_task_run_closeout_serializes_repo_sync_audit(tmp_path: Path):
+    task = Task(task_id="BIG-sync", source="linear", title="Repo sync closeout", description="")
+    run = TaskRun.from_task(task, run_id="run-sync", medium="docker")
+    repo_sync_audit = RepoSyncAudit(
+        sync=GitSyncTelemetry(
+            status="failed",
+            failure_category="dirty",
+            summary="worktree has local changes",
+            branch="feature/OPE-219",
+            remote_ref="origin/feature/OPE-219",
+            dirty_paths=["src/bigclaw/workflow.py"],
+        ),
+        pull_request=PullRequestFreshness(
+            pr_number=219,
+            pr_url="https://github.com/OpenAGIs/BigClaw/pull/219",
+            branch_state="out-of-sync",
+            body_state="drifted",
+            branch_head_sha="abc123",
+            pr_head_sha="def456",
+            expected_body_digest="body-expected",
+            actual_body_digest="body-actual",
+        ),
+    )
+    run.record_closeout(
+        validation_evidence=["pytest"],
+        git_push_succeeded=False,
+        git_push_output="push rejected",
+        git_log_stat_output="commit abc123\n 1 file changed, 2 insertions(+)",
+        repo_sync_audit=repo_sync_audit,
+    )
+
+    ledger = ObservabilityLedger(str(tmp_path / "observability.json"))
+    ledger.append(run)
+    loaded_run = ledger.load_runs()[0]
+
+    assert loaded_run.closeout.repo_sync_audit is not None
+    assert loaded_run.closeout.repo_sync_audit.sync.failure_category == "dirty"
+    assert loaded_run.closeout.repo_sync_audit.pull_request.body_state == "drifted"
 
 
 def test_render_task_run_report(tmp_path: Path):
@@ -92,6 +132,37 @@ def test_render_task_run_report(tmp_path: Path):
     assert "## Collaboration" in report
     assert "Need @security sign-off before we clear this run." in report
     assert "Approved release after manual review." in report
+
+
+def test_render_repo_sync_audit_report():
+    audit = RepoSyncAudit(
+        sync=GitSyncTelemetry(
+            status="failed",
+            failure_category="auth",
+            summary="github token expired",
+            branch="dcjcloud/ope-219",
+            remote_ref="origin/dcjcloud/ope-219",
+            auth_target="github.com/OpenAGIs/BigClaw.git",
+        ),
+        pull_request=PullRequestFreshness(
+            pr_number=219,
+            pr_url="https://github.com/OpenAGIs/BigClaw/pull/219",
+            branch_state="in-sync",
+            body_state="drifted",
+            branch_head_sha="abc123",
+            pr_head_sha="abc123",
+            expected_body_digest="expected",
+            actual_body_digest="actual",
+        ),
+    )
+
+    report = render_repo_sync_audit_report(audit)
+
+    assert "# Repo Sync Audit" in report
+    assert "Failure Category: auth" in report
+    assert "Branch State: in-sync" in report
+    assert "Body State: drifted" in report
+    assert "sync=failed, failure=auth, pr-branch=in-sync, pr-body=drifted" in report
 
 
 def test_render_task_run_detail_page(tmp_path: Path):

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 
 from bigclaw.models import Priority, RiskLevel, Task
-from bigclaw.observability import ObservabilityLedger
+from bigclaw.observability import GitSyncTelemetry, ObservabilityLedger, PullRequestFreshness, RepoSyncAudit
 from bigclaw.reports import PilotMetric, PilotScorecard
 from bigclaw.workflow import AcceptanceGate, WorkflowEngine
 
@@ -222,3 +222,73 @@ def test_workflow_engine_writes_orchestration_report_without_duplicating_ledger_
     journal = json.loads(Path(result.journal_path).read_text())
     assert journal["entries"][2]["step"] == "orchestration"
     assert journal["entries"][-1]["step"] == "closeout"
+
+
+def test_workflow_engine_writes_repo_sync_audit_report_and_records_failure_categories(tmp_path: Path):
+    ledger = ObservabilityLedger(str(tmp_path / "ledger.json"))
+    task = Task(
+        task_id="OPE-219",
+        source="linear",
+        title="Audit repo sync",
+        description="capture sync failures and pr freshness",
+        priority=Priority.P1,
+        acceptance_criteria=["repo-sync-audit", "report-shared"],
+        validation_plan=["pytest"],
+    )
+    repo_sync_audit = RepoSyncAudit(
+        sync=GitSyncTelemetry(
+            status="failed",
+            failure_category="divergence",
+            summary="branch diverged from remote",
+            branch="dcjcloud/ope-219",
+            remote_ref="origin/dcjcloud/ope-219",
+            ahead_by=2,
+            behind_by=1,
+        ),
+        pull_request=PullRequestFreshness(
+            pr_number=219,
+            pr_url="https://github.com/OpenAGIs/BigClaw/pull/219",
+            branch_state="out-of-sync",
+            body_state="drifted",
+            branch_head_sha="abc123",
+            pr_head_sha="def456",
+            expected_body_digest="expected",
+            actual_body_digest="actual",
+        ),
+    )
+
+    result = WorkflowEngine().run(
+        task,
+        run_id="run-wf-ope-219",
+        ledger=ledger,
+        journal_path=str(tmp_path / "journals" / "run-wf-ope-219.json"),
+        validation_evidence=["pytest", "report-shared", "repo-sync-audit"],
+        repo_sync_audit=repo_sync_audit,
+        repo_sync_report_path=str(tmp_path / "reports" / "run-wf-ope-219-repo-sync.md"),
+        git_push_succeeded=True,
+        git_push_output="feature/OPE-219 -> origin/feature/OPE-219",
+        git_log_stat_output="commit abc123\n 3 files changed, 18 insertions(+)",
+    )
+
+    assert result.acceptance.passed is True
+    assert result.repo_sync_report_path is not None
+    assert Path(result.repo_sync_report_path).exists()
+    report = Path(result.repo_sync_report_path).read_text()
+    assert "Failure Category: divergence" in report
+    assert "Body State: drifted" in report
+
+    journal = json.loads(Path(result.journal_path).read_text())
+    assert [entry["step"] for entry in journal["entries"]] == [
+        "intake",
+        "execution",
+        "repo-sync",
+        "acceptance",
+        "closeout",
+    ]
+    assert journal["entries"][2]["details"]["failure_category"] == "divergence"
+    entries = ledger.load()
+    audit_actions = [entry["action"] for entry in entries[0]["audits"]]
+    assert "repo.sync" in audit_actions
+    assert "repo.pr-freshness" in audit_actions
+    assert entries[0]["artifacts"][0]["name"] == "repo-sync-audit"
+    assert entries[0]["closeout"]["repo_sync_audit"]["sync"]["failure_category"] == "divergence"


### PR DESCRIPTION
## Summary
- add structured repo sync telemetry to workflow closeout so dirty, auth, and divergence failures are explicit
- add a reusable repo sync / PR freshness markdown audit report and CLI entrypoint
- record validation evidence in a repo-native OPE-219 validation report and extend workflow/observability tests

## Validation
- `PYTHONPATH=src python -m py_compile src/bigclaw/observability.py src/bigclaw/reports.py src/bigclaw/workflow.py src/bigclaw/__main__.py tests/test_observability.py tests/test_workflow.py`
- direct `WorkflowEngine` / `RepoSyncAudit` validation harness
- direct `python -m bigclaw repo-sync-audit` CLI validation harness

## Notes
- `pytest` crashed with `Segmentation fault: 11` in this environment before producing test output, so validation used direct module execution and compile checks instead
- repo-native validation report: `reports/OPE-219-validation.md`
