### PR TITLE
OPE-228: add checkpoint reset audit history

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -13,7 +13,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Optional SSE replay and filtering via `replay=1`, `after_id`, `Last-Event-ID`, `task_id`, and `trace_id`
 - Replay cursor diagnostics via `X-Replay-*` headers and JSON `cursor` metadata on `GET /events`
 - Retention watermark / replay horizon visibility through API debug payloads and event-log service surfaces
-- Expired checkpoint diagnostics and checkpoint reset surface through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` plus conflict payloads on resume attempts
+- Expired checkpoint diagnostics, checkpoint reset, and operator-facing reset history through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` and `GET /stream/events/checkpoints/{subscriber_id}/history`
 - SQLite retention bootstrap with persisted truncation boundaries that survive process restarts when a replay window is configured
 - Replay-safe consumer delivery metadata via `EventDelivery`, including additive `delivery.mode`, `delivery.replay`, and `delivery.idempotency_key` fields
 - Consumer dedup ledger/result contract covering duplicate, retryable-failure, and already-applied outcomes
@@ -134,7 +134,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - No delivery acknowledgement protocol exists beyond sink-level best effort.
 - Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
-- Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
+- Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, expired checkpoint resumes fail closed with explicit reset guidance, and reset history now preserves prior checkpoint plus replay-boundary context for later audit; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
 

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -10,7 +10,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 
 - `Bus.SubscribeReplay` replays the tail of the in-memory append history before switching the subscriber to live events.
 - `GET /events`, `GET /replay/{id}`, and `GET /stream/events?replay=1` expose replay-oriented views over recorder history.
-- No durable retention watermark, checkpoint expiration signal, or history compaction rule exists yet.
+- Durable retention watermarks, checkpoint expiry diagnostics, and checkpoint reset audit history now exist for SQLite-backed and HTTP-backed event-log paths; broader cleanup policy is still evolving.
 
 ## Retention model
 
@@ -37,7 +37,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 ## Expired cursor fallback contract
 
 - Resume requests against aged-out checkpoints must surface an explicit expired-cursor result.
-- The current API surface now returns checkpoint diagnostics plus a reset path through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` when a saved cursor falls behind the retained boundary.
+- The current API surface now returns checkpoint diagnostics plus reset and history paths through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` and `GET /stream/events/checkpoints/{subscriber_id}/history` when a saved cursor falls behind the retained boundary.
 - The result should include the subscriber or lease identity, the requested checkpoint cursor, and the oldest/newest retained cursors that were available at evaluation time.
 - Operator-facing diagnostics should describe whether recovery can restart from the earliest retained event, from the latest live edge, or requires manual checkpoint reset.
 - Automatic fallback must be policy-driven. The default safe behavior is fail-closed with diagnostics rather than silently skipping truncated history.
@@ -45,7 +45,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 ## Cleanup path
 
 - Retention-aware checkpoint cleanup should only remove checkpoints that are both inactive and no longer useful for replay recovery.
-- Cleanup should record enough metadata to explain why a checkpoint disappeared, including inactivity age, lease status, and retention watermark at deletion time.
+- Reset-oriented cleanup now records prior checkpoint state, retention watermark context, request source, and optional operator identity so post-recovery review can reconstruct why a checkpoint disappeared.
 - A future durable backend should separate:
   - history retention policy,
   - checkpoint inactivity TTL,
@@ -63,7 +63,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 ## Forward path
 
 - `OPE-212` establishes the compaction and retention contract.
-- `OPE-216` established the expired replay cursor semantics, and `OPE-226` now adds the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes.
+- `OPE-216` established the expired replay cursor semantics, `OPE-226` added the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes, and `OPE-228` adds reset audit history for post-recovery operator review.
 - Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
 - SQLite-backed durable logs now persist trimmed replay boundaries across restarts when a retention window is configured, giving operators a stable replay horizon even after reboot.
 

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"sort"
 	"strconv"
@@ -545,9 +546,36 @@ func (s *Server) handleStreamEventCheckpoint(w http.ResponseWriter, r *http.Requ
 		http.Error(w, "checkpoint store unavailable", http.StatusServiceUnavailable)
 		return
 	}
