### PR TITLE
OPE-226: add expired replay checkpoint diagnostics

### DIFF
--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -76,7 +77,7 @@ func (s *Server) Handler() http.Handler {
 		subscriberID := strings.TrimSpace(r.URL.Query().Get("subscriber_id"))
 		afterID, err := s.resolveAfterID(subscriberID, replayCursorFromRequest(r))
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writeCheckpointDiagnosticError(w, err)
 			return
 		}
 		eventTypes := parseEventTypes(r.URL.Query()["event_type"])
@@ -538,11 +539,15 @@ func (s *Server) handleStreamEventCheckpoint(w http.ResponseWriter, r *http.Requ
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{
+		response := map[string]any{
 			"checkpoint": checkpoint,
 			"backend":    s.eventLogBackend(),
 			"durable":    s.eventLogDurable(),
-		})
+		}
+		if diagnostic := s.checkpointDiagnostic(subscriberID); diagnostic != nil {
+			response["diagnostic"] = diagnostic
+		}
+		writeJSON(w, http.StatusOK, response)
 	case http.MethodPost:
 		var payload struct {
 			EventID string `json:"event_id"`
@@ -560,11 +565,15 @@ func (s *Server) handleStreamEventCheckpoint(w http.ResponseWriter, r *http.Requ
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		writeJSON(w, http.StatusOK, map[string]any{
+		response := map[string]any{
 			"checkpoint": checkpoint,
 			"backend":    s.eventLogBackend(),
 			"durable":    s.eventLogDurable(),
-		})
+		}
+		if diagnostic := s.checkpointDiagnostic(subscriberID); diagnostic != nil {
+			response["diagnostic"] = diagnostic
+		}
+		writeJSON(w, http.StatusOK, response)
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
@@ -581,7 +590,7 @@ func (s *Server) handleStreamEvents(w http.ResponseWriter, r *http.Request) {
 	subscriberID := strings.TrimSpace(r.URL.Query().Get("subscriber_id"))
 	afterID, err := s.resolveAfterID(subscriberID, replayCursorFromRequest(r))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
+		writeCheckpointDiagnosticError(w, err)
 		return
 	}
 	eventTypes := parseEventTypes(r.URL.Query()["event_type"])
@@ -818,7 +827,51 @@ func (s *Server) resolveAfterID(subscriberID string, afterID string) (string, er
 		}
 		return "", err
 	}
+	if provider, ok := any(store).(events.CheckpointDiagnosticProvider); ok {
+		diagnostic, err := provider.CheckpointDiagnostic(subscriberID)
+		if err != nil {
+			if events.IsNoEventLog(err) {
+				return "", nil
+			}
+			return "", err
+		}
+		if diagnostic.Status != "" && diagnostic.Status != "ok" {
+			return "", &events.CheckpointDiagnosticError{Diagnostic: diagnostic}
+		}
+	}
 	return checkpoint.EventID, nil
+}
+
+func (s *Server) checkpointDiagnostic(subscriberID string) any {
+	store := s.checkpointStore()
+	if store == nil {
+		return nil
+	}
+	provider, ok := any(store).(events.CheckpointDiagnosticProvider)
+	if !ok {
+		return nil
+	}
+	diagnostic, err := provider.CheckpointDiagnostic(subscriberID)
+	if err != nil {
+		return nil
+	}
+	return diagnostic
+}
+
+func writeCheckpointDiagnosticError(w http.ResponseWriter, err error) {
+	var diagnosticErr *events.CheckpointDiagnosticError
+	if !errors.As(err, &diagnosticErr) {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	status := http.StatusConflict
+	if diagnosticErr.Diagnostic.Status == "expired" {
+		status = http.StatusGone
+	}
+	writeJSON(w, status, map[string]any{
+		"error":      err.Error(),
+		"diagnostic": diagnosticErr.Diagnostic,
+	})
 }
 
 func parseEventTypes(values []string) []domain.EventType {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -2560,12 +2560,16 @@ func TestStreamEventCheckpointEndpointAndResume(t *testing.T) {
 	}
 	var checkpointDecoded struct {
 		Checkpoint events.SubscriberCheckpoint `json:"checkpoint"`
+		Diagnostic events.CheckpointDiagnostic `json:"diagnostic"`
 	}
 	if err := json.Unmarshal(checkpointResponse.Body.Bytes(), &checkpointDecoded); err != nil {
 		t.Fatalf("decode checkpoint response: %v", err)
 	}
 	if checkpointDecoded.Checkpoint.EventID != "evt-check-1" || checkpointDecoded.Checkpoint.SubscriberID != "subscriber-a" {
 		t.Fatalf("unexpected checkpoint payload: %+v", checkpointDecoded.Checkpoint)
+	}
+	if checkpointDecoded.Diagnostic.Status != "ok" || checkpointDecoded.Diagnostic.Reason != "checkpoint_retained" {
+		t.Fatalf("expected retained checkpoint diagnostic, got %+v", checkpointDecoded.Diagnostic)
 	}
 	if err := log1.Close(); err != nil {
 		t.Fatalf("close first sqlite event log: %v", err)
@@ -2620,6 +2624,103 @@ func TestStreamEventCheckpointEndpointAndResume(t *testing.T) {
 		}
 	case <-ctx.Done():
 		t.Fatal("timed out waiting for checkpoint-resumed SSE event")
+	}
+}
+
+func TestEventsEndpointReturnsExpiredCheckpointDiagnosticForSubscriberResume(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	logPath := filepath.Join(t.TempDir(), "event-log.db")
+	store, err := events.NewSQLiteEventLogWithOptions(logPath, events.SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base },
+	})
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.Write(context.Background(), domain.Event{ID: "evt-expired-old", Type: domain.EventTaskQueued, TaskID: "task-expired", TraceID: "trace-expired", Timestamp: base}); err != nil {
+		t.Fatalf("write old event: %v", err)
+	}
+	if _, err := store.Acknowledge("subscriber-expired", "evt-expired-old", base.Add(time.Second)); err != nil {
+		t.Fatalf("acknowledge expired checkpoint: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close initial sqlite event log: %v", err)
+	}
+	storeNow := base.Add(4 * time.Second)
+	storeNowFn := func() time.Time { return storeNow }
+	store, err = events.NewSQLiteEventLogWithOptions(logPath, events.SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       storeNowFn,
+	})
+	if err != nil {
+		t.Fatalf("reopen sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.Write(context.Background(), domain.Event{ID: "evt-expired-new", Type: domain.EventTaskStarted, TaskID: "task-expired", TraceID: "trace-expired", Timestamp: storeNow}); err != nil {
+		t.Fatalf("write retained event: %v", err)
+	}
+	server := &Server{Recorder: observability.NewRecorder(), Queue: queue.NewMemoryQueue(), Bus: events.NewBus(), EventLog: store, Now: time.Now}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/events?subscriber_id=subscriber-expired&trace_id=trace-expired&limit=10", nil)
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusGone {
+		t.Fatalf("expected expired checkpoint to return 410, got %d %s", response.Code, response.Body.String())
+	}
+	var decoded struct {
+		Error      string                      `json:"error"`
+		Diagnostic events.CheckpointDiagnostic `json:"diagnostic"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode expired checkpoint response: %v", err)
+	}
+	if decoded.Diagnostic.Status != "expired" || decoded.Diagnostic.Reason != "checkpoint_expired" {
+		t.Fatalf("expected expired diagnostic payload, got %+v", decoded.Diagnostic)
+	}
+	if decoded.Diagnostic.ResetAction == nil || decoded.Diagnostic.ResetAction.EarliestRetainedEventID != "evt-expired-new" {
+		t.Fatalf("expected reset guidance in expired response, got %+v", decoded.Diagnostic.ResetAction)
+	}
+}
+
+func TestStreamEventsReturnsExpiredCheckpointDiagnosticForSubscriberResume(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	logPath := filepath.Join(t.TempDir(), "event-log.db")
+	store, err := events.NewSQLiteEventLogWithOptions(logPath, events.SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base },
+	})
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	if err := store.Write(context.Background(), domain.Event{ID: "evt-stream-expired-old", Type: domain.EventTaskQueued, TaskID: "task-stream-expired", TraceID: "trace-stream-expired", Timestamp: base}); err != nil {
+		t.Fatalf("write old event: %v", err)
+	}
+	if _, err := store.Acknowledge("subscriber-stream-expired", "evt-stream-expired-old", base.Add(time.Second)); err != nil {
+		t.Fatalf("ack old event: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close initial sqlite event log: %v", err)
+	}
+	store, err = events.NewSQLiteEventLogWithOptions(logPath, events.SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base.Add(4 * time.Second) },
+	})
+	if err != nil {
+		t.Fatalf("reopen sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	if err := store.Write(context.Background(), domain.Event{ID: "evt-stream-expired-new", Type: domain.EventTaskStarted, TaskID: "task-stream-expired", TraceID: "trace-stream-expired", Timestamp: base.Add(4 * time.Second)}); err != nil {
+		t.Fatalf("write retained event: %v", err)
+	}
+	server := &Server{Recorder: observability.NewRecorder(), Queue: queue.NewMemoryQueue(), Bus: events.NewBus(), EventLog: store, Now: time.Now}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/stream/events?subscriber_id=subscriber-stream-expired&trace_id=trace-stream-expired&limit=10", nil)
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusGone {
+		t.Fatalf("expected expired stream checkpoint to return 410, got %d %s", response.Code, response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"status\":\"expired\"") || !strings.Contains(response.Body.String(), "\"reset_action\"") {
+		t.Fatalf("expected expired stream diagnostic payload, got %s", response.Body.String())
 	}
 }
 

--- a/bigclaw-go/internal/events/checkpoints.go
+++ b/bigclaw-go/internal/events/checkpoints.go
@@ -1,14 +1,76 @@
 package events
 
-import "time"
+import (
+	"errors"
+	"fmt"
+	"time"
+)
 
 type SubscriberCheckpoint struct {
-	SubscriberID string    `json:"subscriber_id"`
-	EventID      string    `json:"event_id"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	SubscriberID  string    `json:"subscriber_id"`
+	EventID       string    `json:"event_id"`
+	EventSequence int64     `json:"event_sequence,omitempty"`
+	UpdatedAt     time.Time `json:"updated_at"`
 }
 
 type CheckpointStore interface {
 	Acknowledge(subscriberID string, eventID string, at time.Time) (SubscriberCheckpoint, error)
 	Checkpoint(subscriberID string) (SubscriberCheckpoint, error)
+}
+
+type CheckpointDiagnosticProvider interface {
+	CheckpointDiagnostic(subscriberID string) (CheckpointDiagnostic, error)
+}
+
+type CheckpointDiagnostic struct {
+	SubscriberID       string                 `json:"subscriber_id"`
+	Backend            string                 `json:"backend,omitempty"`
+	Status             string                 `json:"status"`
+	Reason             string                 `json:"reason,omitempty"`
+	Checkpoint         *SubscriberCheckpoint  `json:"checkpoint,omitempty"`
+	RetentionWatermark *RetentionWatermark    `json:"retention_watermark,omitempty"`
+	ResetAction        *CheckpointResetAction `json:"reset_action,omitempty"`
+}
+
+type CheckpointResetAction struct {
+	Action                  string `json:"action"`
+	Scope                   string `json:"scope,omitempty"`
+	EarliestRetainedEventID string `json:"earliest_retained_event_id,omitempty"`
+	LatestRetainedEventID   string `json:"latest_retained_event_id,omitempty"`
+	Message                 string `json:"message,omitempty"`
+}
+
+type CheckpointDiagnosticError struct {
+	Diagnostic CheckpointDiagnostic
+}
+
+func (e *CheckpointDiagnosticError) Error() string {
+	if e == nil {
+		return ""
+	}
+	subscriberID := e.Diagnostic.SubscriberID
+	if subscriberID == "" && e.Diagnostic.Checkpoint != nil {
+		subscriberID = e.Diagnostic.Checkpoint.SubscriberID
+	}
+	if subscriberID == "" {
+		subscriberID = "unknown"
+	}
+	switch e.Diagnostic.Status {
+	case "expired":
+		return fmt.Sprintf("subscriber checkpoint expired for %s", subscriberID)
+	case "missing":
+		return fmt.Sprintf("subscriber checkpoint missing retained event for %s", subscriberID)
+	default:
+		return fmt.Sprintf("subscriber checkpoint unavailable for %s", subscriberID)
+	}
+}
+
+func IsCheckpointDiagnostic(err error) bool {
+	var target *CheckpointDiagnosticError
+	return errors.As(err, &target)
+}
+
+func IsExpiredCheckpoint(err error) bool {
+	var target *CheckpointDiagnosticError
+	return errors.As(err, &target) && target.Diagnostic.Status == "expired"
 }

--- a/bigclaw-go/internal/events/http_log.go
+++ b/bigclaw-go/internal/events/http_log.go
@@ -31,6 +31,10 @@ type checkpointResponse struct {
 	Checkpoint SubscriberCheckpoint `json:"checkpoint"`
 }
 
+type checkpointDiagnosticResponse struct {
+	Diagnostic CheckpointDiagnostic `json:"diagnostic"`
+}
+
 type remoteEventsResponse struct {
 	Events []domain.Event `json:"events"`
 }
@@ -123,6 +127,15 @@ func (s *HTTPEventLog) Checkpoint(subscriberID string) (SubscriberCheckpoint, er
 		return SubscriberCheckpoint{}, mapRemoteEventLogError(err)
 	}
 	return response.Checkpoint, nil
+}
+
+func (s *HTTPEventLog) CheckpointDiagnostic(subscriberID string) (CheckpointDiagnostic, error) {
+	var response checkpointDiagnosticResponse
+	err := s.doJSON(context.Background(), http.MethodGet, "/checkpoints/"+url.PathEscape(strings.TrimSpace(subscriberID))+"/diagnostic", nil, &response)
+	if err != nil {
+		return CheckpointDiagnostic{}, mapRemoteEventLogError(err)
+	}
+	return response.Diagnostic, nil
 }
 
 func (s *HTTPEventLog) RetentionWatermark() (RetentionWatermark, error) {

--- a/bigclaw-go/internal/events/http_log_test.go
+++ b/bigclaw-go/internal/events/http_log_test.go
@@ -120,3 +120,41 @@ func TestHTTPEventLogReadsPersistedRetentionBoundaryFromService(t *testing.T) {
 		t.Fatalf("expected retained remote event window, got %+v", watermark)
 	}
 }
