### PR TITLE
OPE-227: add broker adapter dry-run capability probe

### DIFF
--- a/bigclaw-go/docs/reports/broker-event-log-adapter-contract.md
+++ b/bigclaw-go/docs/reports/broker-event-log-adapter-contract.md
@@ -40,6 +40,21 @@ This note captures the implementation-ready boundary for `OPE-208` / `BIG-PAR-02
 - `BIGCLAW_EVENT_LOG_REPLAY_LIMIT` sets the default catch-up page size for replay-oriented consumers.
 - `BIGCLAW_EVENT_LOG_CHECKPOINT_INTERVAL` sets the default checkpoint flush cadence for streaming consumers.
 
+## Dry-run capability probe
+
+- `internal/events/durability.go` now exposes a `broker_probe` payload inside `event_durability` for replicated targets, even before a live broker adapter exists.
+- The probe is explicitly `mode=dry_run` and `implementation_state=planned_only` so operator tooling can distinguish contract validation from a shipped backend.
+- The payload mirrors configured driver / URLs / topic / consumer-group values, reports field-level validation errors, and advertises the provider-facing capability contract for:
+  - replicated publish acknowledgement;
+  - replay via portable `Position.Sequence` mapping;
+  - durable checkpoint monotonicity;
+  - derived task / trace filtering;
+  - visible retention boundaries.
+- The same probe also summarizes the current failure modes that a future provider implementation must satisfy before rollout:
+  - ambiguous publish outcomes during broker failover;
+  - checkpoint fencing gaps during consumer takeover;
+  - retention-boundary drift after compaction or expiry.
+
 ## First backend implementation path
 
 - Keep the existing in-process `Bus` for local fanout and SSE/live delivery.

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -9,6 +9,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 ## Current baseline
 
 - `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads, including broker bootstrap readiness derived from configured driver / URLs / topic settings.
