### PR TITLE
OPE-232: refresh checkpoint reset rollout review pack

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -14,6 +14,8 @@ This report summarizes the current event bus reliability evidence and the next r
 - Replay cursor diagnostics via `X-Replay-*` headers and JSON `cursor` metadata on `GET /events`
 - Retention watermark / replay horizon visibility through API debug payloads and event-log service surfaces
 - Expired checkpoint diagnostics, checkpoint reset surface, and persisted operator history through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` plus `GET /stream/events/checkpoints/{subscriber_id}/history` and conflict payloads on resume attempts
+- Recent checkpoint reset review summaries through `GET /debug/status`, `GET /v2/control-center/audit`, `GET /v2/reports/distributed`, and `GET /v2/reports/distributed/export`
+- Shared-service reset review parity through `/checkpoint-resets` and `/checkpoints/{subscriber_id}/history` on the event-log service handler
 - SQLite retention bootstrap with persisted truncation boundaries that survive process restarts when a replay window is configured
 - Replay-safe consumer delivery metadata via `EventDelivery`, including additive `delivery.mode`, `delivery.replay`, and `delivery.idempotency_key` fields
 - Consumer dedup ledger/result contract covering duplicate, retryable-failure, and already-applied outcomes
@@ -35,6 +37,8 @@ This report summarizes the current event bus reliability evidence and the next r
 - Checkpoint offsets remain monotonic within a subscriber group and reject rollback writes.
 - Operators can inspect backend capability support before dispatching replay-oriented operations.
 - Operator-facing capability payloads now distinguish durable consumer dedup support from process-local replay/checkpoint support.
+- Local debug, control-center audit, and distributed rollout reports all surface the same recent checkpoint reset summary so release review does not depend on raw SQLite inspection.
+- Shared SQLite and HTTP-backed event-log deployments can expose the same reset audit/history trail over service endpoints, keeping review artifacts stable when operators are not colocated with the process.
 
 ## Evidence
 
@@ -56,10 +60,51 @@ This report summarizes the current event bus reliability evidence and the next r
 - `internal/events/dedup_ledger.go`
 - `internal/events/dedup_ledger_test.go`
 - `internal/events/sqlite_log.go`
+- `internal/events/log_service.go`
+- `internal/events/http_log_test.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
+- `internal/api/expansion.go`
+- `internal/api/expansion_test.go`
 - `cmd/bigclawd/main.go`
 - `internal/config/config.go`
+
+## Checkpoint reset review pack
+
+The current checkpoint reset evidence pack is intentionally redundant across operator surfaces so release, reliability, and distributed-platform review can all attach the same reset narrative without drilling into raw storage:
+
+- Primary review endpoints:
+  - `GET /stream/events/checkpoints/{subscriber_id}`
+  - `GET /stream/events/checkpoints/{subscriber_id}/history`
+  - `GET /debug/status`
+  - `GET /v2/control-center/audit`
+  - `GET /v2/reports/distributed`
+  - `GET /v2/reports/distributed/export`
+- Shared-service parity endpoints:
+  - `GET /checkpoint-resets`
+  - `GET /checkpoints/{subscriber_id}/history`
+- Summary fields expected across those views:
+  - subscriber identity
+  - reset reason such as `operator_reset`
+  - previous checkpoint event id / sequence
+  - retention watermark and trimmed boundary context
+  - reset timestamp and backend identity
+
+## Review artifact set by backend
+
+- Local single-process or SQLite-backed review:
+  - attach `GET /stream/events/checkpoints/{subscriber_id}/history`
+  - attach `GET /debug/status`
+  - attach `GET /v2/control-center/audit`
+  - attach `GET /v2/reports/distributed/export`
+- Shared-service or remote event-log review:
+  - attach `GET /checkpoints/{subscriber_id}/history`
+  - attach `GET /checkpoint-resets`
+  - attach `GET /v2/control-center/audit`
+  - attach `GET /v2/reports/distributed/export`
+- Future replicated backend review:
+  - preserve the same checkpoint-history, recent-reset, control-center, and distributed-export artifacts
+  - add replicated backend identity and failover domain details from the durability rollout contract before claiming rollout readiness
 
 ## Current durability shape
 

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -10,7 +10,8 @@ The current Go runtime still uses in-process replay history in `internal/events/
 
 - `Bus.SubscribeReplay` replays the tail of the in-memory append history before switching the subscriber to live events.
 - `GET /events`, `GET /replay/{id}`, and `GET /stream/events?replay=1` expose replay-oriented views over recorder history.
-- No durable retention watermark, checkpoint expiration signal, or history compaction rule exists yet.
+- Durable event-log backends now expose retention watermark context, expired checkpoint diagnostics, checkpoint reset actions, and persisted reset history through `GET/DELETE /stream/events/checkpoints/{subscriber_id}` plus `GET /stream/events/checkpoints/{subscriber_id}/history`.
+- Operator-facing review surfaces now mirror the same reset evidence through `GET /debug/status`, `GET /v2/control-center/audit`, and distributed report/export payloads.
 
 ## Retention model
 
@@ -60,10 +61,24 @@ The current Go runtime still uses in-process replay history in `internal/events/
 - Resume failure reason: expired cursor, unknown subscriber, or backend mismatch
 - Suggested recovery action: restart from earliest retained, reset checkpoint, or investigate backend corruption
 