+
+func TestHTTPEventLogReadsExpiredCheckpointDiagnosticFromService(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	store, err := NewSQLiteEventLogWithOptions(filepath.Join(t.TempDir(), "event-log.db"), SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base },
+	})
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	server := httptest.NewServer(NewEventLogServiceHandler(store))
+	defer server.Close()
+	client, err := NewHTTPEventLog(server.URL, "")
+	if err != nil {
+		t.Fatalf("new http event log: %v", err)
+	}
+	if err := client.Write(context.Background(), domain.Event{ID: "evt-http-diagnostic-old", Type: domain.EventTaskQueued, TaskID: "task-http-diagnostic", TraceID: "trace-http-diagnostic", Timestamp: base}); err != nil {
+		t.Fatalf("write old remote event: %v", err)
+	}
+	if _, err := client.Acknowledge("subscriber-http-diagnostic", "evt-http-diagnostic-old", base.Add(time.Second)); err != nil {
+		t.Fatalf("ack remote checkpoint: %v", err)
+	}
+	store.now = func() time.Time { return base.Add(4 * time.Second) }
+	if err := client.Write(context.Background(), domain.Event{ID: "evt-http-diagnostic-new", Type: domain.EventTaskStarted, TaskID: "task-http-diagnostic", TraceID: "trace-http-diagnostic", Timestamp: base.Add(4 * time.Second)}); err != nil {
+		t.Fatalf("write new remote event: %v", err)
+	}
+	diagnostic, err := client.CheckpointDiagnostic("subscriber-http-diagnostic")
+	if err != nil {
+		t.Fatalf("read remote checkpoint diagnostic: %v", err)
+	}
+	if diagnostic.Status != "expired" || diagnostic.Reason != "checkpoint_expired" {
+		t.Fatalf("expected expired checkpoint diagnostic, got %+v", diagnostic)
+	}
+	if diagnostic.ResetAction == nil || diagnostic.ResetAction.EarliestRetainedEventID != "evt-http-diagnostic-new" {
+		t.Fatalf("expected reset action in remote diagnostic, got %+v", diagnostic.ResetAction)
+	}
+}