+- The same payload now carries a `broker_probe` dry-run summary so operators can inspect expected broker capabilities, failure modes, and config-validation results before a live provider adapter is wired.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
 - `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
 
@@ -63,6 +64,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - active backend and target backend
 - replication factor or quorum expectation
 - whether publisher acknowledgement is required before success is reported
+- dry-run broker capability expectations and config-validation results when the replicated target is selected
 - rollout checks and their failure modes
 - failure-domain summaries
 - references to the supporting validation pack and rollout contract documents

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -248,10 +248,18 @@ func TestAuditAndReplayEndpoints(t *testing.T) {
 func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	recorder := observability.NewRecorder()
 	server := &Server{
-		Recorder:  recorder,
-		Queue:     queue.NewMemoryQueue(),
-		EventPlan: events.NewDurabilityPlan("http", "broker_replicated", 5),
-		Now:       time.Now,
+		Recorder: recorder,
+		Queue:    queue.NewMemoryQueue(),
+		EventPlan: events.NewDurabilityPlanWithBrokerConfig("http", "broker_replicated", 5, events.BrokerRuntimeConfig{
+			Driver:             "kafka",
+			URLs:               []string{"kafka-1:9092", "kafka-2:9092"},
+			Topic:              "bigclaw.events",
+			ConsumerGroup:      "bigclaw-consumers",
+			PublishTimeout:     7 * time.Second,
+			ReplayLimit:        2048,
+			CheckpointInterval: 15 * time.Second,
+		}),
+		Now: time.Now,
 	}
 	response := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
@@ -277,6 +285,12 @@ func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), "\"verification_evidence\"") {
 		t.Fatalf("expected verification evidence in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"broker_probe\"") || !strings.Contains(response.Body.String(), "\"mode\":\"dry_run\"") {
+		t.Fatalf("expected broker dry-run probe in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"implementation_state\":\"planned_only\"") || !strings.Contains(response.Body.String(), "\"backend\":\"broker_adapter\"") {
+		t.Fatalf("expected broker capability contract in payload, got %s", response.Body.String())
 	}
 }
 

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -50,6 +50,31 @@ type BrokerBootstrapStatus struct {
 	ValidationErrors   []string `json:"validation_errors,omitempty"`
 }
 
+type BrokerFailureModeSummary struct {
+	Name       string `json:"name"`
+	Summary    string `json:"summary"`
+	Mitigation string `json:"mitigation"`
+}
+
+type BrokerAdapterDryRun struct {
+	Mode                  string                     `json:"mode"`
+	ImplementationState   string                     `json:"implementation_state"`
+	Driver                string                     `json:"driver,omitempty"`
+	URLs                  []string                   `json:"urls,omitempty"`
+	Topic                 string                     `json:"topic,omitempty"`
+	ConsumerGroup         string                     `json:"consumer_group,omitempty"`
+	PublishTimeout        string                     `json:"publish_timeout,omitempty"`
+	ReplayLimit           int                        `json:"replay_limit,omitempty"`
+	CheckpointInterval    string                     `json:"checkpoint_interval,omitempty"`
+	Ready                 bool                       `json:"ready"`
+	ValidationErrors      []string                   `json:"validation_errors,omitempty"`
+	Capabilities          BackendCapabilities        `json:"capabilities"`
+	OrderingScope         string                     `json:"ordering_scope"`
+	PortablePositionKeys  []string                   `json:"portable_position_keys"`
+	FailureModes          []BrokerFailureModeSummary `json:"failure_modes"`
+	VerificationArtifacts []string                   `json:"verification_artifacts"`
+}
+
 type DurabilityPlan struct {
 	Current              DurabilityProfile      `json:"current"`
 	Target               DurabilityProfile      `json:"target"`
@@ -61,6 +86,7 @@ type DurabilityPlan struct {
 	FailureDomains       []FailureDomain        `json:"failure_domains"`
 	VerificationEvidence []VerificationEvidence `json:"verification_evidence"`
 	BrokerBootstrap      *BrokerBootstrapStatus `json:"broker_bootstrap,omitempty"`
+	BrokerProbe          *BrokerAdapterDryRun   `json:"broker_probe,omitempty"`
 }
 
 func NormalizeDurabilityBackend(value string) DurabilityBackend {
@@ -217,6 +243,7 @@ func NewDurabilityPlanWithBrokerConfig(currentBackend, targetBackend string, rep
 	}
 	if current.Replicated || target.Replicated {
 		plan.BrokerBootstrap = BrokerBootstrapStatusFromConfig(broker)
+		plan.BrokerProbe = BrokerAdapterDryRunFromConfig(broker)
 	}
 	return plan
 }
@@ -231,10 +258,87 @@ func BrokerBootstrapStatusFromConfig(cfg BrokerRuntimeConfig) *BrokerBootstrapSt
 		ReplayLimit:        cfg.ReplayLimit,
 		CheckpointInterval: cfg.CheckpointInterval.String(),
 	}
-	if err := cfg.Validate(); err != nil {
-		status.ValidationErrors = []string{err.Error()}
+	if issues := cfg.ValidationErrors(); len(issues) > 0 {
+		status.ValidationErrors = issues
 		return status
 	}
 	status.Ready = true
 	return status
+}
+
+func BrokerAdapterDryRunFromConfig(cfg BrokerRuntimeConfig) *BrokerAdapterDryRun {
+	probe := &BrokerAdapterDryRun{
+		Mode:                "dry_run",
+		ImplementationState: "planned_only",
+		Driver:              strings.TrimSpace(cfg.Driver),
+		URLs:                append([]string(nil), cfg.URLs...),
+		Topic:               strings.TrimSpace(cfg.Topic),
+		ConsumerGroup:       strings.TrimSpace(cfg.ConsumerGroup),
+		PublishTimeout:      cfg.PublishTimeout.String(),
+		ReplayLimit:         cfg.ReplayLimit,
+		CheckpointInterval:  cfg.CheckpointInterval.String(),
+		Capabilities: BackendCapabilities{
+			Backend: "broker_adapter",
+			Scope:   "provider_contract",
+			Publish: FeatureSupport{
+				Supported: true,
+				Mode:      "replicated_ack_required",
+				Detail:    "Success is expected to mean replicated commit acknowledgement rather than leader-local enqueue.",
+			},
+			Replay: FeatureSupport{
+				Supported: true,
+				Mode:      "portable_sequence_cursor",
+				Detail:    "Replay is expected to map provider offsets back to Position.Sequence for resume safety.",
+			},
+			Checkpoint: FeatureSupport{
+				Supported: true,
+				Mode:      "durable_consumer_progress",
+				Detail:    "Checkpoint writes must stay monotonic in the durable sequence space across failover.",
+			},
+			Dedup: FeatureSupport{
+				Supported: false,
+				Detail:    "Consumer dedup persistence remains a separate contract from the broker event-log adapter.",
+			},
+			Filtering: FeatureSupport{
+				Supported: true,
+				Mode:      "derived_task_trace_filters",
+				Detail:    "Task and trace filtering must remain stable across replay even if the provider exposes different native selectors.",
+			},
+			Retention: FeatureSupport{
+				Supported: true,
+				Mode:      "retention_boundary_visible",
+				Detail:    "The adapter must expose oldest/newest retained replay boundaries before resumable recovery is claimed.",
+			},
+		},
+		OrderingScope:        "partition or quorum log order",
+		PortablePositionKeys: []string{"sequence", "partition", "offset"},
+		FailureModes: []BrokerFailureModeSummary{
+			{
+				Name:       "ambiguous_publish_outcome",
+				Summary:    "A leader crash or timeout can leave publish outcome unknown without replay-visible reconciliation.",
+				Mitigation: "Require replicated acknowledgements and surface unknown-commit outcomes explicitly.",
+			},
+			{
+				Name:       "checkpoint_fencing_gap",
+				Summary:    "Consumer takeover can regress durable progress if stale writers are not fenced.",
+				Mitigation: "Persist checkpoint sequence with lease or epoch metadata and reject stale writes.",
+			},
+			{
+				Name:       "retention_boundary_drift",
+				Summary:    "Expired checkpoints can appear structurally valid after compaction even when the log window moved forward.",
+				Mitigation: "Expose retention boundaries and fail closed until an operator chooses a reset action.",
+			},
+		},
+		VerificationArtifacts: []string{
+			"docs/reports/broker-event-log-adapter-contract.md",
+			"docs/reports/replicated-event-log-durability-rollout-contract.md",
+			"docs/reports/broker-failover-fault-injection-validation-pack.md",
+		},
+	}
+	if issues := cfg.ValidationErrors(); len(issues) > 0 {
+		probe.ValidationErrors = issues
+		return probe
+	}
+	probe.Ready = true
+	return probe
 }

--- a/bigclaw-go/internal/events/durability_test.go
+++ b/bigclaw-go/internal/events/durability_test.go
@@ -54,4 +54,36 @@ func TestNewDurabilityPlanWithBrokerConfigIncludesBootstrapStatus(t *testing.T) 
 	if plan.BrokerBootstrap.ReplayLimit != 2048 || plan.BrokerBootstrap.CheckpointInterval != "15s" {
 		t.Fatalf("unexpected broker bootstrap timings: %+v", plan.BrokerBootstrap)
 	}
+	if plan.BrokerProbe == nil {
+		t.Fatal("expected broker dry-run probe")
+	}
+	if plan.BrokerProbe.Mode != "dry_run" || !plan.BrokerProbe.Ready {
+		t.Fatalf("expected ready dry-run probe, got %+v", plan.BrokerProbe)
+	}
+	if plan.BrokerProbe.Capabilities.Publish.Mode != "replicated_ack_required" {
+		t.Fatalf("unexpected broker publish capability: %+v", plan.BrokerProbe.Capabilities.Publish)
+	}
+	if len(plan.BrokerProbe.FailureModes) != 3 {
+		t.Fatalf("expected broker failure mode summaries, got %+v", plan.BrokerProbe.FailureModes)
+	}
+}
+
+func TestNewDurabilityPlanWithInvalidBrokerConfigSurfacesProbeErrors(t *testing.T) {
+	plan := NewDurabilityPlanWithBrokerConfig("memory", "broker_replicated", 3, BrokerRuntimeConfig{})
+
+	if plan.BrokerBootstrap == nil || plan.BrokerBootstrap.Ready {
+		t.Fatalf("expected bootstrap status to stay unready, got %+v", plan.BrokerBootstrap)
+	}
+	if len(plan.BrokerBootstrap.ValidationErrors) < 3 {
+		t.Fatalf("expected detailed bootstrap validation errors, got %+v", plan.BrokerBootstrap)
+	}
+	if plan.BrokerProbe == nil || plan.BrokerProbe.Ready {
+		t.Fatalf("expected dry-run probe to stay unready, got %+v", plan.BrokerProbe)
+	}
+	if len(plan.BrokerProbe.ValidationErrors) < 3 {
+		t.Fatalf("expected probe validation errors, got %+v", plan.BrokerProbe)
+	}
+	if plan.BrokerProbe.Capabilities.Replay.Mode != "portable_sequence_cursor" {
+		t.Fatalf("expected portable replay capability contract, got %+v", plan.BrokerProbe.Capabilities.Replay)
+	}
 }

--- a/bigclaw-go/internal/events/log.go
+++ b/bigclaw-go/internal/events/log.go
@@ -78,28 +78,33 @@ type BrokerRuntimeConfig struct {
 	CheckpointInterval time.Duration
 }
 
-func (cfg BrokerRuntimeConfig) Validate() error {
-	missing := make([]string, 0, 3)
+func (cfg BrokerRuntimeConfig) ValidationErrors() []string {
+	var issues []string
 	if strings.TrimSpace(cfg.Driver) == "" {
-		missing = append(missing, "driver")
+		issues = append(issues, "broker event log config missing driver")
 	}
 	if len(cfg.URLs) == 0 {
-		missing = append(missing, "urls")
+		issues = append(issues, "broker event log config missing urls")
 	}
 	if strings.TrimSpace(cfg.Topic) == "" {
-		missing = append(missing, "topic")
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("broker event log config missing %s", strings.Join(missing, ", "))
+		issues = append(issues, "broker event log config missing topic")
 	}
 	if cfg.PublishTimeout <= 0 {
-		return fmt.Errorf("broker event log publish timeout must be positive")
+		issues = append(issues, "broker event log publish timeout must be positive")
 	}
 	if cfg.ReplayLimit <= 0 {
-		return fmt.Errorf("broker event log replay limit must be positive")
+		issues = append(issues, "broker event log replay limit must be positive")
 	}
 	if cfg.CheckpointInterval <= 0 {
-		return fmt.Errorf("broker event log checkpoint interval must be positive")
+		issues = append(issues, "broker event log checkpoint interval must be positive")
+	}
+	return issues
+}
+
+func (cfg BrokerRuntimeConfig) Validate() error {
+	issues := cfg.ValidationErrors()
+	if len(issues) > 0 {
+		return fmt.Errorf(strings.Join(issues, "; "))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- add a broker dry-run probe to the event durability plan so debug payloads expose config validation and provider capability expectations before a live adapter exists
- surface detailed broker config validation errors for bootstrap and dry-run reporting
- document the new operator-facing probe and cover it with API and durability tests