### PR TITLE
OPE-224 broker-backed event-log adapter bootstrap

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -34,25 +34,34 @@ func main() {
 	defer closeQueue(q)
 
 	var eventLog events.EventLog
+	var eventLogCapability *events.BackendCapabilities
 	switch {
 	case cfg.EventLogRemoteURL != "":
 		eventLog, err = events.NewHTTPEventLog(cfg.EventLogRemoteURL, cfg.EventLogRemoteBearer)
 		if err != nil {
 			panic(err)
 		}
+		capability := eventLog.Capabilities()
+		eventLogCapability = &capability
 	case cfg.EventLogSQLitePath != "":
 		eventLog, err = events.NewSQLiteEventLog(cfg.EventLogSQLitePath)
 		if err != nil {
 			panic(err)
 		}
+		capability := eventLog.Capabilities()
+		eventLogCapability = &capability
 		defer closeEventLog(eventLog)
 	default:
-		if _, err = buildEventLog(cfg); err != nil {
+		eventLogCapability, err = buildEventLogCapabilities(cfg)
+		if err != nil {
 			panic(err)
 		}
 	}
 
 	bus := events.NewBus()
+	if eventLogCapability != nil {
+		bus.SetCapabilities(*eventLogCapability)
+	}
 	if eventLog != nil {
 		bus.AddSink(eventLog)
 	}
@@ -128,10 +137,10 @@ func main() {
 	fmt.Printf("%s stopped events=%d\n", cfg.ServiceName, len(bus.Replay()))
 }
 
-func buildEventLog(cfg config.Config) (*events.MemoryLog, error) {
+func buildEventLogCapabilities(cfg config.Config) (*events.BackendCapabilities, error) {
 	switch cfg.EventLogBackend {
 	case "", string(events.EventLogBackendMemory):
-		return events.NewMemoryLog(), nil
+		return nil, nil
 	case string(events.EventLogBackendBroker):
 		broker := events.BrokerRuntimeConfig{
 			Driver:             cfg.EventLogBrokerDriver,
@@ -145,7 +154,8 @@ func buildEventLog(cfg config.Config) (*events.MemoryLog, error) {
 		if err := broker.Validate(); err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("event log backend %q is not implemented yet; driver=%s topic=%s contract validated for the future adapter", cfg.EventLogBackend, broker.Driver, broker.Topic)
+		capability := events.BrokerBootstrapCapabilities(broker)
+		return &capability, nil
 	default:
 		return nil, fmt.Errorf("unsupported event log backend: %s", cfg.EventLogBackend)
 	}

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -149,6 +149,7 @@ This report summarizes the current event bus reliability evidence and the next r
 
 - `internal/events/log.go` now defines the provider-neutral event-log and checkpoint contract for future broker-backed adapters.
 - `internal/events/memory_log.go` provides the contract-compatible in-memory baseline while BigClaw remains on local fanout.
+- When `BIGCLAW_EVENT_LOG_BACKEND=broker` passes bootstrap validation, runtime and debug payloads now report `backend=broker` with `scope=broker_bootstrap` so operators can distinguish "validated config" from a live writable adapter.
 - Broker-facing runtime knobs are reserved behind `BIGCLAW_EVENT_LOG_*` env vars so a first provider adapter can land without changing publish/replay/checkpoint callers.
 - No durable external event log yet; replay is process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -10,6 +10,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 
 - `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
+- Runtime and debug payloads now expose that validated-but-unwired state explicitly as `event_log.backend=broker` with `scope=broker_bootstrap`.
 - `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
 
 ## Runtime contract

--- a/bigclaw-go/internal/api/metrics.go
+++ b/bigclaw-go/internal/api/metrics.go
@@ -47,9 +47,6 @@ func (s *Server) buildMetricsSnapshot() metricsSnapshot {
 	if s.Control != nil {
 		snapshot.Control = s.Control.Snapshot()
 	}
-	if s.EventLog != nil {
-		snapshot.EventLog = map[string]any{"backend": s.EventLog.Backend(), "capabilities": s.EventLog.Capabilities()}
-	}
 	return snapshot
 }
 

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -176,12 +176,6 @@ func (s *Server) Handler() http.Handler {
 		if watermark := s.retentionWatermark(); watermark != nil {
 			payload["retention_watermark"] = watermark
 		}
-		if s.EventLog != nil {
-			payload["event_log"] = map[string]any{
-				"backend":      s.EventLog.Backend(),
-				"capabilities": s.EventLog.Capabilities(),
-			}
-		}
 		writeJSON(w, http.StatusOK, payload)
 	})
 	mux.HandleFunc("/v2/dashboard/engineering", s.handleV2EngineeringDashboard)
@@ -724,6 +718,9 @@ func (s *Server) queryMemoryEvents(taskID, traceID, afterID string, limit int) [
 }
 
 func (s *Server) eventLogCapabilities(ctx context.Context) events.BackendCapabilities {
+	if s.EventLog != nil {
+		return s.EventLog.Capabilities()
+	}
 	if s.Bus != nil {
 		return s.Bus.Capabilities(ctx)
 	}

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -2734,3 +2734,17 @@ func TestDebugStatusIncludesRetentionWatermark(t *testing.T) {
 		t.Fatalf("expected retention watermark in debug payload, got %s", response.Body.String())
 	}
 }
+
+func TestEventLogCapabilitiesPreferConfiguredEventLog(t *testing.T) {
+	server := &Server{
+		Recorder: observability.NewRecorder(),
+		Queue:    queue.NewMemoryQueue(),
+		Bus:      events.NewBus(),
+		EventLog: &blockingEventLog{},
+		Now:      time.Now,
+	}
+	capability := server.eventLogCapabilities(context.Background())
+	if capability.Scope != "test_double" || !capability.Checkpoint.Supported || capability.Retention.Mode != "test_memory" {
+		t.Fatalf("expected configured event log capabilities, got %+v", capability)
+	}
+}

--- a/bigclaw-go/internal/events/bus_test.go
+++ b/bigclaw-go/internal/events/bus_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -91,6 +92,25 @@ func TestBusCapabilitiesDefaultAndOverride(t *testing.T) {
 	bus.SetCapabilityProvider(staticCapabilityProvider{capability: override})
 	if got := bus.Capabilities(context.Background()); got.Backend != "broker_adapter" || !got.Checkpoint.Supported || got.Retention.Mode != "ttl" {
 		t.Fatalf("expected provider override, got %+v", got)
+	}
+}
+
+func TestBrokerBootstrapCapabilitiesAdvertiseConfiguredReadiness(t *testing.T) {
+	capability := BrokerBootstrapCapabilities(BrokerRuntimeConfig{
+		Driver: "kafka",
+		Topic:  "bigclaw.events",
+	})
+	if capability.Backend != "broker" || capability.Scope != "broker_bootstrap" {
+		t.Fatalf("unexpected broker bootstrap capability identity: %+v", capability)
+	}
+	if capability.Publish.Supported || capability.Replay.Supported || capability.Checkpoint.Supported {
+		t.Fatalf("expected broker bootstrap to avoid claiming live support, got %+v", capability)
+	}
+	if capability.Filtering.Mode != "provider_defined" || capability.Retention.Mode != "broker_managed" {
+		t.Fatalf("expected broker bootstrap filtering/retention guidance, got %+v", capability)
+	}
+	if !strings.Contains(capability.Publish.Detail, "driver=kafka") || !strings.Contains(capability.Publish.Detail, "topic=bigclaw.events") {
+		t.Fatalf("expected broker bootstrap detail to include configured driver/topic, got %q", capability.Publish.Detail)
 	}
 }
 

--- a/bigclaw-go/internal/events/capabilities.go
+++ b/bigclaw-go/internal/events/capabilities.go
@@ -1,6 +1,9 @@
 package events
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type FeatureSupport struct {
 	Supported bool   `json:"supported"`
@@ -85,6 +88,46 @@ func UnavailableCapabilities() BackendCapabilities {
 		Retention: FeatureSupport{
 			Supported: false,
 			Detail:    "No event bus backend is configured.",
+		},
+	}
+}
+
+func BrokerBootstrapCapabilities(cfg BrokerRuntimeConfig) BackendCapabilities {
+	detail := "Broker adapter bootstrap config validated; live provider wiring is not implemented yet."
+	if cfg.Driver != "" || cfg.Topic != "" {
+		detail = fmt.Sprintf("Broker adapter bootstrap config validated for driver=%s topic=%s; live provider wiring is not implemented yet.", cfg.Driver, cfg.Topic)
+	}
+	return BackendCapabilities{
+		Backend: "broker",
+		Scope:   "broker_bootstrap",
+		Publish: FeatureSupport{
+			Supported: false,
+			Mode:      "contract_validated",
+			Detail:    detail,
+		},
+		Replay: FeatureSupport{
+			Supported: false,
+			Mode:      "contract_validated",
+			Detail:    "Replay contract and cursor expectations are reserved for the future broker adapter.",
+		},
+		Checkpoint: FeatureSupport{
+			Supported: false,
+			Mode:      "contract_validated",
+			Detail:    "Checkpoint semantics are defined, but no broker-backed checkpoint store is wired yet.",
+		},
+		Dedup: FeatureSupport{
+			Supported: false,
+			Detail:    "Durable consumer dedup remains a separate backend concern until a broker adapter lands.",
+		},
+		Filtering: FeatureSupport{
+			Supported: true,
+			Mode:      "provider_defined",
+			Detail:    "Broker adapters are expected to preserve task and trace filtering semantics.",
+		},
+		Retention: FeatureSupport{
+			Supported: true,
+			Mode:      "broker_managed",
+			Detail:    "Retention boundaries will be enforced by the chosen broker backend once implemented.",
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- expose broker bootstrap event-log capabilities without claiming a live provider implementation
- make runtime and debug event-log payloads use a consistent capability shape and prefer the configured event log when present
- cover broker bootstrap and configured event-log capability precedence with Go tests

## Validation
- go test ./internal/events ./internal/api ./cmd/bigclawd
