### PR TITLE
OPE-222: replicated event-log durability rollout contract

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -77,6 +77,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - `internal/events/bus.go`: publish path remains the place to insert append/ack behavior ahead of live fanout.
 - `internal/api/server.go`: operational reporting for current and target durability mode plus runtime capability probes.
 - Subscriber checkpoint persistence, replay endpoints, and dedup ledger surfaces preserve resume and idempotency semantics while moving state out of process-local memory.
+- `internal/events/durability.go`: rollout-facing contract for replicated durability phases, failure domains, and required verification evidence.
 
 ## Migration and compatibility constraints
 
@@ -128,6 +129,15 @@ This report summarizes the current event bus reliability evidence and the next r
 - No durable retention watermark exists in the runtime yet; expired-cursor fallback is currently defined only against the in-process replay window, and the target compaction semantics are defined in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+
+## Replicated rollout contract
+
+- `docs/reports/replicated-event-log-durability-rollout-contract.md` now captures the minimum rollout gates for a broker-backed or quorum-backed adapter:
+  - replicated publish acknowledgements must distinguish committed, rejected, and ambiguous outcomes;
+  - replay and checkpoint state must share the same durable sequence domain across failover;
+  - retention boundaries must be operator-visible before resumable recovery is claimed;
+  - live fanout must remain isolated from broker catch-up lag.
+- The same contract is surfaced in `events.DurabilityPlan`, so debug/control-plane payloads can show rollout checks, failure domains, and supporting evidence links before a live adapter exists.
 
 ## Next adapter boundary
 

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -1,0 +1,87 @@
+# Replicated Event-Log Durability Rollout Contract
+
+## Scope
+
+This report defines the rollout contract for `OPE-222` / `BIG-PAR-035`: the minimum runtime, operator, and validation expectations BigClaw must satisfy before claiming a replicated broker-backed or quorum-backed event log.
+
+It builds on the provider-neutral adapter boundary in `docs/reports/broker-event-log-adapter-contract.md`, the retention semantics in `docs/reports/replay-retention-semantics-report.md`, and the failover scenarios in `docs/reports/broker-failover-fault-injection-validation-pack.md`.
+
+## Current baseline
+
+- `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads.
+- `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
+- `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
+
+## Runtime contract
+
+### Publish
+
+- Success must mean the event reached the configured replicated durability boundary, not merely a leader-local buffer.
+- Ambiguous publish outcomes must be classifiable as `committed`, `rejected`, or `unknown_commit` using replay and audit evidence.
+- Event identity fields (`id`, `task_id`, `trace_id`, `event_type`) must remain stable across append, replay, and duplicate delivery windows.
+
+### Replay and live handoff
+
+- Replay order must be monotonic within the provider's durable ordering scope and mapped back to the portable `Position.Sequence`.
+- Live fanout must remain decoupled from broker catch-up lag so replay recovery does not stall process-local subscribers or SSE clients.
+- Replay resume and checkpoint acknowledgement must reference the same durable sequence space after failover, reconnect, or consumer takeover.
+
+### Checkpoints
+
+- Checkpoints must remain monotonic by durable sequence, not by wall-clock arrival order.
+- Stale writers must be fenced with lease/epoch metadata before a replicated backend is considered rollout-safe.
+- Retention or compaction must not silently reinterpret an expired checkpoint as a valid later resume point.
+
+## Rollout phases
+
+| Phase | Goal | Exit condition |
+| --- | --- | --- |
+| `contract` | keep provider-neutral append/replay/checkpoint expectations stable | runtime plan and docs expose rollout checks, failure domains, and verification evidence |
+| `stubbed_validation` | prove failover and checkpoint accounting with deterministic harnesses | scenario runner can emit the report shape in `broker-failover-fault-injection-validation-pack.md` |
+| `single_backend_trial` | wire one replicated adapter without changing callers | one provider backend can publish, replay, and checkpoint behind the existing event-log contract |
+| `rollout_ready` | claim operator-safe replicated durability | pass failover, retention-boundary, and checkpoint-fencing evidence for the chosen provider |
+
+## Failure domains
+
+### Broker leader or quorum loss
+
+- Risk: acknowledged writes may be ambiguous until leadership stabilizes.
+- Required mitigation: replicated publish acknowledgements plus replay-visible reconciliation of ambiguous outcomes.
+
+### Checkpoint store failover
+
+- Risk: stale consumers can overwrite newer progress after ownership transfer.
+- Required mitigation: durable checkpoint fencing using sequence monotonicity and lease epoch metadata.
+
+### Retention or compaction drift
+
+- Risk: replay cursors or checkpoints may reference trimmed history even though their shape is still valid.
+- Required mitigation: expose retention watermarks and fail closed on expired cursors until an explicit reset policy is invoked.
+
+## Required operator signals
+
+- active backend and target backend
+- replication factor or quorum expectation
+- whether publisher acknowledgement is required before success is reported
+- rollout checks and their failure modes
+- failure-domain summaries
+- references to the supporting validation pack and rollout contract documents
+
+The current repo-native source for these signals is the `event_durability` payload exposed through `GET /debug/status`.
+
+## Validation evidence required before a live adapter lands
+
+- debug/control-plane payload proving the active runtime advertises the replicated rollout contract
+- failover validation artifacts matching the scenario matrix in `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- replay retention diagnostics proving expired checkpoints are surfaced explicitly
+- checkpoint takeover evidence proving stale writers cannot regress durable progress
+
+## Repo evidence
+
+- `internal/events/durability.go`
+- `internal/events/durability_test.go`
+- `internal/api/server_test.go`
+- `cmd/bigclawd/main.go`
+- `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- `docs/reports/replay-retention-semantics-report.md`

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -268,6 +268,15 @@ func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	if !strings.Contains(response.Body.String(), "\"replication_factor\":5") {
 		t.Fatalf("expected replication factor in payload, got %s", response.Body.String())
 	}
+	if !strings.Contains(response.Body.String(), "\"rollout_checks\"") {
+		t.Fatalf("expected rollout checks in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"failure_domains\"") {
+		t.Fatalf("expected failure domains in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"verification_evidence\"") {
+		t.Fatalf("expected verification evidence in payload, got %s", response.Body.String())
+	}
 }
 
 func TestDeadLetterEndpoints(t *testing.T) {

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -21,13 +21,33 @@ type DurabilityProfile struct {
 	OrderingScope       string            `json:"ordering_scope"`
 }
 
+type RolloutCheck struct {
+	Name        string `json:"name"`
+	Requirement string `json:"requirement"`
+	FailureMode string `json:"failure_mode"`
+}
+
+type FailureDomain struct {
+	Name      string   `json:"name"`
+	Impact    string   `json:"impact"`
+	Mitigates []string `json:"mitigates"`
+}
+
+type VerificationEvidence struct {
+	Name      string   `json:"name"`
+	Artifacts []string `json:"artifacts"`
+}
+
 type DurabilityPlan struct {
-	Current              DurabilityProfile `json:"current"`
-	Target               DurabilityProfile `json:"target"`
-	ReplicationFactor    int               `json:"replication_factor"`
-	RequiresPublisherAck bool              `json:"requires_publisher_ack"`
-	MigrationConstraints []string          `json:"migration_constraints"`
-	IntegrationPoints    []string          `json:"integration_points"`
+	Current              DurabilityProfile      `json:"current"`
+	Target               DurabilityProfile      `json:"target"`
+	ReplicationFactor    int                    `json:"replication_factor"`
+	RequiresPublisherAck bool                   `json:"requires_publisher_ack"`
+	MigrationConstraints []string               `json:"migration_constraints"`
+	IntegrationPoints    []string               `json:"integration_points"`
+	RolloutChecks        []RolloutCheck         `json:"rollout_checks"`
+	FailureDomains       []FailureDomain        `json:"failure_domains"`
+	VerificationEvidence []VerificationEvidence `json:"verification_evidence"`
 }
 
 func NormalizeDurabilityBackend(value string) DurabilityBackend {
@@ -105,6 +125,77 @@ func NewDurabilityPlan(currentBackend, targetBackend string, replicationFactor i
 			"internal/api/server.go debug and control-plane reporting",
 			"internal/events bus publish/subscribe path",
 			"subscriber checkpoint persistence and replay endpoints",
+		},
+		RolloutChecks: []RolloutCheck{
+			{
+				Name:        "durable_publish_ack",
+				Requirement: "publish success must represent replicated commit acknowledgement rather than leader-local enqueue",
+				FailureMode: "ambiguous client timeout or leader crash can leave operators unable to classify whether an event committed",
+			},
+			{
+				Name:        "replay_checkpoint_alignment",
+				Requirement: "replay cursors and subscriber checkpoints must resolve to the same durable sequence domain across failover",
+				FailureMode: "consumer recovery can skip or duplicate committed events after broker election or reconnect",
+			},
+			{
+				Name:        "retention_boundary_visibility",
+				Requirement: "the backend must expose oldest/newest retained replay boundaries before rollout claims resumable recovery",
+				FailureMode: "aged-out checkpoints can silently start from an unsafe later point instead of surfacing truncation",
+			},
+			{
+				Name:        "live_fanout_isolation",
+				Requirement: "SSE and in-process live subscribers must stay decoupled from broker catch-up lag and replay backfill",
+				FailureMode: "replay recovery or broker lag can stall live delivery and blur the source of operator-visible latency",
+			},
+		},
+		FailureDomains: []FailureDomain{
+			{
+				Name:   "broker_leader_or_quorum_loss",
+				Impact: "publish acknowledgements and replay visibility may diverge until leadership or quorum is re-established",
+				Mitigates: []string{
+					"require replicated publish acknowledgements",
+					"record ambiguous publish outcomes for replay reconciliation",
+				},
+			},
+			{
+				Name:   "checkpoint_store_failover",
+				Impact: "stale writers can regress subscriber progress if checkpoint ownership is not fenced by durable sequence and lease epoch",
+				Mitigates: []string{
+					"persist monotonic checkpoint sequence with ownership metadata",
+					"reject stale checkpoint writes after takeover",
+				},
+			},
+			{
+				Name:   "retention_or_compaction_drift",
+				Impact: "resume requests can point outside the retained log window even when the cursor shape is valid",
+				Mitigates: []string{
+					"surface retention watermarks in operator diagnostics",
+					"fail closed on expired checkpoints until an explicit reset policy is chosen",
+				},
+			},
+		},
+		VerificationEvidence: []VerificationEvidence{
+			{
+				Name: "debug_and_control_plane_surface",
+				Artifacts: []string{
+					"GET /debug/status event_durability payload",
+					"control-plane snapshots carrying backend and rollout metadata",
+				},
+			},
+			{
+				Name: "replay_and_failover_validation",
+				Artifacts: []string{
+					"docs/reports/broker-failover-fault-injection-validation-pack.md",
+					"future broker-failover-<backend>-report.json scenario outputs",
+				},
+			},
+			{
+				Name: "operator_rollout_contract",
+				Artifacts: []string{
+					"docs/reports/event-bus-reliability-report.md",
+					"docs/reports/replicated-event-log-durability-rollout-contract.md",
+				},
+			},
 		},
 	}
 }

--- a/bigclaw-go/internal/events/durability_test.go
+++ b/bigclaw-go/internal/events/durability_test.go
@@ -1,0 +1,29 @@
+package events
+
+import "testing"
+
+func TestNewDurabilityPlanForReplicatedTargetIncludesRolloutContract(t *testing.T) {
+	plan := NewDurabilityPlan("http", "broker_replicated", 5)
+
+	if !plan.RequiresPublisherAck {
+		t.Fatal("expected replicated target to require publisher acknowledgements")
+	}
+	if len(plan.RolloutChecks) < 4 {
+		t.Fatalf("expected rollout checks for replicated target, got %+v", plan.RolloutChecks)
+	}
+	if plan.RolloutChecks[0].Name != "durable_publish_ack" {
+		t.Fatalf("unexpected first rollout check: %+v", plan.RolloutChecks[0])
+	}
+	if len(plan.FailureDomains) < 3 {
+		t.Fatalf("expected failure domains for replicated target, got %+v", plan.FailureDomains)
+	}
+	if plan.FailureDomains[1].Name != "checkpoint_store_failover" {
+		t.Fatalf("unexpected checkpoint failure domain: %+v", plan.FailureDomains[1])
+	}
+	if len(plan.VerificationEvidence) < 3 {
+		t.Fatalf("expected verification evidence entries, got %+v", plan.VerificationEvidence)
+	}
+	if plan.VerificationEvidence[2].Artifacts[1] != "docs/reports/replicated-event-log-durability-rollout-contract.md" {
+		t.Fatalf("expected rollout contract artifact, got %+v", plan.VerificationEvidence[2])
+	}
+}

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -38,6 +38,12 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 - Downstream consumers still need idempotent handlers and durable dedupe stores; the system remains replay-safe, not globally exactly-once.
 - Parallel validation for Kubernetes, Ray, and shared-queue takeover should continue to be bundled as repo-native evidence.
 
+### Current rollout gate
+
+- `OPE-222` now makes the replicated durability rollout contract explicit in repo-native form:
+  - rollout metadata lives in `bigclaw-go/internal/events/durability.go` so debug/control-plane payloads can advertise checks, failure domains, and evidence links;
+  - `bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md` defines the minimum publish-ack, replay/checkpoint, retention-boundary, and failover expectations before a replicated adapter can be called rollout-ready.
+
 ## Recommended BigClaw parallel mainline
 
 1. Multi-worker and multi-node control-plane observability.


### PR DESCRIPTION
## Summary
- extend `events.DurabilityPlan` with replicated rollout checks, failure domains, and verification evidence
- add tests covering the new durability contract and its debug-status exposure
- document the replicated durability rollout contract and link it from the existing reliability/gap analysis docs

## Validation
- go test ./internal/events ./internal/api

## Linear
- OPE-222