-	subscriberID := strings.TrimPrefix(r.URL.Path, "/stream/events/checkpoints/")
+	path := strings.TrimPrefix(r.URL.Path, "/stream/events/checkpoints/")
+	historyRequest := strings.HasSuffix(path, "/history")
+	subscriberID := strings.TrimSuffix(path, "/history")
+	subscriberID = strings.TrimSuffix(subscriberID, "/")
 	if subscriberID == "" {
 		http.Error(w, "missing subscriber id", http.StatusBadRequest)
+		return
+	}
+	if historyRequest {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		historyProvider := s.checkpointResetHistoryProvider()
+		if historyProvider == nil {
+			http.Error(w, "checkpoint reset history unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+		history, err := historyProvider.CheckpointResetHistory(subscriberID, limit)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		writeJSON(w, http.StatusOK, map[string]any{
+			"subscriber_id": subscriberID,
+			"history":       history,
+			"backend":       s.eventLogBackend(),
+			"durable":       s.eventLogDurable(),
+		})
 		return
 	}
 	switch r.Method {
@@ -594,6 +622,41 @@ func (s *Server) handleStreamEventCheckpoint(w http.ResponseWriter, r *http.Requ
 			"durable":    s.eventLogDurable(),
 		})
 	case http.MethodDelete:
