### PR TITLE
OPE-223 durable replay retention backend bootstrap

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -33,24 +34,11 @@ func main() {
 	}
 	defer closeQueue(q)
 
-	var eventLog events.EventLog
-	switch {
-	case cfg.EventLogRemoteURL != "":
-		eventLog, err = events.NewHTTPEventLog(cfg.EventLogRemoteURL, cfg.EventLogRemoteBearer)
-		if err != nil {
-			panic(err)
-		}
-	case cfg.EventLogSQLitePath != "":
-		eventLog, err = events.NewSQLiteEventLog(cfg.EventLogSQLitePath)
-		if err != nil {
-			panic(err)
-		}
-		defer closeEventLog(eventLog)
-	default:
-		if _, err = buildEventLog(cfg); err != nil {
-			panic(err)
-		}
+	eventLog, err := buildConfiguredEventLog(cfg)
+	if err != nil {
+		panic(err)
 	}
+	defer closeEventLog(eventLog)
 
 	bus := events.NewBus()
 	if eventLog != nil {
@@ -128,6 +116,32 @@ func main() {
 	fmt.Printf("%s stopped events=%d\n", cfg.ServiceName, len(bus.Replay()))
 }
 
+func buildConfiguredEventLog(cfg config.Config) (events.EventLog, error) {
+	switch backend := effectiveEventBackend(cfg); backend {
+	case "":
+		return nil, nil
+	case string(events.BackendSQLite):
+		path := strings.TrimSpace(cfg.EventLogSQLitePath)
+		if path == "" {
+			path = sqlitePathFromDSN(cfg.EventLogDSN)
+		}
+		return events.NewSQLiteEventLog(path)
+	case string(events.BackendHTTP):
+		endpoint := strings.TrimSpace(cfg.EventLogRemoteURL)
+		if endpoint == "" {
+			endpoint = strings.TrimSpace(cfg.EventLogDSN)
+		}
+		return events.NewHTTPEventLog(endpoint, cfg.EventLogRemoteBearer)
+	case string(events.BackendMemory):
+		return nil, nil
+	default:
+		if _, err := buildEventLog(cfg); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+}
+
 func buildEventLog(cfg config.Config) (*events.MemoryLog, error) {
 	switch cfg.EventLogBackend {
 	case "", string(events.EventLogBackendMemory):
@@ -149,6 +163,36 @@ func buildEventLog(cfg config.Config) (*events.MemoryLog, error) {
 	default:
 		return nil, fmt.Errorf("unsupported event log backend: %s", cfg.EventLogBackend)
 	}
+}
+
+func effectiveEventBackend(cfg config.Config) string {
+	backend := strings.ToLower(strings.TrimSpace(cfg.EventBackend))
+	switch backend {
+	case "", string(events.BackendMemory):
+		switch {
+		case strings.TrimSpace(cfg.EventLogRemoteURL) != "":
+			return string(events.BackendHTTP)
+		case strings.TrimSpace(cfg.EventLogSQLitePath) != "":
+			return string(events.BackendSQLite)
+		default:
+			return backend
+		}
+	default:
+		return backend
+	}
+}
+
+func sqlitePathFromDSN(dsn string) string {
+	trimmed := strings.TrimSpace(dsn)
+	if after, ok := strings.CutPrefix(trimmed, "file:"); ok {
+		if path, _, hasQuery := strings.Cut(after, "?"); hasQuery {
+			return path
+		}
+		if after != "" {
+			return after
+		}
+	}
+	return trimmed
 }
 
 func buildQueue(cfg config.Config) (queue.Queue, error) {

--- a/bigclaw-go/cmd/bigclawd/main_test.go
+++ b/bigclaw-go/cmd/bigclawd/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"bigclaw-go/internal/config"
+)
+
+func TestBuildConfiguredEventLogUsesSQLiteDurableBackendContract(t *testing.T) {
+	cfg := config.Default()
+	cfg.EventBackend = "sqlite"
+	cfg.EventLogDSN = filepath.Join(t.TempDir(), "event-log.db")
+	cfg.EventCheckpointDSN = cfg.EventLogDSN
+	cfg.EventRetention = time.Hour
+
+	eventLog, err := buildConfiguredEventLog(cfg)
+	if err != nil {
+		t.Fatalf("build sqlite event log: %v", err)
+	}
+	if eventLog == nil {
+		t.Fatal("expected sqlite event log")
+	}
+	defer closeEventLog(eventLog)
+	if eventLog.Backend() != "sqlite" {
+		t.Fatalf("expected sqlite backend, got %q", eventLog.Backend())
+	}
+}
+
+func TestBuildConfiguredEventLogUsesHTTPDurableBackendContract(t *testing.T) {
+	cfg := config.Default()
+	cfg.EventBackend = "http"
+	cfg.EventLogDSN = "http://127.0.0.1:8080/internal/events/log"
+	cfg.EventCheckpointDSN = cfg.EventLogDSN
+	cfg.EventRetention = time.Hour
+
+	eventLog, err := buildConfiguredEventLog(cfg)
+	if err != nil {
+		t.Fatalf("build http event log: %v", err)
+	}
+	if eventLog == nil {
+		t.Fatal("expected http event log")
+	}
+	if eventLog.Backend() != "http" {
+		t.Fatalf("expected http backend, got %q", eventLog.Backend())
+	}
+}

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -103,13 +103,14 @@ This report summarizes the current event bus reliability evidence and the next r
 | Backend | Implemented in bootstrap | Durable history | Publish | Replay | Checkpoint | Filtering | Required config |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | `memory` | yes | no | native | native | unsupported | native | none |
-| `sqlite` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-| `http` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
+| `sqlite` | yes | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
+| `http` | yes | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
 | `broker` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
 
 ## Validation contract
 
 - Startup validates `BIGCLAW_EVENT_BACKEND` against the backend catalog before queue/bootstrap wiring begins.
+- The same `BIGCLAW_EVENT_BACKEND` / `BIGCLAW_EVENT_LOG_DSN` contract now bootstraps the concrete SQLite and HTTP durable event-log implementations instead of serving only as a validation-only planning surface.
 - Durable backends must provide explicit event-log DSN, checkpoint DSN, and positive retention.
 - `BIGCLAW_EVENT_REQUIRE_REPLAY`, `BIGCLAW_EVENT_REQUIRE_CHECKPOINT`, and `BIGCLAW_EVENT_REQUIRE_FILTERING` express the runtime features operators expect from the selected backend.
 - Unsupported combinations fail fast with field-specific errors instead of silently downgrading runtime behavior.
@@ -133,6 +134,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, but expired-cursor fallback is still defined primarily against the current replay window and the target compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
+- Debug and metrics payloads now include backend-specific `retention_bootstrap` metadata so operators can distinguish local SQLite retention from shared HTTP-backed retention when reviewing replay durability.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
 

--- a/bigclaw-go/internal/api/metrics.go
+++ b/bigclaw-go/internal/api/metrics.go
@@ -21,6 +21,7 @@ type metricsSnapshot struct {
 	EventDurability     any
 	EventLog            any
 	RetentionWatermark  any
+	RetentionBootstrap  any
 }
 
 func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
@@ -43,12 +44,17 @@ func (s *Server) buildMetricsSnapshot() metricsSnapshot {
 		EventDurability:     s.EventPlan,
 		EventLog:            s.eventLogCapabilities(context.Background()),
 		RetentionWatermark:  s.retentionWatermark(),
+		RetentionBootstrap:  s.retentionBootstrap(),
 	}
 	if s.Control != nil {
 		snapshot.Control = s.Control.Snapshot()
 	}
 	if s.EventLog != nil {
-		snapshot.EventLog = map[string]any{"backend": s.EventLog.Backend(), "capabilities": s.EventLog.Capabilities()}
+		snapshot.EventLog = map[string]any{
+			"backend":             s.EventLog.Backend(),
+			"capabilities":        s.EventLog.Capabilities(),
+			"retention_bootstrap": s.retentionBootstrap(),
+		}
 	}
 	return snapshot
 }
@@ -62,6 +68,7 @@ func metricsJSONPayload(snapshot metricsSnapshot) map[string]any {
 		"event_durability":     snapshot.EventDurability,
 		"event_log":            snapshot.EventLog,
 		"retention_watermark":  snapshot.RetentionWatermark,
+		"retention_bootstrap":  snapshot.RetentionBootstrap,
 	}
 }
 

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -178,8 +178,9 @@ func (s *Server) Handler() http.Handler {
 		}
 		if s.EventLog != nil {
 			payload["event_log"] = map[string]any{
-				"backend":      s.EventLog.Backend(),
-				"capabilities": s.EventLog.Capabilities(),
+				"backend":             s.EventLog.Backend(),
+				"capabilities":        s.EventLog.Capabilities(),
+				"retention_bootstrap": s.retentionBootstrap(),
 			}
 		}
 		writeJSON(w, http.StatusOK, payload)
@@ -799,6 +800,16 @@ func (s *Server) retentionWatermark() any {
 				return watermark
 			}
 		}
+	}
+	return nil
+}
+
+func (s *Server) retentionBootstrap() any {
+	if s.EventLog == nil {
+		return nil
+	}
+	if provider, ok := s.EventLog.(events.RetentionBootstrapProvider); ok {
+		return provider.RetentionBootstrap()
 	}
 	return nil
 }

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -2734,3 +2734,24 @@ func TestDebugStatusIncludesRetentionWatermark(t *testing.T) {
 		t.Fatalf("expected retention watermark in debug payload, got %s", response.Body.String())
 	}
 }