--- a/bigclaw-go/internal/events/log_service.go
+++ b/bigclaw-go/internal/events/log_service.go
@@ -72,7 +72,52 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 		writeEventLogJSON(w, http.StatusOK, map[string]any{"events": history})
 	})
 	mux.HandleFunc("/checkpoints/", func(w http.ResponseWriter, r *http.Request) {
-		subscriberID := strings.TrimPrefix(r.URL.Path, "/checkpoints/")
+		subscriberPath := strings.TrimPrefix(r.URL.Path, "/checkpoints/")
+		if strings.HasSuffix(subscriberPath, "/diagnostic") {
+			subscriberID := strings.TrimSuffix(subscriberPath, "/diagnostic")
+			subscriberID = strings.TrimSuffix(subscriberID, "/")
+			if subscriberID == "" {
+				http.Error(w, "missing subscriber id", http.StatusBadRequest)
+				return
+			}
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			provider, ok := any(store).(CheckpointDiagnosticProvider)
+			if !ok {
+				checkpoint, err := store.Checkpoint(subscriberID)
+				if err != nil {
+					if IsNoEventLog(err) {
+						http.Error(w, "checkpoint not found", http.StatusNotFound)
+						return
+					}
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				writeEventLogJSON(w, http.StatusOK, map[string]any{
+					"diagnostic": CheckpointDiagnostic{
+						SubscriberID: subscriberID,
+						Status:       "ok",
+						Reason:       "checkpoint_retained",
+						Checkpoint:   &checkpoint,
+					},
+				})
+				return
+			}
+			diagnostic, err := provider.CheckpointDiagnostic(subscriberID)
+			if err != nil {
+				if IsNoEventLog(err) {
+					http.Error(w, "checkpoint not found", http.StatusNotFound)
+					return
+				}
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			writeEventLogJSON(w, http.StatusOK, map[string]any{"diagnostic": diagnostic})
+			return
+		}
+		subscriberID := subscriberPath
 		if subscriberID == "" {
 			http.Error(w, "missing subscriber id", http.StatusBadRequest)
 			return
@@ -107,7 +152,14 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
-			writeEventLogJSON(w, http.StatusOK, map[string]any{"checkpoint": checkpoint})
+			response := map[string]any{"checkpoint": checkpoint}
+			if provider, ok := any(store).(CheckpointDiagnosticProvider); ok {
+				diagnostic, diagErr := provider.CheckpointDiagnostic(subscriberID)
+				if diagErr == nil {
+					response["diagnostic"] = diagnostic
+				}
+			}
+			writeEventLogJSON(w, http.StatusOK, response)
 		default:
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 		}

--- a/bigclaw-go/internal/events/sqlite_log.go
+++ b/bigclaw-go/internal/events/sqlite_log.go
@@ -262,14 +262,50 @@ func (s *SQLiteEventLog) Checkpoint(subscriberID string) (SubscriberCheckpoint, 
 	if s == nil || s.db == nil {
 		return SubscriberCheckpoint{}, sql.ErrNoRows
 	}
-	row := s.db.QueryRow(`SELECT subscriber_id, event_id, updated_at_ns FROM subscriber_checkpoint WHERE subscriber_id = ?`, subscriberID)
+	row := s.db.QueryRow(`SELECT subscriber_id, event_id, event_seq, updated_at_ns FROM subscriber_checkpoint WHERE subscriber_id = ?`, subscriberID)
 	var checkpoint SubscriberCheckpoint
 	var updatedAtNS int64
-	if err := row.Scan(&checkpoint.SubscriberID, &checkpoint.EventID, &updatedAtNS); err != nil {
+	if err := row.Scan(&checkpoint.SubscriberID, &checkpoint.EventID, &checkpoint.EventSequence, &updatedAtNS); err != nil {
 		return SubscriberCheckpoint{}, err
 	}
 	checkpoint.UpdatedAt = time.Unix(0, updatedAtNS).UTC()
 	return checkpoint, nil
+}
+
+func (s *SQLiteEventLog) CheckpointDiagnostic(subscriberID string) (CheckpointDiagnostic, error) {
+	checkpoint, err := s.Checkpoint(subscriberID)
+	if err != nil {
+		return CheckpointDiagnostic{}, err
+	}
+	watermark, err := s.RetentionWatermark()
+	if err != nil {
+		return CheckpointDiagnostic{}, err
+	}
+	diagnostic := CheckpointDiagnostic{
+		SubscriberID:       subscriberID,
+		Backend:            s.Backend(),
+		Status:             "ok",
+		Reason:             "checkpoint_retained",
+		Checkpoint:         &checkpoint,
+		RetentionWatermark: &watermark,
+	}
+	_, ok, err := s.lookupSequenceForEventID(checkpoint.EventID)
+	if err != nil {
+		return CheckpointDiagnostic{}, err
+	}
+	if ok {
+		return diagnostic, nil
+	}
+	if checkpoint.EventSequence > 0 && watermark.TrimmedThroughSequence >= checkpoint.EventSequence {
+		diagnostic.Status = "expired"
+		diagnostic.Reason = "checkpoint_expired"
+		diagnostic.ResetAction = checkpointResetAction(watermark)
+		return diagnostic, nil
+	}
+	diagnostic.Status = "missing"
+	diagnostic.Reason = "checkpoint_event_missing"
+	diagnostic.ResetAction = checkpointResetAction(watermark)
+	return diagnostic, nil
 }
 
 func (s *SQLiteEventLog) queryAfter(base string, args []any, afterID string, limit int) ([]domain.Event, error) {
@@ -468,7 +504,18 @@ func reverseEvents(events []domain.Event) {
 
 var _ EventLog = (*SQLiteEventLog)(nil)
 var _ CheckpointStore = (*SQLiteEventLog)(nil)
+var _ CheckpointDiagnosticProvider = (*SQLiteEventLog)(nil)
 
 func IsNoEventLog(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)
+}
+
+func checkpointResetAction(watermark RetentionWatermark) *CheckpointResetAction {
+	return &CheckpointResetAction{
+		Action:                  "reset_checkpoint",
+		Scope:                   "subscriber",
+		EarliestRetainedEventID: watermark.OldestEventID,
+		LatestRetainedEventID:   watermark.NewestEventID,
+		Message:                 "Reset the subscriber checkpoint to a retained event or clear it before retrying replay.",
+	}
 }

--- a/bigclaw-go/internal/events/sqlite_log_test.go
+++ b/bigclaw-go/internal/events/sqlite_log_test.go
@@ -228,3 +228,41 @@ func TestSQLiteEventLogRetentionBoundaryPersistsAcrossInstances(t *testing.T) {
 		t.Fatalf("expected retained replay window after reopen, got %+v", replayed)
 	}
 }
+
+func TestSQLiteEventLogCheckpointDiagnosticExpiresTrimmedCheckpoint(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	log, err := NewSQLiteEventLogWithOptions(filepath.Join(t.TempDir(), "event-log.db"), SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base },
+	})
+	if err != nil {
+		t.Fatalf("new sqlite event log with retention: %v", err)
+	}
+	defer func() { _ = log.Close() }()
+	if err := log.Write(context.Background(), domain.Event{ID: "evt-diagnostic-old", Type: domain.EventTaskQueued, TaskID: "task-diagnostic", TraceID: "trace-diagnostic", Timestamp: base}); err != nil {
+		t.Fatalf("write old event: %v", err)
+	}
+	if _, err := log.Acknowledge("subscriber-diagnostic", "evt-diagnostic-old", base.Add(500*time.Millisecond)); err != nil {
+		t.Fatalf("acknowledge old event: %v", err)
+	}
+	log.now = func() time.Time { return base.Add(4 * time.Second) }
+	if err := log.Write(context.Background(), domain.Event{ID: "evt-diagnostic-new", Type: domain.EventTaskStarted, TaskID: "task-diagnostic", TraceID: "trace-diagnostic", Timestamp: base.Add(4 * time.Second)}); err != nil {
+		t.Fatalf("write new event: %v", err)
+	}
+	diagnostic, err := log.CheckpointDiagnostic("subscriber-diagnostic")
+	if err != nil {
+		t.Fatalf("checkpoint diagnostic: %v", err)
+	}
+	if diagnostic.Status != "expired" || diagnostic.Reason != "checkpoint_expired" {
+		t.Fatalf("expected expired checkpoint diagnostic, got %+v", diagnostic)
+	}
+	if diagnostic.Checkpoint == nil || diagnostic.Checkpoint.EventID != "evt-diagnostic-old" || diagnostic.Checkpoint.EventSequence == 0 {
+		t.Fatalf("expected checkpoint metadata in diagnostic, got %+v", diagnostic.Checkpoint)
+	}
+	if diagnostic.RetentionWatermark == nil || diagnostic.RetentionWatermark.OldestEventID != "evt-diagnostic-new" {
+		t.Fatalf("expected retained watermark context, got %+v", diagnostic.RetentionWatermark)
+	}
+	if diagnostic.ResetAction == nil || diagnostic.ResetAction.Action != "reset_checkpoint" || diagnostic.ResetAction.EarliestRetainedEventID != "evt-diagnostic-new" {
+		t.Fatalf("expected reset guidance in diagnostic, got %+v", diagnostic.ResetAction)
+	}
+}


### PR DESCRIPTION
## Summary
- add durable checkpoint diagnostic types with retention watermark context and reset guidance
- fail closed on expired subscriber checkpoint replay for API and remote event-log service flows
- cover SQLite, HTTP event-log, and API expired-checkpoint regressions

## Validation
- go test ./internal/events ./internal/api