### PR TITLE
OPE-220: expose retention watermarks for replay surfaces

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -12,6 +12,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - SSE stream via `GET /stream/events`
 - Optional SSE replay and filtering via `replay=1`, `after_id`, `Last-Event-ID`, `task_id`, and `trace_id`
 - Replay cursor diagnostics via `X-Replay-*` headers and JSON `cursor` metadata on `GET /events`
+- Retention watermark diagnostics via `retention_watermark` on `GET /events`, `/debug/status`, and the internal event-log service
 - Replay-safe consumer delivery metadata via `EventDelivery`, including additive `delivery.mode`, `delivery.replay`, and `delivery.idempotency_key` fields
 - Consumer dedup ledger/result contract covering duplicate, retryable-failure, and already-applied outcomes
 - Replay-safe consumer dedup ledger contract with stable storage key and result semantics
@@ -125,7 +126,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - No delivery acknowledgement protocol exists beyond sink-level best effort.
 - Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
-- No durable retention watermark exists in the runtime yet; expired-cursor fallback is currently defined only against the in-process replay window, and the target compaction semantics are defined in `docs/reports/replay-retention-semantics-report.md`.
+- Retention watermark visibility now exists for in-memory and shared event-log backends, but retention enforcement and checkpoint cleanup policy are still follow-on work; expired-cursor fallback and target compaction semantics remain defined in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
 

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -10,7 +10,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 
 - `Bus.SubscribeReplay` replays the tail of the in-memory append history before switching the subscriber to live events.
 - `GET /events`, `GET /replay/{id}`, and `GET /stream/events?replay=1` expose replay-oriented views over recorder history.
-- No durable retention watermark, checkpoint expiration signal, or history compaction rule exists yet.
+- Runtime surfaces now expose a retention watermark for in-memory and shared event-log backends, but checkpoint expiration signaling and automated compaction policy are still pending.
 
 ## Retention model
 
@@ -63,7 +63,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 
 - `OPE-212` establishes the compaction and retention contract.
 - `OPE-216` can build the concrete API/error surface for expired replay cursors and truncated-history fallback.
-- Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
+- Durable backends extending `internal/events` now expose retention watermarks through API/debug and event-log service payloads; replay-aware checkpoint cleanup still remains to be implemented.
 
 ## Repo evidence
 

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -89,14 +89,15 @@ func (s *Server) Handler() http.Handler {
 			history = limitQueriedEvents(filterEventsByType(history, eventTypes), afterID, limit)
 			writeReplayCursorHeaders(w, cursor)
 			writeJSON(w, http.StatusOK, map[string]any{
-				"events":        history,
-				"cursor":        cursor,
-				"subscriber_id": subscriberID,
-				"after_id":      afterID,
-				"next_after_id": nextAfterID(history, afterID),
-				"event_types":   eventTypes,
-				"backend":       "memory",
-				"durable":       false,
+				"events":              history,
+				"cursor":              cursor,
+				"subscriber_id":       subscriberID,
+				"after_id":            afterID,
+				"next_after_id":       nextAfterID(history, afterID),
+				"event_types":         eventTypes,
+				"backend":             "memory",
+				"durable":             false,
+				"retention_watermark": s.retentionWatermark(r.Context()),
 			})
 			return
 		}
@@ -109,13 +110,14 @@ func (s *Server) Handler() http.Handler {
 			history = events.WithDeliveryBatch(history, domain.EventDeliveryModeReplay)
 		}
 		writeJSON(w, http.StatusOK, map[string]any{
-			"events":        history,
-			"subscriber_id": subscriberID,
-			"after_id":      afterID,
-			"next_after_id": nextAfterID(history, afterID),
-			"event_types":   eventTypes,
-			"backend":       backend,
-			"durable":       s.eventLogDurable(),
+			"events":              history,
+			"subscriber_id":       subscriberID,
+			"after_id":            afterID,
+			"next_after_id":       nextAfterID(history, afterID),
+			"event_types":         eventTypes,
+			"backend":             backend,
+			"durable":             s.eventLogDurable(),
+			"retention_watermark": s.retentionWatermark(r.Context()),
 		})
 	})
 	mux.HandleFunc("/subscriber-groups/leases", s.handleSubscriberGroupLease)