+## Review artifact set
+
+- Local or SQLite-backed review should capture:
+  - `GET /stream/events/checkpoints/{subscriber_id}`
+  - `GET /stream/events/checkpoints/{subscriber_id}/history`
+  - `GET /debug/status`
+  - `GET /v2/control-center/audit`
+- Shared-service review should capture:
+  - `GET /checkpoints/{subscriber_id}/history`
+  - `GET /checkpoint-resets`
+  - `GET /v2/control-center/audit`
+  - `GET /v2/reports/distributed/export`
+- Future replicated backends should preserve the same artifact set while adding replicated durability-plan metadata and failover evidence links.
+
 ## Forward path
 
 - `OPE-212` establishes the compaction and retention contract.
-- `OPE-216` established the expired replay cursor semantics, `OPE-226` added the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes, and `OPE-228` extends that flow with persisted reset audit history.
+- `OPE-216` established the expired replay cursor semantics, `OPE-226` added the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes, `OPE-228` extended that flow with persisted reset audit history, `OPE-229` surfaced recent reset summaries in debug and control-plane views, and `OPE-231` carried the same summary into distributed report/export payloads.
 - Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
 - SQLite-backed durable logs now persist trimmed replay boundaries across restarts when a retention window is configured, giving operators a stable replay horizon even after reboot.
 