+		var request events.CheckpointResetRequest
+		if r.Body != nil {
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil && !errors.Is(err, io.EOF) {
+				http.Error(w, fmt.Sprintf("decode checkpoint reset: %v", err), http.StatusBadRequest)
+				return
+			}
+		}
+		request.RequestedBy = firstNonEmpty(request.RequestedBy, r.Header.Get("X-BigClaw-Operator"), r.Header.Get("X-Operator-ID"))
+		request.Source = firstNonEmpty(request.Source, "api:/stream/events/checkpoints")
+		if request.Reason == "" {
+			if checkpoint, err := store.Checkpoint(subscriberID); err == nil {
+				if diagnostics := s.checkpointDiagnosticsForCheckpoint(subscriberID, checkpoint); diagnostics != nil {
+					request.Reason = diagnostics.Reason
+				}
+			}
+		}
+		if manager := s.checkpointResetManager(); manager != nil {
+			record, err := manager.ResetCheckpointWithAudit(subscriberID, request)
+			if err != nil {
+				if events.IsNoEventLog(err) {
+					http.Error(w, "checkpoint not found", http.StatusNotFound)
+					return
+				}
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			writeJSON(w, http.StatusOK, map[string]any{
+				"subscriber_id": subscriberID,
+				"reset":         true,
+				"backend":       s.eventLogBackend(),
+				"durable":       s.eventLogDurable(),
+				"reset_audit":   record,
+			})
+			return
+		}
 		resetter := s.checkpointResetter()
 		if resetter == nil {
 			http.Error(w, "checkpoint reset unavailable", http.StatusServiceUnavailable)
@@ -817,6 +880,20 @@ func (s *Server) checkpointStore() events.CheckpointStore {
 func (s *Server) checkpointResetter() events.CheckpointResetter {
 	if resetter, ok := s.EventLog.(events.CheckpointResetter); ok {
 		return resetter
+	}
+	return nil
+}
+
+func (s *Server) checkpointResetManager() events.CheckpointResetManager {
+	if manager, ok := s.EventLog.(events.CheckpointResetManager); ok {
+		return manager
+	}
+	return nil
+}
+
+func (s *Server) checkpointResetHistoryProvider() events.CheckpointResetHistoryProvider {
+	if provider, ok := s.EventLog.(events.CheckpointResetHistoryProvider); ok {
+		return provider
 	}
 	return nil
 }

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -2789,9 +2789,23 @@ func TestStreamEventCheckpointExpiredDiagnosticsAndReset(t *testing.T) {
 
 	resetResponse := httptest.NewRecorder()
 	resetRequest := httptest.NewRequest(http.MethodDelete, "/stream/events/checkpoints/subscriber-expired", nil)
+	resetRequest.Header.Set("X-BigClaw-Operator", "operator-api")
 	server.Handler().ServeHTTP(resetResponse, resetRequest)
 	if resetResponse.Code != http.StatusOK {
 		t.Fatalf("expected checkpoint reset 200, got %d %s", resetResponse.Code, resetResponse.Body.String())
+	}
+	if !strings.Contains(resetResponse.Body.String(), "\"reset_audit\"") || !strings.Contains(resetResponse.Body.String(), "\"requested_by\":\"operator-api\"") || !strings.Contains(resetResponse.Body.String(), "\"reason\":\"checkpoint_before_retention_boundary\"") {
+		t.Fatalf("expected reset audit payload, got %s", resetResponse.Body.String())
+	}
+
+	historyResponse := httptest.NewRecorder()
+	historyRequest := httptest.NewRequest(http.MethodGet, "/stream/events/checkpoints/subscriber-expired/history?limit=10", nil)
+	server.Handler().ServeHTTP(historyResponse, historyRequest)
+	if historyResponse.Code != http.StatusOK {
+		t.Fatalf("expected checkpoint history 200, got %d %s", historyResponse.Code, historyResponse.Body.String())
+	}
+	if !strings.Contains(historyResponse.Body.String(), "\"history\"") || !strings.Contains(historyResponse.Body.String(), "\"requested_by\":\"operator-api\"") || !strings.Contains(historyResponse.Body.String(), "\"trimmed_through_event_id\":\"evt-expired-1\"") {
+		t.Fatalf("expected reset history payload, got %s", historyResponse.Body.String())
 	}
 
 	recoveredResponse := httptest.NewRecorder()
@@ -2808,5 +2822,14 @@ func TestStreamEventCheckpointExpiredDiagnosticsAndReset(t *testing.T) {
 	}
 	if len(recovered.Events) != 1 || recovered.Events[0].ID != "evt-expired-2" {
 		t.Fatalf("expected replay from earliest retained event after reset, got %+v", recovered.Events)
+	}
+
+	historyAfterRecovery := httptest.NewRecorder()
+	server.Handler().ServeHTTP(historyAfterRecovery, historyRequest)
+	if historyAfterRecovery.Code != http.StatusOK {
+		t.Fatalf("expected checkpoint history after recovery 200, got %d %s", historyAfterRecovery.Code, historyAfterRecovery.Body.String())
+	}
+	if !strings.Contains(historyAfterRecovery.Body.String(), "\"previous_checkpoint\"") || !strings.Contains(historyAfterRecovery.Body.String(), "\"evt-expired-1\"") {
+		t.Fatalf("expected reset history to remain visible after recovery, got %s", historyAfterRecovery.Body.String())
 	}
 }

--- a/bigclaw-go/internal/events/checkpoints.go
+++ b/bigclaw-go/internal/events/checkpoints.go
@@ -9,6 +9,22 @@ type SubscriberCheckpoint struct {
 	UpdatedAt     time.Time `json:"updated_at"`
 }
 
+type CheckpointResetRequest struct {
+	RequestedBy string `json:"requested_by,omitempty"`
+	Reason      string `json:"reason,omitempty"`
+	Source      string `json:"source,omitempty"`
+}
+
+type CheckpointResetRecord struct {
+	SubscriberID       string                `json:"subscriber_id"`
+	ResetAt            time.Time             `json:"reset_at"`
+	RequestedBy        string                `json:"requested_by,omitempty"`
+	Reason             string                `json:"reason,omitempty"`
+	Source             string                `json:"source,omitempty"`
+	PreviousCheckpoint *SubscriberCheckpoint `json:"previous_checkpoint,omitempty"`
+	RetentionWatermark *RetentionWatermark   `json:"retention_watermark,omitempty"`
+}
+
 type CheckpointStore interface {
 	Acknowledge(subscriberID string, eventID string, at time.Time) (SubscriberCheckpoint, error)
 	Checkpoint(subscriberID string) (SubscriberCheckpoint, error)
@@ -16,4 +32,12 @@ type CheckpointStore interface {
 
 type CheckpointResetter interface {
 	ResetCheckpoint(subscriberID string) error
+}
+
+type CheckpointResetManager interface {
+	ResetCheckpointWithAudit(subscriberID string, request CheckpointResetRequest) (CheckpointResetRecord, error)
+}
+
+type CheckpointResetHistoryProvider interface {
+	CheckpointResetHistory(subscriberID string, limit int) ([]CheckpointResetRecord, error)
 }

--- a/bigclaw-go/internal/events/http_log.go
+++ b/bigclaw-go/internal/events/http_log.go
@@ -31,6 +31,14 @@ type checkpointResponse struct {
 	Checkpoint SubscriberCheckpoint `json:"checkpoint"`
 }
 
+type checkpointResetResponse struct {
+	ResetAudit CheckpointResetRecord `json:"reset_audit"`
+}
+
+type checkpointResetHistoryResponse struct {
+	History []CheckpointResetRecord `json:"history"`
+}
+
 type remoteEventsResponse struct {
 	Events []domain.Event `json:"events"`
 }
@@ -126,11 +134,34 @@ func (s *HTTPEventLog) Checkpoint(subscriberID string) (SubscriberCheckpoint, er
 }
 
 func (s *HTTPEventLog) ResetCheckpoint(subscriberID string) error {
-	err := s.doJSON(context.Background(), http.MethodDelete, "/checkpoints/"+url.PathEscape(strings.TrimSpace(subscriberID)), nil, nil)
-	if err != nil {
-		return mapRemoteEventLogError(err)
+	_, err := s.ResetCheckpointWithAudit(subscriberID, CheckpointResetRequest{})
+	return err
+}
+
+func (s *HTTPEventLog) ResetCheckpointWithAudit(subscriberID string, request CheckpointResetRequest) (CheckpointResetRecord, error) {
+	var response checkpointResetResponse
+	var body any
+	if request != (CheckpointResetRequest{}) {
+		body = request
 	}
-	return nil
+	err := s.doJSON(context.Background(), http.MethodDelete, "/checkpoints/"+url.PathEscape(strings.TrimSpace(subscriberID)), body, &response)
+	if err != nil {
+		return CheckpointResetRecord{}, mapRemoteEventLogError(err)
+	}
+	return response.ResetAudit, nil
+}
+
+func (s *HTTPEventLog) CheckpointResetHistory(subscriberID string, limit int) ([]CheckpointResetRecord, error) {
+	path := "/checkpoints/" + url.PathEscape(strings.TrimSpace(subscriberID)) + "/history"
+	if limit > 0 {
+		path += "?limit=" + strconv.Itoa(limit)
+	}
+	var response checkpointResetHistoryResponse
+	err := s.doJSON(context.Background(), http.MethodGet, path, nil, &response)
+	if err != nil {
+		return nil, mapRemoteEventLogError(err)
+	}
+	return response.History, nil
 }
 
 func (s *HTTPEventLog) RetentionWatermark() (RetentionWatermark, error) {
@@ -265,3 +296,5 @@ func (e statusError) Error() string {
 var _ EventLog = (*HTTPEventLog)(nil)
 var _ CheckpointStore = (*HTTPEventLog)(nil)
 var _ CheckpointResetter = (*HTTPEventLog)(nil)
+var _ CheckpointResetManager = (*HTTPEventLog)(nil)
+var _ CheckpointResetHistoryProvider = (*HTTPEventLog)(nil)

--- a/bigclaw-go/internal/events/http_log_test.go
+++ b/bigclaw-go/internal/events/http_log_test.go
@@ -150,4 +150,62 @@ func TestHTTPEventLogResetsCheckpointThroughService(t *testing.T) {
 	if _, err := client.Checkpoint("subscriber-reset"); !IsNoEventLog(err) {
 		t.Fatalf("expected checkpoint to be cleared, got %v", err)
 	}
+	history, err := client.CheckpointResetHistory("subscriber-reset", 10)
+	if err != nil {
+		t.Fatalf("checkpoint reset history: %v", err)
+	}
+	if len(history) != 1 || history[0].PreviousCheckpoint == nil || history[0].PreviousCheckpoint.EventID != "evt-reset-1" {
+		t.Fatalf("unexpected checkpoint reset history: %+v", history)
+	}
+}
+
+func TestHTTPEventLogResetsCheckpointWithAuditMetadata(t *testing.T) {
+	base := time.Unix(1_700_000_000, 0).UTC()
+	logPath := filepath.Join(t.TempDir(), "event-log.db")
+	store, err := NewSQLiteEventLog(logPath)
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	for _, event := range []domain.Event{
+		{ID: "evt-reset-audit-1", Type: domain.EventTaskQueued, TaskID: "task-reset-audit", TraceID: "trace-reset-audit", Timestamp: base},
+		{ID: "evt-reset-audit-2", Type: domain.EventTaskStarted, TaskID: "task-reset-audit", TraceID: "trace-reset-audit", Timestamp: base.Add(3 * time.Second)},
+	} {
+		if err := store.Write(context.Background(), event); err != nil {
+			t.Fatalf("write reset audit event %s: %v", event.ID, err)
+		}
+	}
+	if _, err := store.Acknowledge("subscriber-reset-audit", "evt-reset-audit-1", base.Add(time.Second)); err != nil {
+		t.Fatalf("ack checkpoint: %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("close initial sqlite event log: %v", err)
+	}
+	store, err = NewSQLiteEventLogWithOptions(logPath, SQLiteEventLogOptions{
+		Retention: 2 * time.Second,
+		Now:       func() time.Time { return base.Add(4 * time.Second) },
+	})
+	if err != nil {
+		t.Fatalf("reopen sqlite event log with retention: %v", err)
+	}
+	defer func() { _ = store.Close() }()
+	server := httptest.NewServer(NewEventLogServiceHandler(store))
+	defer server.Close()
+	client, err := NewHTTPEventLog(server.URL, "")
+	if err != nil {
+		t.Fatalf("new http event log: %v", err)
+	}
+	record, err := client.ResetCheckpointWithAudit("subscriber-reset-audit", CheckpointResetRequest{
+		RequestedBy: "operator-http",
+		Reason:      "checkpoint_before_retention_boundary",
+		Source:      "api:/stream/events/checkpoints",
+	})
+	if err != nil {
+		t.Fatalf("reset checkpoint with audit: %v", err)
+	}
+	if record.RequestedBy != "operator-http" || record.PreviousCheckpoint == nil || record.PreviousCheckpoint.EventID != "evt-reset-audit-1" {
+		t.Fatalf("unexpected checkpoint reset audit record: %+v", record)
+	}
+	if record.RetentionWatermark == nil || record.RetentionWatermark.TrimmedThroughEventID != "evt-reset-audit-1" {
+		t.Fatalf("expected retention boundary in reset audit, got %+v", record.RetentionWatermark)
+	}
 }

--- a/bigclaw-go/internal/events/log_service.go
+++ b/bigclaw-go/internal/events/log_service.go
@@ -2,6 +2,8 @@ package events
 
 import (
 	"encoding/json"
+	"errors"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -72,9 +74,31 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 		writeEventLogJSON(w, http.StatusOK, map[string]any{"events": history})
 	})
 	mux.HandleFunc("/checkpoints/", func(w http.ResponseWriter, r *http.Request) {
-		subscriberID := strings.TrimPrefix(r.URL.Path, "/checkpoints/")
+		path := strings.TrimPrefix(r.URL.Path, "/checkpoints/")
+		historyRequest := strings.HasSuffix(path, "/history")
+		subscriberID := strings.TrimSuffix(path, "/history")
+		subscriberID = strings.TrimSuffix(subscriberID, "/")
 		if subscriberID == "" {
 			http.Error(w, "missing subscriber id", http.StatusBadRequest)
+			return
+		}
+		if historyRequest {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			historyProvider, ok := any(store).(CheckpointResetHistoryProvider)
+			if !ok {
+				http.Error(w, "checkpoint reset history unavailable", http.StatusServiceUnavailable)
+				return
+			}
+			limit, _ := strconv.Atoi(r.URL.Query().Get("limit"))
+			history, err := historyProvider.CheckpointResetHistory(subscriberID, limit)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			writeEventLogJSON(w, http.StatusOK, map[string]any{"history": history})
 			return
 		}
 		switch r.Method {
@@ -109,6 +133,27 @@ func NewEventLogServiceHandler(store LogServiceStore) http.Handler {
 			}
 			writeEventLogJSON(w, http.StatusOK, map[string]any{"checkpoint": checkpoint})
 		case http.MethodDelete:
+			manager, ok := any(store).(CheckpointResetManager)
+			if ok {
+				var request CheckpointResetRequest
+				if r.Body != nil {
+					if err := json.NewDecoder(r.Body).Decode(&request); err != nil && !errors.Is(err, io.EOF) {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+				}
+				record, err := manager.ResetCheckpointWithAudit(subscriberID, request)
+				if err != nil {
+					if IsNoEventLog(err) {
+						http.Error(w, "checkpoint not found", http.StatusNotFound)
+						return
+					}
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				writeEventLogJSON(w, http.StatusOK, map[string]any{"subscriber_id": subscriberID, "reset": true, "reset_audit": record})
+				return
+			}
 			resetter, ok := any(store).(CheckpointResetter)
 			if !ok {
 				http.Error(w, "checkpoint reset unavailable", http.StatusServiceUnavailable)

--- a/bigclaw-go/internal/events/sqlite_log.go
+++ b/bigclaw-go/internal/events/sqlite_log.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"bigclaw-go/internal/domain"
@@ -158,6 +159,17 @@ func (s *SQLiteEventLog) init() error {
 			event_seq INTEGER NOT NULL,
 			updated_at_ns INTEGER NOT NULL
 		);`,
+		`CREATE TABLE IF NOT EXISTS checkpoint_reset_audit (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			subscriber_id TEXT NOT NULL,
+			reset_at_ns INTEGER NOT NULL,
+			requested_by TEXT NOT NULL,
+			reason TEXT NOT NULL,
+			source TEXT NOT NULL,
+			previous_checkpoint_json BLOB,
+			retention_watermark_json BLOB
+		);`,
+		`CREATE INDEX IF NOT EXISTS idx_checkpoint_reset_audit_subscriber ON checkpoint_reset_audit(subscriber_id, reset_at_ns DESC, id DESC);`,
 		`CREATE TABLE IF NOT EXISTS event_log_retention_state (
 			singleton INTEGER PRIMARY KEY CHECK(singleton = 1),
 			policy TEXT NOT NULL,
@@ -273,21 +285,142 @@ func (s *SQLiteEventLog) Checkpoint(subscriberID string) (SubscriberCheckpoint, 
 }
 
 func (s *SQLiteEventLog) ResetCheckpoint(subscriberID string) error {
+	_, err := s.ResetCheckpointWithAudit(subscriberID, CheckpointResetRequest{})
+	return err
+}
+
+func (s *SQLiteEventLog) ResetCheckpointWithAudit(subscriberID string, request CheckpointResetRequest) (CheckpointResetRecord, error) {
 	if s == nil || s.db == nil || subscriberID == "" {
-		return sql.ErrNoRows
+		return CheckpointResetRecord{}, sql.ErrNoRows
 	}
-	result, err := s.db.Exec(`DELETE FROM subscriber_checkpoint WHERE subscriber_id = ?`, subscriberID)
+	checkpoint, err := s.Checkpoint(subscriberID)
 	if err != nil {
-		return err
+		return CheckpointResetRecord{}, err
+	}
+	record := CheckpointResetRecord{
+		SubscriberID:       subscriberID,
+		ResetAt:            s.nowUTC(),
+		RequestedBy:        strings.TrimSpace(request.RequestedBy),
+		Reason:             strings.TrimSpace(request.Reason),
+		Source:             strings.TrimSpace(request.Source),
+		PreviousCheckpoint: &checkpoint,
+	}
+	if record.RequestedBy == "" {
+		record.RequestedBy = "unknown"
+	}
+	if record.Reason == "" {
+		record.Reason = "operator_requested_reset"
+	}
+	if record.Source == "" {
+		record.Source = "sqlite_event_log"
+	}
+	if watermark, err := s.RetentionWatermark(); err == nil {
+		record.RetentionWatermark = &watermark
+	}
+	previousCheckpointJSON, err := json.Marshal(record.PreviousCheckpoint)
+	if err != nil {
+		return CheckpointResetRecord{}, err
+	}
+	var retentionWatermarkJSON []byte
+	if record.RetentionWatermark != nil {
+		retentionWatermarkJSON, err = json.Marshal(record.RetentionWatermark)
+		if err != nil {
+			return CheckpointResetRecord{}, err
+		}
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return CheckpointResetRecord{}, err
+	}
+	defer func() { _ = tx.Rollback() }()
+	result, err := tx.Exec(`DELETE FROM subscriber_checkpoint WHERE subscriber_id = ?`, subscriberID)
+	if err != nil {
+		return CheckpointResetRecord{}, err
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return err
+		return CheckpointResetRecord{}, err
 	}
 	if rowsAffected == 0 {
-		return sql.ErrNoRows
+		return CheckpointResetRecord{}, sql.ErrNoRows
 	}
-	return nil
+	if _, err := tx.Exec(`
+		INSERT INTO checkpoint_reset_audit(
+			subscriber_id,
+			reset_at_ns,
+			requested_by,
+			reason,
+			source,
+			previous_checkpoint_json,
+			retention_watermark_json
+		) VALUES(?, ?, ?, ?, ?, ?, ?)
+	`, record.SubscriberID, record.ResetAt.UnixNano(), record.RequestedBy, record.Reason, record.Source, previousCheckpointJSON, retentionWatermarkJSON); err != nil {
+		return CheckpointResetRecord{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return CheckpointResetRecord{}, err
+	}
+	return record, nil
+}
+
+func (s *SQLiteEventLog) CheckpointResetHistory(subscriberID string, limit int) ([]CheckpointResetRecord, error) {
+	if s == nil || s.db == nil || subscriberID == "" {
+		return nil, nil
+	}
+	query := `
+		SELECT reset_at_ns, requested_by, reason, source, previous_checkpoint_json, retention_watermark_json
+		FROM checkpoint_reset_audit
+		WHERE subscriber_id = ?
+		ORDER BY reset_at_ns DESC, id DESC
+	`
+	args := []any{subscriberID}
+	if limit > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	history := make([]CheckpointResetRecord, 0)
+	for rows.Next() {
+		var resetAtNS int64
+		var requestedBy string
+		var reason string
+		var source string
+		var previousCheckpointJSON []byte
+		var retentionWatermarkJSON []byte
+		if err := rows.Scan(&resetAtNS, &requestedBy, &reason, &source, &previousCheckpointJSON, &retentionWatermarkJSON); err != nil {
+			return nil, err
+		}
+		record := CheckpointResetRecord{
+			SubscriberID: subscriberID,
+			ResetAt:      time.Unix(0, resetAtNS).UTC(),
+			RequestedBy:  requestedBy,
+			Reason:       reason,
+			Source:       source,
+		}
+		if len(previousCheckpointJSON) > 0 {
+			var checkpoint SubscriberCheckpoint
+			if err := json.Unmarshal(previousCheckpointJSON, &checkpoint); err != nil {
+				return nil, err
+			}
+			record.PreviousCheckpoint = &checkpoint
+		}
+		if len(retentionWatermarkJSON) > 0 {
+			var watermark RetentionWatermark
+			if err := json.Unmarshal(retentionWatermarkJSON, &watermark); err != nil {
+				return nil, err
+			}
+			record.RetentionWatermark = &watermark
+		}
+		history = append(history, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return history, nil
 }
 
 func (s *SQLiteEventLog) queryAfter(base string, args []any, afterID string, limit int) ([]domain.Event, error) {
@@ -486,6 +619,9 @@ func reverseEvents(events []domain.Event) {
 
 var _ EventLog = (*SQLiteEventLog)(nil)
 var _ CheckpointStore = (*SQLiteEventLog)(nil)
+var _ CheckpointResetter = (*SQLiteEventLog)(nil)
+var _ CheckpointResetManager = (*SQLiteEventLog)(nil)
+var _ CheckpointResetHistoryProvider = (*SQLiteEventLog)(nil)
 
 func IsNoEventLog(err error) bool {
 	return errors.Is(err, sql.ErrNoRows)


### PR DESCRIPTION
## Summary
- persist checkpoint reset audit records with prior checkpoint and retention watermark context in the SQLite event log
- expose reset audit responses and history through the API plus HTTP event-log service/client paths
- extend reset regressions and update replay-retention reliability docs for the new operator audit trail

## Validation
- cd bigclaw-go && go test ./internal/events ./internal/api
- cd bigclaw-go && go test ./...
