### PR TITLE
OPE-231: add checkpoint resets to distributed diagnostics reports

### DIFF
--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"time"
 
 	"bigclaw-go/internal/control"
 	"bigclaw-go/internal/domain"
@@ -75,6 +76,7 @@ type distributedDiagnostics struct {
 	RoutingReasons   []routingReasonSummary        `json:"routing_reasons"`
 	ExecutorCapacity []executorCapacityView        `json:"executor_capacity"`
 	ClusterHealth    clusterHealthRollup           `json:"cluster_health"`
+	CheckpointResets *checkpointResetSnapshot      `json:"checkpoint_resets,omitempty"`
 	RolloutReport    distributedDiagnosticsReport  `json:"rollout_report"`
 }
 
@@ -346,6 +348,7 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		RoutingReasons:   routingReasons,
 		ExecutorCapacity: executorCapacity,
 		ClusterHealth:    clusterHealth,
+		CheckpointResets: s.checkpointResetAuditSnapshot(filters.AuditLimit),
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
 		Markdown:  renderDistributedDiagnosticsMarkdown(diagnostics, filters),
@@ -568,6 +571,9 @@ func distributedExportURL(filters controlCenterFilters) string {
 	if filters.Limit > 0 {
 		values.Set("limit", fmt.Sprintf("%d", filters.Limit))
 	}
+	if filters.AuditLimit > 0 {
+		values.Set("audit_limit", fmt.Sprintf("%d", filters.AuditLimit))
+	}
 	encoded := values.Encode()
 	if encoded == "" {
 		return "/v2/reports/distributed/export"
@@ -652,6 +658,33 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 	if len(diagnostics.ClusterHealth.TakeoverOwners) > 0 {
 		lines = append(lines, "- Takeover owners: "+formatFacetCounts(diagnostics.ClusterHealth.TakeoverOwners))
 	}
+	lines = append(lines, "", "## Checkpoint Resets")
+	if diagnostics.CheckpointResets == nil || diagnostics.CheckpointResets.RecentCount == 0 {
+		lines = append(lines, "- No recent checkpoint resets captured")
+	} else {
+		lines = append(lines, fmt.Sprintf("- Recent checkpoint resets: %d", diagnostics.CheckpointResets.RecentCount))
+		if len(diagnostics.CheckpointResets.BySubscriber) > 0 {
+			lines = append(lines, "- By subscriber: "+formatCheckpointResetFacetCounts(diagnostics.CheckpointResets.BySubscriber))
+		}
+		if len(diagnostics.CheckpointResets.ByReason) > 0 {
+			lines = append(lines, "- By reason: "+formatCheckpointResetFacetCounts(diagnostics.CheckpointResets.ByReason))
+		}
+		for _, item := range diagnostics.CheckpointResets.Recent {
+			checkpointEventID := "none"
+			trimmedThroughEventID := "none"
+			oldestEventID := "none"
+			retentionWindowSeconds := int64(0)
+			if item.PreviousCheckpoint != nil {
+				checkpointEventID = firstNonEmpty(strings.TrimSpace(item.PreviousCheckpoint.EventID), "none")
+			}
+			if item.RetentionWatermark != nil {
+				trimmedThroughEventID = firstNonEmpty(strings.TrimSpace(item.RetentionWatermark.TrimmedThroughEventID), "none")
+				oldestEventID = firstNonEmpty(strings.TrimSpace(item.RetentionWatermark.OldestEventID), "none")
+				retentionWindowSeconds = item.RetentionWatermark.RetentionWindowSeconds
+			}
+			lines = append(lines, fmt.Sprintf("- %s: subscriber=%s reason=%s checkpoint=%s trimmed_through=%s oldest_retained=%s window_seconds=%d", item.ResetAt.Format(time.RFC3339), firstNonEmpty(strings.TrimSpace(item.SubscriberID), "unknown"), firstNonEmpty(strings.TrimSpace(item.Reason), "unknown"), checkpointEventID, trimmedThroughEventID, oldestEventID, retentionWindowSeconds))
+		}
+	}
 	lines = append(lines, "", "## Notes")
 	for _, note := range diagnostics.ClusterHealth.Notes {
 		lines = append(lines, "- "+note)
@@ -661,6 +694,14 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 }
 
 func formatFacetCounts(items []auditFacetCount) string {
+	parts := make([]string, 0, len(items))
+	for _, item := range items {
+		parts = append(parts, fmt.Sprintf("%s=%d", item.Key, item.Count))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatCheckpointResetFacetCounts(items []checkpointResetFacetCount) string {
 	parts := make([]string, 0, len(items))
 	for _, item := range items {
 		parts = append(parts, fmt.Sprintf("%s=%d", item.Key, item.Count))

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -1686,11 +1686,17 @@ func TestV2ControlCenterIncludesMultiWorkerPoolSummary(t *testing.T) {
 func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	recorder := observability.NewRecorder()
 	controller := control.New()
+	store, err := events.NewSQLiteEventLog(filepath.Join(t.TempDir(), "distributed-diagnostics-event-log.db"))
+	if err != nil {
+		t.Fatalf("new sqlite event log: %v", err)
+	}
+	defer func() { _ = store.Close() }()
 	server := &Server{
 		Recorder:  recorder,
 		Queue:     queue.NewMemoryQueue(),
 		Executors: []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
 		Control:   controller,
+		EventLog:  store,
 		Worker:    fakeWorkerPoolStatus{},
 		Now:       func() time.Time { return time.Unix(1700007200, 0) },
 	}
@@ -1714,6 +1720,15 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 		{ID: "evt-ray-completed", Type: domain.EventTaskCompleted, TaskID: "diag-ray", TraceID: "trace-ray", Timestamp: base.Add(7 * time.Second), Payload: map[string]any{"executor": domain.ExecutorRay}},
 	} {
 		recorder.Record(event)
+	}
+	if err := store.Write(context.Background(), domain.Event{ID: "evt-diag-reset-1", Type: domain.EventTaskQueued, TaskID: "diag-k8s", TraceID: "trace-k8s", Timestamp: base.Add(8 * time.Second)}); err != nil {
+		t.Fatalf("write distributed reset event: %v", err)
+	}
+	if _, err := store.Acknowledge("subscriber-dist-reset", "evt-diag-reset-1", base.Add(9*time.Second)); err != nil {
+		t.Fatalf("ack distributed reset checkpoint: %v", err)
+	}
+	if err := store.ResetCheckpoint("subscriber-dist-reset"); err != nil {
+		t.Fatalf("reset distributed checkpoint: %v", err)
 	}
 
 	response := httptest.NewRecorder()
@@ -1763,6 +1778,21 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 					Count int    `json:"count"`
 				} `json:"takeover_owners"`
 			} `json:"cluster_health"`
+			CheckpointResets struct {
+				RecentCount  int `json:"recent_count"`
+				BySubscriber []struct {
+					Key   string `json:"key"`
+					Count int    `json:"count"`
+				} `json:"by_subscriber"`
+				ByReason []struct {
+					Key   string `json:"key"`
+					Count int    `json:"count"`
+				} `json:"by_reason"`
+				Recent []struct {
+					SubscriberID string `json:"subscriber_id"`
+					Reason       string `json:"reason"`
+				} `json:"recent"`
+			} `json:"checkpoint_resets"`
 			RolloutReport struct {
 				Markdown  string `json:"markdown"`
 				ExportURL string `json:"export_url"`
@@ -1799,8 +1829,32 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	if len(decoded.Diagnostics.ClusterHealth.TakeoverOwners) == 0 || decoded.Diagnostics.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("expected takeover owner rollup, got %+v", decoded.Diagnostics.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
+	if decoded.Diagnostics.CheckpointResets.RecentCount != 1 || len(decoded.Diagnostics.CheckpointResets.BySubscriber) != 1 || decoded.Diagnostics.CheckpointResets.BySubscriber[0].Key != "subscriber-dist-reset" {
+		t.Fatalf("expected checkpoint reset summary in distributed diagnostics, got %+v", decoded.Diagnostics.CheckpointResets)
+	}
+	if len(decoded.Diagnostics.CheckpointResets.ByReason) != 1 || decoded.Diagnostics.CheckpointResets.ByReason[0].Key != "operator_reset" {
+		t.Fatalf("expected checkpoint reset reason facet, got %+v", decoded.Diagnostics.CheckpointResets)
+	}
+	if len(decoded.Diagnostics.CheckpointResets.Recent) != 1 || decoded.Diagnostics.CheckpointResets.Recent[0].SubscriberID != "subscriber-dist-reset" {
+		t.Fatalf("expected recent checkpoint reset entry, got %+v", decoded.Diagnostics.CheckpointResets)
+	}
+	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Checkpoint Resets") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "subscriber-dist-reset") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "audit_limit=10") {
 		t.Fatalf("unexpected rollout report payload: %+v", decoded.Diagnostics.RolloutReport)
+	}
+
+	exportResponse := httptest.NewRecorder()
+	handler.ServeHTTP(exportResponse, httptest.NewRequest(http.MethodGet, "/v2/reports/distributed/export?team=platform&project=alpha&limit=10&audit_limit=10", nil))
+	if exportResponse.Code != http.StatusOK {
+		t.Fatalf("expected distributed export 200, got %d %s", exportResponse.Code, exportResponse.Body.String())
+	}
+	if contentType := exportResponse.Header().Get("Content-Type"); !strings.Contains(contentType, "text/markdown") {
+		t.Fatalf("expected markdown export content type, got %q", contentType)
+	}
+	if disposition := exportResponse.Header().Get("Content-Disposition"); !strings.Contains(disposition, "bigclaw-distributed-diagnostics-platform.md") {
+		t.Fatalf("expected export attachment filename, got %q", disposition)
+	}
+	if !strings.Contains(exportResponse.Body.String(), "Checkpoint Resets") || !strings.Contains(exportResponse.Body.String(), "subscriber-dist-reset") || !strings.Contains(exportResponse.Body.String(), "operator_reset") {
+		t.Fatalf("expected checkpoint reset summary in distributed export, got %s", exportResponse.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- include checkpoint reset audit summaries in distributed diagnostics JSON payloads
- add checkpoint reset sections to the distributed markdown export and preserve audit_limit in generated export URLs
- cover the control-center diagnostics and export flow with a regression test backed by the SQLite event log

## Validation
- go test ./internal/api -run TestV2ControlCenterIncludesDistributedDiagnostics -count=1