@@ -73,4 +88,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 - `internal/events/bus_test.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
+- `internal/api/expansion.go`
+- `internal/api/expansion_test.go`
+- `internal/events/log_service.go`
 - `docs/reports/event-bus-reliability-report.md`

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -33,10 +33,20 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 
 ### Remaining gaps
 
-- Replay retention watermarks are now visible in runtime payloads, SQLite-backed logs now persist trimmed replay boundaries across restarts, expired durable checkpoints now fail closed with reset guidance, and checkpoint resets now leave a persisted operator history trail; memory-only deployments are still bounded by in-process history and broker/quorum retention remains future work.
+- Replay retention watermarks are now visible in runtime payloads, SQLite-backed logs now persist trimmed replay boundaries across restarts, expired durable checkpoints now fail closed with reset guidance, checkpoint resets leave a persisted operator history trail, and reset summaries now flow through debug, control-center, and distributed report/export payloads; memory-only deployments are still bounded by in-process history and broker/quorum retention remains future work.
 - Service-style SQLite and HTTP-backed coordination improve sharing, but replicated broker or quorum-backed durability is still future work.
 - Downstream consumers still need idempotent handlers and durable dedupe stores; the system remains replay-safe, not globally exactly-once.
 - Parallel validation for Kubernetes, Ray, and shared-queue takeover should continue to be bundled as repo-native evidence.
+
+### Current review-pack contract
+
+- Local rollout review should be able to attach one stable checkpoint reset pack from:
+  - `GET /stream/events/checkpoints/{subscriber_id}/history`
+  - `GET /debug/status`
+  - `GET /v2/control-center/audit`
+  - `GET /v2/reports/distributed/export`
+- Shared-service review should use the same control-center and distributed export artifacts plus event-log service history from `/checkpoints/{subscriber_id}/history` and `/checkpoint-resets`.
+- Future replicated backends should preserve the same artifact names and add backend/failover evidence from the replicated durability rollout contract instead of inventing a separate review bundle.
 
 ### Current rollout gate
 

--- a/docs/parallel-refill-queue.json
+++ b/docs/parallel-refill-queue.json
@@ -31,39 +31,39 @@
       "OPE-224",
       "OPE-225",
       "OPE-226",
-      "OPE-227"
-    ],
-    "active": [
+      "OPE-227",
       "OPE-228",
       "OPE-229"
     ],
-    "standby": [
-      "OPE-230"
+    "active": [
+      "OPE-230",
+      "OPE-231",
+      "OPE-232"
     ]
   },
   "issue_order": [
-    "OPE-228",
-    "OPE-229",
-    "OPE-230"
+    "OPE-230",
+    "OPE-231",
+    "OPE-232"
   ],
   "issues": [
-    {
-      "identifier": "OPE-228",
-      "title": "BIG-PAR-041 checkpoint reset audit trail and operator history",
-      "track": "Reset Audit",
-      "status": "In Progress"
-    },
-    {
-      "identifier": "OPE-229",
-      "title": "BIG-PAR-042 checkpoint reset review surface in debug / control-plane payloads",
-      "track": "Control Plane Review",
-      "status": "In Progress"
-    },
     {
       "identifier": "OPE-230",
       "title": "BIG-PAR-043 checkpoint reset validation bundle refresh",
       "track": "Validation Bundle",
-      "status": "Todo"
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-231",
+      "title": "BIG-PAR-044 checkpoint reset distributed report / export integration",
+      "track": "Distributed Report",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-232",
+      "title": "BIG-PAR-045 checkpoint reset rollout evidence / review-pack refresh",
+      "track": "Review Pack",
+      "status": "In Progress"
     }
   ]
 }

--- a/docs/parallel-refill-queue.md
+++ b/docs/parallel-refill-queue.md
@@ -39,13 +39,15 @@ manual operator can refill the next parallel-safe issues in a stable order.
   - `OPE-226` — expired replay checkpoint diagnostics / reset surface
   - `OPE-227` — broker adapter dry-run capability probe
 - Active:
+  - `OPE-230` — checkpoint reset validation bundle refresh
+  - `OPE-231` — checkpoint reset distributed report / export integration
+  - `OPE-232` — checkpoint reset rollout evidence / review-pack refresh
+- Completed:
   - `OPE-228` — checkpoint reset audit trail and operator history
   - `OPE-229` — checkpoint reset review surface in debug / control-plane payloads
-- Standby:
-  - `OPE-230` — checkpoint reset validation bundle refresh
 
 ## Canonical refill order
 
-1. `OPE-228`
-2. `OPE-229`
-3. `OPE-230`
+1. `OPE-230`
+2. `OPE-231`
+3. `OPE-232`


### PR DESCRIPTION
## Summary
- refresh the checkpoint reset evidence docs to cite the shipped debug, control-center, stream-history, and distributed export surfaces
- document the expected review artifact set for local, shared-service, and future replicated backends
- update the canonical parallel refill queue docs/json to match the current OPE-230/OPE-231/OPE-232 active batch

## Validation
- PYTHONPATH=src python3 - <<'PY'
from bigclaw.parallel_refill import ParallelIssueQueue
q = ParallelIssueQueue("docs/parallel-refill-queue.json")
print({"project_slug": q.project_slug(), "target": q.target_in_progress(), "states": sorted(q.refill_states())})
PY
- python3 -m json.tool docs/parallel-refill-queue.json >/dev/null