@@ -154,7 +156,11 @@ func (s *Server) Handler() http.Handler {
 			"audit_events":     len(s.Recorder.Logs()),
 			"executors":        s.executorNames(),
 			"event_durability": s.EventPlan,
-			"event_log":        s.eventLogCapabilities(r.Context()),
+			"event_log": map[string]any{
+				"backend":             s.eventLogBackend(),
+				"capabilities":        s.eventLogCapabilities(r.Context()),
+				"retention_watermark": s.retentionWatermark(r.Context()),
+			},
 		}
 		if s.Worker != nil {
 			payload["worker"] = s.Worker.Snapshot()
@@ -164,12 +170,6 @@ func (s *Server) Handler() http.Handler {
 		}
 		if s.Control != nil {
 			payload["control"] = s.Control.Snapshot()
-		}
-		if s.EventLog != nil {
-			payload["event_log"] = map[string]any{
-				"backend":      s.EventLog.Backend(),
-				"capabilities": s.EventLog.Capabilities(),
-			}
 		}
 		writeJSON(w, http.StatusOK, payload)
 	})
@@ -713,10 +713,28 @@ func (s *Server) queryMemoryEvents(taskID, traceID, afterID string, limit int) [
 }
 
 func (s *Server) eventLogCapabilities(ctx context.Context) events.BackendCapabilities {
-	if s.Bus != nil {
-		return s.Bus.Capabilities(ctx)
+	var capability events.BackendCapabilities
+	if s.EventLog != nil {
+		capability = s.EventLog.Capabilities()
+	} else if s.Bus != nil {
+		capability = s.Bus.Capabilities(ctx)
+	} else {
+		capability = events.UnavailableCapabilities()
 	}
-	return events.UnavailableCapabilities()
+	capability.RetentionWatermark = events.RetentionWatermark{}
+	return capability
+}
+
+func (s *Server) retentionWatermark(ctx context.Context) events.RetentionWatermark {
+	if provider, ok := s.EventLog.(events.RetentionWatermarkProvider); ok {
+		return provider.RetentionWatermark(ctx)
+	}
+	if s.Bus != nil {
+		if provider, ok := any(s.Bus).(events.RetentionWatermarkProvider); ok {
+			return provider.RetentionWatermark(ctx)
+		}
+	}
+	return events.RetentionWatermark{}
 }
 
 func replayCursorFromRequest(r *http.Request) string {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -547,6 +547,9 @@ func TestEventsEndpointReturnsCursorFallbackMetadataWhenReplayWindowExpired(t *t
 	if !strings.Contains(response.Body.String(), "\"status\":\"expired\"") || !strings.Contains(response.Body.String(), "\"evt-old-2\"") {
 		t.Fatalf("expected cursor metadata and fallback events, got %s", response.Body.String())
 	}
+	if !strings.Contains(response.Body.String(), "\"retention_watermark\":{\"available\":true") || !strings.Contains(response.Body.String(), "\"oldest_event_id\":\"evt-old-2\"") || !strings.Contains(response.Body.String(), "\"newest_event_id\":\"evt-old-3\"") {
+		t.Fatalf("expected retention watermark in events payload, got %s", response.Body.String())
+	}
 }
 
 func TestStreamEventsUsesLastEventIDForExpiredCursorFallback(t *testing.T) {
@@ -636,6 +639,9 @@ func TestDebugStatusIncludesWorkerSnapshot(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), "worker-a") || !strings.Contains(response.Body.String(), "successful_runs") || !strings.Contains(response.Body.String(), "event_log") || !strings.Contains(response.Body.String(), "in_memory_history") || !strings.Contains(response.Body.String(), "checkpoint") {
 		t.Fatalf("expected worker snapshot in debug payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"retention_watermark\":{\"available\":false") {
+		t.Fatalf("expected retention watermark in debug payload, got %s", response.Body.String())
 	}
 }
 
@@ -2325,11 +2331,12 @@ func TestEventsEndpointSupportsAfterIDCursor(t *testing.T) {
 		t.Fatalf("expected events 200, got %d %s", response.Code, response.Body.String())
 	}
 	var decoded struct {
-		Events      []domain.Event `json:"events"`
-		AfterID     string         `json:"after_id"`
-		NextAfterID string         `json:"next_after_id"`
-		Backend     string         `json:"backend"`
-		Durable     bool           `json:"durable"`
+		Events             []domain.Event            `json:"events"`
+		AfterID            string                    `json:"after_id"`
+		NextAfterID        string                    `json:"next_after_id"`
+		Backend            string                    `json:"backend"`
+		Durable            bool                      `json:"durable"`
+		RetentionWatermark events.RetentionWatermark `json:"retention_watermark"`
 	}
 	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
 		t.Fatalf("decode cursor events response: %v", err)
@@ -2342,6 +2349,9 @@ func TestEventsEndpointSupportsAfterIDCursor(t *testing.T) {
 	}
 	if decoded.Backend != "sqlite" || !decoded.Durable {
 		t.Fatalf("unexpected durable metadata: %+v", decoded)
+	}
+	if !decoded.RetentionWatermark.Available || decoded.RetentionWatermark.OldestEventID != "evt-durable-1" || decoded.RetentionWatermark.NewestEventID != "evt-durable-3" {
+		t.Fatalf("unexpected durable retention watermark: %+v", decoded.RetentionWatermark)
 	}
 }
 

--- a/bigclaw-go/internal/events/bus.go
+++ b/bigclaw-go/internal/events/bus.go
@@ -3,6 +3,7 @@ package events
 import (
 	"context"
 	"sync"
+	"time"
 
 	"bigclaw-go/internal/domain"
 )
@@ -95,9 +96,28 @@ func (b *Bus) Capabilities(ctx context.Context) BackendCapabilities {
 	capability := b.capability
 	b.mu.RUnlock()
 	if provider != nil {
-		return provider.Capabilities(ctx)
+		capability = provider.Capabilities(ctx)
 	}
+	capability.RetentionWatermark = b.RetentionWatermark(ctx)
 	return capability
+}
+
+func (b *Bus) RetentionWatermark(_ context.Context) RetentionWatermark {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if len(b.history) == 0 {
+		return RetentionWatermark{}
+	}
+	oldest := b.history[0]
+	newest := b.history[len(b.history)-1]
+	return RetentionWatermark{
+		Available:            true,
+		OldestEventID:        oldest.ID,
+		NewestEventID:        newest.ID,
+		OldestEventTimestamp: oldest.Timestamp.UTC().Format(time.RFC3339Nano),
+		NewestEventTimestamp: newest.Timestamp.UTC().Format(time.RFC3339Nano),
+		RetainedEventCount:   len(b.history),
+	}
 }
 
 func (b *Bus) Publish(event domain.Event) {

--- a/bigclaw-go/internal/events/bus_test.go
+++ b/bigclaw-go/internal/events/bus_test.go
@@ -67,12 +67,17 @@ func (p staticCapabilityProvider) Capabilities(context.Context) BackendCapabilit
 
 func TestBusCapabilitiesDefaultAndOverride(t *testing.T) {
 	bus := NewBus()
+	bus.Publish(domain.Event{ID: "evt-cap-1", Type: domain.EventTaskQueued, Timestamp: time.Unix(1700000000, 0).UTC()})
+	bus.Publish(domain.Event{ID: "evt-cap-2", Type: domain.EventTaskStarted, Timestamp: time.Unix(1700000001, 0).UTC()})
 	capability := bus.Capabilities(context.Background())
 	if capability.Backend != "in_memory_history" {
 		t.Fatalf("expected default backend in_memory_history, got %s", capability.Backend)
 	}
 	if !capability.Replay.Supported || capability.Checkpoint.Supported {
 		t.Fatalf("unexpected default capability set: %+v", capability)
+	}
+	if !capability.RetentionWatermark.Available || capability.RetentionWatermark.OldestEventID != "evt-cap-1" || capability.RetentionWatermark.NewestEventID != "evt-cap-2" || capability.RetentionWatermark.RetainedEventCount != 2 {
+		t.Fatalf("expected default retention watermark, got %+v", capability.RetentionWatermark)
 	}
 
 	override := BackendCapabilities{
@@ -88,7 +93,7 @@ func TestBusCapabilitiesDefaultAndOverride(t *testing.T) {
 		Retention: FeatureSupport{Supported: true, Mode: "ttl"},
 	}
 	bus.SetCapabilityProvider(staticCapabilityProvider{capability: override})
-	if got := bus.Capabilities(context.Background()); got.Backend != "broker_adapter" || !got.Checkpoint.Supported || got.Retention.Mode != "ttl" {
+	if got := bus.Capabilities(context.Background()); got.Backend != "broker_adapter" || !got.Checkpoint.Supported || got.Retention.Mode != "ttl" || got.RetentionWatermark.OldestEventID != "evt-cap-1" {
 		t.Fatalf("expected provider override, got %+v", got)
 	}
 }

--- a/bigclaw-go/internal/events/capabilities.go
+++ b/bigclaw-go/internal/events/capabilities.go
@@ -8,18 +8,32 @@ type FeatureSupport struct {
 	Detail    string `json:"detail,omitempty"`
 }
 
+type RetentionWatermark struct {
+	Available            bool   `json:"available"`
+	OldestEventID        string `json:"oldest_event_id,omitempty"`
+	NewestEventID        string `json:"newest_event_id,omitempty"`
+	OldestEventTimestamp string `json:"oldest_event_timestamp,omitempty"`
+	NewestEventTimestamp string `json:"newest_event_timestamp,omitempty"`
+	RetainedEventCount   int    `json:"retained_event_count"`
+}
+
 type BackendCapabilities struct {
-	Backend    string         `json:"backend"`
-	Scope      string         `json:"scope,omitempty"`
-	Publish    FeatureSupport `json:"publish"`
-	Replay     FeatureSupport `json:"replay"`
-	Checkpoint FeatureSupport `json:"checkpoint"`
-	Filtering  FeatureSupport `json:"filtering"`
-	Retention  FeatureSupport `json:"retention"`
+	Backend            string             `json:"backend"`
+	Scope              string             `json:"scope,omitempty"`
+	Publish            FeatureSupport     `json:"publish"`
+	Replay             FeatureSupport     `json:"replay"`
+	Checkpoint         FeatureSupport     `json:"checkpoint"`
+	Filtering          FeatureSupport     `json:"filtering"`
+	Retention          FeatureSupport     `json:"retention"`
+	RetentionWatermark RetentionWatermark `json:"retention_watermark"`
 }
 
 type CapabilityProvider interface {
 	Capabilities(context.Context) BackendCapabilities
+}
+
+type RetentionWatermarkProvider interface {
+	RetentionWatermark(context.Context) RetentionWatermark
 }
 
 func defaultBusCapabilities() BackendCapabilities {

--- a/bigclaw-go/internal/events/http_log.go
+++ b/bigclaw-go/internal/events/http_log.go
@@ -32,7 +32,13 @@ type checkpointResponse struct {
 }
 
 type remoteEventsResponse struct {
-	Events []domain.Event `json:"events"`
+	Events             []domain.Event     `json:"events"`
+	RetentionWatermark RetentionWatermark `json:"retention_watermark"`
+}
+
+type remoteStatusResponse struct {
+	Backend      string              `json:"backend"`
+	Capabilities BackendCapabilities `json:"capabilities"`
 }
 
 func NewHTTPEventLog(endpoint, bearerToken string) (*HTTPEventLog, error) {
@@ -55,6 +61,10 @@ func (s *HTTPEventLog) Backend() string {
 }
 
 func (s *HTTPEventLog) Capabilities() BackendCapabilities {
+	status, err := s.status(context.Background())
+	if err == nil {
+		return status.Capabilities
+	}
 	return BackendCapabilities{
 		Backend:    "http",
 		Scope:      "remote_service",
@@ -64,6 +74,14 @@ func (s *HTTPEventLog) Capabilities() BackendCapabilities {
 		Filtering:  FeatureSupport{Supported: true, Mode: "server_side"},
 		Retention:  FeatureSupport{Supported: true, Mode: "remote_service"},
 	}
+}
+
+func (s *HTTPEventLog) RetentionWatermark(ctx context.Context) RetentionWatermark {
+	status, err := s.status(ctx)
+	if err != nil {
+		return RetentionWatermark{}
+	}
+	return status.Capabilities.RetentionWatermark
 }
 
 func (s *HTTPEventLog) Write(ctx context.Context, event domain.Event) error {
@@ -150,6 +168,14 @@ func (s *HTTPEventLog) queryEvents(params url.Values) ([]domain.Event, error) {
 	return response.Events, nil
 }
 
+func (s *HTTPEventLog) status(ctx context.Context) (remoteStatusResponse, error) {
+	var response remoteStatusResponse
+	if err := s.doJSON(ctx, http.MethodGet, "/status", nil, &response); err != nil {
+		return remoteStatusResponse{}, err
+	}
+	return response, nil
+}
+
 func (s *HTTPEventLog) doJSON(ctx context.Context, method, path string, body any, out any) error {
 	endpoint, err := s.endpoint(path)
 	if err != nil {
@@ -218,6 +244,8 @@ func mapRemoteEventLogError(err error) error {
 	}
 	return err
 }
+
+var _ RetentionWatermarkProvider = (*HTTPEventLog)(nil)
 
 func errorsAsStatus(err error, out *statusError) bool {
 	status, ok := err.(statusError)

--- a/bigclaw-go/internal/events/http_log_test.go
+++ b/bigclaw-go/internal/events/http_log_test.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
@@ -52,5 +54,45 @@ func TestHTTPEventLogRoundTripsThroughService(t *testing.T) {
 	}
 	if checkpoint.EventID != "evt-remote-2" || checkpoint.SubscriberID != "subscriber-remote" {
 		t.Fatalf("unexpected remote checkpoint payload: %+v", checkpoint)
+	}
+	watermark := client.RetentionWatermark(context.Background())
+	if !watermark.Available || watermark.OldestEventID != "evt-remote-1" || watermark.NewestEventID != "evt-remote-2" {
+		t.Fatalf("unexpected remote retention watermark: %+v", watermark)
+	}
+	if capabilities := client.Capabilities(); capabilities.RetentionWatermark.NewestEventID != "evt-remote-2" {
+		t.Fatalf("expected remote capabilities watermark, got %+v", capabilities.RetentionWatermark)
+	}
+}
+
+func TestEventLogServiceEventsResponseIncludesRetentionWatermark(t *testing.T) {
+	store, err := NewSQLiteEventLog(filepath.Join(t.TempDir(), "event-log.db"))
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	base := time.Unix(1700000200, 0).UTC()
+	for _, event := range []domain.Event{
+		{ID: "evt-service-1", Type: domain.EventTaskQueued, TaskID: "task-service", TraceID: "trace-service", Timestamp: base},
+		{ID: "evt-service-2", Type: domain.EventTaskStarted, TaskID: "task-service", TraceID: "trace-service", Timestamp: base.Add(time.Second)},
+	} {
+		if err := store.Write(context.Background(), event); err != nil {
+			t.Fatalf("write %s: %v", event.ID, err)
+		}
+	}
+	request := httptest.NewRequest(http.MethodGet, "/events?trace_id=trace-service&limit=10", nil)
+	response := httptest.NewRecorder()
+	NewEventLogServiceHandler(store).ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d %s", response.Code, response.Body.String())
+	}
+	var decoded struct {
+		Events             []domain.Event     `json:"events"`
+		RetentionWatermark RetentionWatermark `json:"retention_watermark"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode event-log service response: %v", err)
+	}
+	if len(decoded.Events) != 2 || decoded.RetentionWatermark.OldestEventID != "evt-service-1" || decoded.RetentionWatermark.NewestEventID != "evt-service-2" {
+		t.Fatalf("unexpected service watermark payload: %+v", decoded)
 	}
 }

--- a/bigclaw-go/internal/events/log_service.go
+++ b/bigclaw-go/internal/events/log_service.go
@@ -20,6 +20,16 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		writeEventLogJSON(w, http.StatusOK, map[string]any{"ok": true})
 	})
+	mux.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		writeEventLogJSON(w, http.StatusOK, map[string]any{
+			"backend":      store.Backend(),
+			"capabilities": store.Capabilities(),
+		})
+	})
 	mux.HandleFunc("/record", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -50,7 +60,11 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		writeEventLogJSON(w, http.StatusOK, map[string]any{"events": history})
+		payload := map[string]any{"events": history}
+		if provider, ok := store.(RetentionWatermarkProvider); ok {
+			payload["retention_watermark"] = provider.RetentionWatermark(r.Context())
+		}
+		writeEventLogJSON(w, http.StatusOK, payload)
 	})
 	mux.HandleFunc("/checkpoints/", func(w http.ResponseWriter, r *http.Request) {
 		subscriberID := strings.TrimPrefix(r.URL.Path, "/checkpoints/")

--- a/bigclaw-go/internal/events/sqlite_log.go
+++ b/bigclaw-go/internal/events/sqlite_log.go
@@ -63,13 +63,43 @@ func (s *SQLiteEventLog) Backend() string {
 
 func (s *SQLiteEventLog) Capabilities() BackendCapabilities {
 	return BackendCapabilities{
-		Backend:    "sqlite",
-		Scope:      "shared_node",
-		Publish:    FeatureSupport{Supported: true, Mode: "append_only"},
-		Replay:     FeatureSupport{Supported: true, Mode: "durable"},
-		Checkpoint: FeatureSupport{Supported: true, Mode: "subscriber_ack"},
-		Filtering:  FeatureSupport{Supported: true, Mode: "server_side"},
-		Retention:  FeatureSupport{Supported: true, Mode: "sqlite_wal"},
+		Backend:            "sqlite",
+		Scope:              "shared_node",
+		Publish:            FeatureSupport{Supported: true, Mode: "append_only"},
+		Replay:             FeatureSupport{Supported: true, Mode: "durable"},
+		Checkpoint:         FeatureSupport{Supported: true, Mode: "subscriber_ack"},
+		Filtering:          FeatureSupport{Supported: true, Mode: "server_side"},
+		Retention:          FeatureSupport{Supported: true, Mode: "sqlite_wal"},
+		RetentionWatermark: s.RetentionWatermark(context.Background()),
+	}
+}
+
+func (s *SQLiteEventLog) RetentionWatermark(_ context.Context) RetentionWatermark {
+	if s == nil || s.db == nil {
+		return RetentionWatermark{}
+	}
+	row := s.db.QueryRow(`
+		SELECT
+			COUNT(*),
+			COALESCE((SELECT event_id FROM event_log ORDER BY seq ASC LIMIT 1), ''),
+			COALESCE((SELECT timestamp_ns FROM event_log ORDER BY seq ASC LIMIT 1), 0),
+			COALESCE((SELECT event_id FROM event_log ORDER BY seq DESC LIMIT 1), ''),
+			COALESCE((SELECT timestamp_ns FROM event_log ORDER BY seq DESC LIMIT 1), 0)
+		FROM event_log
+	`)
+	var count int
+	var oldestID, newestID string
+	var oldestTS, newestTS int64
+	if err := row.Scan(&count, &oldestID, &oldestTS, &newestID, &newestTS); err != nil || count == 0 {
+		return RetentionWatermark{}
+	}
+	return RetentionWatermark{
+		Available:            true,
+		OldestEventID:        oldestID,
+		NewestEventID:        newestID,
+		OldestEventTimestamp: time.Unix(0, oldestTS).UTC().Format(time.RFC3339Nano),
+		NewestEventTimestamp: time.Unix(0, newestTS).UTC().Format(time.RFC3339Nano),
+		RetainedEventCount:   count,
 	}
 }
 
@@ -294,6 +324,7 @@ func reverseEvents(events []domain.Event) {
 
 var _ EventLog = (*SQLiteEventLog)(nil)
 var _ CheckpointStore = (*SQLiteEventLog)(nil)
+var _ RetentionWatermarkProvider = (*SQLiteEventLog)(nil)
 
 func IsNoEventLog(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)

--- a/bigclaw-go/internal/events/sqlite_log_test.go
+++ b/bigclaw-go/internal/events/sqlite_log_test.go
@@ -122,6 +122,31 @@ func TestSQLiteEventLogCheckpointPersistsAcrossInstances(t *testing.T) {
 	}
 }
 
+func TestSQLiteEventLogReportsRetentionWatermark(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "event-log.db")
+	log, err := NewSQLiteEventLog(path)
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = log.Close() }()
+	base := time.Unix(1700000100, 0).UTC()
+	for _, event := range []domain.Event{
+		{ID: "evt-watermark-1", Type: domain.EventTaskQueued, TaskID: "task-watermark", TraceID: "trace-watermark", Timestamp: base},
+		{ID: "evt-watermark-2", Type: domain.EventTaskCompleted, TaskID: "task-watermark", TraceID: "trace-watermark", Timestamp: base.Add(time.Second)},
+	} {
+		if err := log.Write(context.Background(), event); err != nil {
+			t.Fatalf("write %s: %v", event.ID, err)
+		}
+	}
+	watermark := log.RetentionWatermark(context.Background())
+	if !watermark.Available || watermark.OldestEventID != "evt-watermark-1" || watermark.NewestEventID != "evt-watermark-2" || watermark.RetainedEventCount != 2 {
+		t.Fatalf("unexpected retention watermark: %+v", watermark)
+	}
+	if capabilities := log.Capabilities(); capabilities.RetentionWatermark.NewestEventID != "evt-watermark-2" {
+		t.Fatalf("expected capabilities to include retention watermark, got %+v", capabilities.RetentionWatermark)
+	}
+}
+
 func TestSQLiteEventLogCheckpointAcknowledgeIsMonotonic(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "event-log.db")
 	log, err := NewSQLiteEventLog(path)

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -33,7 +33,7 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 
 ### Remaining gaps
 
-- Replay retention is still bounded primarily by in-process history when no external durable backend is configured.
+- Replay retention is still bounded primarily by in-process history when no external durable backend is configured, but the runtime now exposes the current replay horizon through retention watermark payloads on the local API and shared event-log service surfaces.
 - Service-style SQLite and HTTP-backed coordination improve sharing, but replicated broker or quorum-backed durability is still future work.
 - Downstream consumers still need idempotent handlers and durable dedupe stores; the system remains replay-safe, not globally exactly-once.
 - Parallel validation for Kubernetes, Ray, and shared-queue takeover should continue to be bundled as repo-native evidence.


### PR DESCRIPTION
## Summary
- add a provider-neutral retention watermark surface for in-memory, SQLite, and HTTP event-log backends
- expose watermark details on the events API, debug status payload, and the internal event-log service
- add regression coverage and update retention reliability docs

## Validation
- cd bigclaw-go && go test ./internal/events ./internal/api