+
+func TestDebugStatusIncludesRetentionBootstrap(t *testing.T) {
+	store, err := events.NewSQLiteEventLog(filepath.Join(t.TempDir(), "event-log.db"))
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	server := &Server{Recorder: observability.NewRecorder(), Queue: queue.NewMemoryQueue(), Bus: events.NewBus(), EventLog: store, Now: time.Now}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected debug status 200, got %d", response.Code)
+	}
+	body := response.Body.String()
+	for _, want := range []string{"retention_bootstrap", "\"backend\":\"sqlite\"", "\"retention_mode\":\"durable_oldest_newest_watermark\""} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in debug payload, got %s", want, body)
+		}
+	}
+}

--- a/bigclaw-go/internal/events/backend_contract.go
+++ b/bigclaw-go/internal/events/backend_contract.go
@@ -75,7 +75,7 @@ func Catalog() map[BackendKind]BackendProfile {
 		},
 		BackendSQLite: {
 			Backend:               BackendSQLite,
-			Implemented:           false,
+			Implemented:           true,
 			Durable:               true,
 			RequiresLogDSN:        true,
 			RequiresCheckpointDSN: true,
@@ -88,7 +88,7 @@ func Catalog() map[BackendKind]BackendProfile {
 		},
 		BackendHTTP: {
 			Backend:               BackendHTTP,
-			Implemented:           false,
+			Implemented:           true,
 			Durable:               true,
 			RequiresLogDSN:        true,
 			RequiresCheckpointDSN: true,

--- a/bigclaw-go/internal/events/backend_contract_test.go
+++ b/bigclaw-go/internal/events/backend_contract_test.go
@@ -32,7 +32,7 @@ func TestValidateBackendConfigRejectsCheckpointOnMemory(t *testing.T) {
 	}
 }
 
-func TestValidateBackendConfigRejectsUnwiredDurableBackend(t *testing.T) {
+func TestValidateBackendConfigAcceptsSQLiteDurableBackend(t *testing.T) {
 	report := ValidateBackendConfig(BackendConfig{
 		Backend:           BackendSQLite,
 		LogDSN:            "file:events.db",
@@ -42,11 +42,23 @@ func TestValidateBackendConfigRejectsUnwiredDurableBackend(t *testing.T) {
 		RequireFiltering:  true,
 		RequireCheckpoint: true,
 	})
-	if !report.HasErrors() {
-		t.Fatal("expected unwired sqlite backend to fail")
+	if report.HasErrors() {
+		t.Fatalf("expected sqlite backend validation to pass, got %+v", report.Issues)
 	}
-	if err := report.Error(); err == nil || !strings.Contains(err.Error(), "not wired into the bootstrap runtime") {
-		t.Fatalf("expected bootstrap runtime validation error, got %v", err)
+}
+
+func TestValidateBackendConfigAcceptsHTTPDurableBackend(t *testing.T) {
+	report := ValidateBackendConfig(BackendConfig{
+		Backend:           BackendHTTP,
+		LogDSN:            "http://127.0.0.1:8080/internal/events/log",
+		CheckpointDSN:     "http://127.0.0.1:8080/internal/events/log",
+		Retention:         time.Hour,
+		RequireReplay:     true,
+		RequireFiltering:  true,
+		RequireCheckpoint: true,
+	})
+	if report.HasErrors() {
+		t.Fatalf("expected http backend validation to pass, got %+v", report.Issues)
 	}
 }
 

--- a/bigclaw-go/internal/events/http_log.go
+++ b/bigclaw-go/internal/events/http_log.go
@@ -134,6 +134,18 @@ func (s *HTTPEventLog) RetentionWatermark() (RetentionWatermark, error) {
 	return response.RetentionWatermark, nil
 }
 
+func (s *HTTPEventLog) RetentionBootstrap() RetentionBootstrap {
+	return RetentionBootstrap{
+		Backend:       "http",
+		Durable:       true,
+		Shared:        true,
+		LogDSN:        s.Path(),
+		CheckpointDSN: s.Path(),
+		RetentionMode: "remote_service_watermark",
+		Detail:        "Retention boundaries are delegated to the shared event-log service and remain available across client restarts as long as the backing durable store is preserved.",
+	}
+}
+
 func (s *HTTPEventLog) Path() string {
 	if s == nil || s.baseURL == nil {
 		return ""

--- a/bigclaw-go/internal/events/http_log_test.go
+++ b/bigclaw-go/internal/events/http_log_test.go
@@ -84,3 +84,49 @@ func TestHTTPEventLogReadsRetentionWatermarkFromService(t *testing.T) {
 		t.Fatalf("unexpected remote watermark: %+v", watermark)
 	}
 }
+
+func TestHTTPEventLogRetentionWatermarkSurvivesServiceRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "event-log.db")
+	store1, err := NewSQLiteEventLog(path)
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	server1 := httptest.NewServer(NewEventLogServiceHandler(store1))
+	client, err := NewHTTPEventLog(server1.URL, "")
+	if err != nil {
+		t.Fatalf("new http event log: %v", err)
+	}
+	base := time.Now()
+	for _, event := range []domain.Event{
+		{ID: "evt-http-restart-1", Type: domain.EventTaskQueued, TaskID: "task-http-restart", TraceID: "trace-http-restart", Timestamp: base},
+		{ID: "evt-http-restart-2", Type: domain.EventTaskStarted, TaskID: "task-http-restart", TraceID: "trace-http-restart", Timestamp: base.Add(time.Second)},
+	} {
+		if err := client.Write(context.Background(), event); err != nil {
+			t.Fatalf("write remote event %s: %v", event.ID, err)
+		}
+	}
+	server1.Close()
+	if err := store1.Close(); err != nil {
+		t.Fatalf("close first sqlite event log: %v", err)
+	}
+
+	store2, err := NewSQLiteEventLog(path)
+	if err != nil {
+		t.Fatalf("reopen sqlite event log: %v", err)
+	}
+	defer func() { _ = store2.Close() }()
+	server2 := httptest.NewServer(NewEventLogServiceHandler(store2))
+	defer server2.Close()
+	client, err = NewHTTPEventLog(server2.URL, "")
+	if err != nil {
+		t.Fatalf("new restarted http event log: %v", err)
+	}
+
+	watermark, err := client.RetentionWatermark()
+	if err != nil {
+		t.Fatalf("read retention watermark after service restart: %v", err)
+	}
+	if watermark.Backend != "sqlite" || watermark.EventCount != 2 || watermark.OldestEventID != "evt-http-restart-1" || watermark.NewestEventID != "evt-http-restart-2" {
+		t.Fatalf("unexpected remote watermark after restart: %+v", watermark)
+	}
+}

--- a/bigclaw-go/internal/events/sqlite_log.go
+++ b/bigclaw-go/internal/events/sqlite_log.go
@@ -94,6 +94,17 @@ func (s *SQLiteEventLog) RetentionWatermark() (RetentionWatermark, error) {
 	return watermark, nil
 }
 
+func (s *SQLiteEventLog) RetentionBootstrap() RetentionBootstrap {
+	return RetentionBootstrap{
+		Backend:       "sqlite",
+		Durable:       true,
+		LogDSN:        s.Path(),
+		CheckpointDSN: s.Path(),
+		RetentionMode: "durable_oldest_newest_watermark",
+		Detail:        "Retention boundaries are derived from the durable SQLite append log and survive process restarts on the same shared file.",
+	}
+}
+
 func (s *SQLiteEventLog) Path() string {
 	if s == nil {
 		return ""

--- a/bigclaw-go/internal/events/sqlite_log_test.go
+++ b/bigclaw-go/internal/events/sqlite_log_test.go
@@ -176,3 +176,37 @@ func TestSQLiteEventLogRetentionWatermark(t *testing.T) {
 		t.Fatalf("expected ordered watermark sequences, got %+v", watermark)
 	}
 }
+
+func TestSQLiteEventLogRetentionWatermarkPersistsAcrossInstances(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "event-log.db")
+	log1, err := NewSQLiteEventLog(path)
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	base := time.Now()
+	for _, event := range []domain.Event{
+		{ID: "evt-watermark-persist-1", Type: domain.EventTaskQueued, TaskID: "task-watermark", TraceID: "trace-watermark", Timestamp: base},
+		{ID: "evt-watermark-persist-2", Type: domain.EventTaskStarted, TaskID: "task-watermark", TraceID: "trace-watermark", Timestamp: base.Add(time.Second)},
+	} {
+		if err := log1.Write(context.Background(), event); err != nil {
+			t.Fatalf("write %s: %v", event.ID, err)
+		}
+	}
+	if err := log1.Close(); err != nil {
+		t.Fatalf("close first sqlite event log: %v", err)
+	}
+
+	log2, err := NewSQLiteEventLog(path)
+	if err != nil {
+		t.Fatalf("reopen sqlite event log: %v", err)
+	}
+	defer func() { _ = log2.Close() }()
+
+	watermark, err := log2.RetentionWatermark()
+	if err != nil {
+		t.Fatalf("retention watermark after reopen: %v", err)
+	}
+	if watermark.Backend != "sqlite" || watermark.EventCount != 2 || watermark.OldestEventID != "evt-watermark-persist-1" || watermark.NewestEventID != "evt-watermark-persist-2" {
+		t.Fatalf("unexpected reopened retention watermark: %+v", watermark)
+	}
+}

--- a/bigclaw-go/internal/events/watermark.go
+++ b/bigclaw-go/internal/events/watermark.go
@@ -13,3 +13,17 @@ type RetentionWatermark struct {
 type RetentionWatermarkProvider interface {
 	RetentionWatermark() (RetentionWatermark, error)
 }
+
+type RetentionBootstrap struct {
+	Backend       string `json:"backend,omitempty"`
+	Durable       bool   `json:"durable"`
+	Shared        bool   `json:"shared,omitempty"`
+	LogDSN        string `json:"log_dsn,omitempty"`
+	CheckpointDSN string `json:"checkpoint_dsn,omitempty"`
+	RetentionMode string `json:"retention_mode,omitempty"`
+	Detail        string `json:"detail,omitempty"`
+}
+
+type RetentionBootstrapProvider interface {
+	RetentionBootstrap() RetentionBootstrap
+}


### PR DESCRIPTION
## Summary
- wire `BIGCLAW_EVENT_BACKEND` and `BIGCLAW_EVENT_LOG_DSN` into concrete SQLite and HTTP durable event-log bootstrap selection
- expose backend-specific `retention_bootstrap` metadata in debug and metrics payloads
- add restart/shared-backend retention watermark regression coverage and update the reliability report

## Validation
- go test ./cmd/bigclawd ./internal/events ./internal/api