### PR TITLE
OPE-234: add replicated event-log rollout readiness summary

### DIFF
--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -67,7 +67,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - failure-domain summaries
 - references to the supporting validation pack and rollout contract documents
 
-The current repo-native source for these signals is the `event_durability` payload exposed through `GET /debug/status`.
+The current repo-native source for these signals is the `event_durability` payload exposed through `GET /debug/status`, including the machine-readable `rollout_readiness` summary that mirrors this contract in control-plane and distributed report/export responses.
 
 ## Validation evidence required before a live adapter lands
 

--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -9,6 +9,7 @@ import (
 
 	"bigclaw-go/internal/control"
 	"bigclaw-go/internal/domain"
+	"bigclaw-go/internal/events"
 	"bigclaw-go/internal/executor"
 	"bigclaw-go/internal/risk"
 )
@@ -75,6 +76,7 @@ type distributedDiagnostics struct {
 	RoutingReasons   []routingReasonSummary        `json:"routing_reasons"`
 	ExecutorCapacity []executorCapacityView        `json:"executor_capacity"`
 	ClusterHealth    clusterHealthRollup           `json:"cluster_health"`
+	EventLogRollout  events.RolloutReadiness       `json:"event_log_rollout"`
 	RolloutReport    distributedDiagnosticsReport  `json:"rollout_report"`
 }
 
@@ -122,6 +124,7 @@ func (s *Server) handleV2DistributedReport(w http.ResponseWriter, r *http.Reques
 		"routing_reasons":   diagnostics.RoutingReasons,
 		"executor_capacity": diagnostics.ExecutorCapacity,
 		"cluster_health":    diagnostics.ClusterHealth,
+		"event_log_rollout": diagnostics.EventLogRollout,
 		"report":            diagnostics.RolloutReport,
 	})
 }
@@ -346,6 +349,7 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		RoutingReasons:   routingReasons,
 		ExecutorCapacity: executorCapacity,
 		ClusterHealth:    clusterHealth,
+		EventLogRollout:  s.EventPlan.RolloutReadiness,
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
 		Markdown:  renderDistributedDiagnosticsMarkdown(diagnostics, filters),
@@ -591,9 +595,40 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 		fmt.Sprintf("- Idle workers: %d", diagnostics.Summary.IdleWorkers),
 		fmt.Sprintf("- Saturated executors: %d", diagnostics.Summary.SaturatedExecutors),
 		fmt.Sprintf("- Active takeovers: %d", diagnostics.Summary.ActiveTakeovers),
-		"",
-		"## Routing Reasons",
 	}
+	if diagnostics.EventLogRollout.Summary != "" {
+		lines = append(lines,
+			"",
+			"## Event-Log Rollout Readiness",
+			fmt.Sprintf("- Phase: %s", diagnostics.EventLogRollout.Phase),
+			fmt.Sprintf("- Status: %s", diagnostics.EventLogRollout.Status),
+			fmt.Sprintf("- Summary: %s", diagnostics.EventLogRollout.Summary),
+			fmt.Sprintf("- Current capability probe: publish=%s replay=%s checkpoint=%s filtering=%s retention=%s", diagnostics.EventLogRollout.CurrentProbe.Publish, diagnostics.EventLogRollout.CurrentProbe.Replay, diagnostics.EventLogRollout.CurrentProbe.Checkpoint, diagnostics.EventLogRollout.CurrentProbe.Filtering, diagnostics.EventLogRollout.CurrentProbe.Retention),
+			fmt.Sprintf("- Target capability probe: publish=%s replay=%s checkpoint=%s filtering=%s retention=%s", diagnostics.EventLogRollout.TargetProbe.Publish, diagnostics.EventLogRollout.TargetProbe.Replay, diagnostics.EventLogRollout.TargetProbe.Checkpoint, diagnostics.EventLogRollout.TargetProbe.Filtering, diagnostics.EventLogRollout.TargetProbe.Retention),
+		)
+		if broker := diagnostics.EventLogRollout.BrokerRuntime; broker != nil {
+			lines = append(lines, fmt.Sprintf("- Broker runtime: ready=%t driver=%s topic=%s consumer_group=%s replay_limit=%d", broker.Ready, firstNonEmpty(broker.Driver, "unset"), firstNonEmpty(broker.Topic, "unset"), firstNonEmpty(broker.ConsumerGroup, "unset"), broker.ReplayLimit))
+			if len(broker.URLs) > 0 {
+				lines = append(lines, "- Broker URLs: "+strings.Join(broker.URLs, ", "))
+			}
+		}
+		if len(diagnostics.EventLogRollout.ReadinessNotes) > 0 {
+			lines = append(lines, "- Readiness notes:")
+			for _, note := range diagnostics.EventLogRollout.ReadinessNotes {
+				lines = append(lines, "  - "+note)
+			}
+		}
+		if len(diagnostics.EventLogRollout.RemainingChecks) > 0 {
+			lines = append(lines, "- Remaining checks:")
+			for _, check := range diagnostics.EventLogRollout.RemainingChecks {
+				lines = append(lines, "  - "+check)
+			}
+		}
+		if len(diagnostics.EventLogRollout.EvidenceArtifacts) > 0 {
+			lines = append(lines, "- Evidence artifacts: "+strings.Join(diagnostics.EventLogRollout.EvidenceArtifacts, ", "))
+		}
+	}
+	lines = append(lines, "", "## Routing Reasons")
 	if len(diagnostics.RoutingReasons) == 0 {
 		lines = append(lines, "- No routing decisions captured")
 	} else {

--- a/bigclaw-go/internal/api/expansion_test.go
+++ b/bigclaw-go/internal/api/expansion_test.go
@@ -283,9 +283,18 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 		Recorder:  recorder,
 		Queue:     queue.NewMemoryQueue(),
 		Executors: []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
-		Control:   controller,
-		Worker:    fakeWorkerPoolStatus{},
-		Now:       func() time.Time { return base.Add(6 * time.Hour) },
+		EventPlan: events.NewDurabilityPlanWithBrokerConfig("http", "broker_replicated", 5, events.BrokerRuntimeConfig{
+			Driver:             "kafka",
+			URLs:               []string{"kafka-1:9092", "kafka-2:9092"},
+			Topic:              "bigclaw.events",
+			ConsumerGroup:      "bigclaw-consumers",
+			PublishTimeout:     5 * time.Second,
+			ReplayLimit:        2048,
+			CheckpointInterval: 15 * time.Second,
+		}),
+		Control: controller,
+		Worker:  fakeWorkerPoolStatus{},
+		Now:     func() time.Time { return base.Add(6 * time.Hour) },
 	}
 	for _, task := range []domain.Task{
 		{ID: "report-local", TraceID: "trace-report-local", Title: "Local", State: domain.TaskSucceeded, Metadata: map[string]string{"team": "platform", "project": "apollo"}, UpdatedAt: base.Add(time.Minute)},
@@ -345,6 +354,9 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 				Count int    `json:"count"`
 			} `json:"takeover_owners"`
 		} `json:"cluster_health"`
+		EventLogRollout struct {
+			Status string `json:"status"`
+		} `json:"event_log_rollout"`
 		Report struct {
 			Markdown  string `json:"markdown"`
 			ExportURL string `json:"export_url"`
@@ -368,7 +380,10 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 	if len(decoded.ClusterHealth.TakeoverOwners) == 0 || decoded.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("unexpected takeover owner breakdown: %+v", decoded.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Report.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Report.Markdown, "gpu workloads default to ray executor") || !strings.Contains(decoded.Report.Markdown, "Team breakdown") {
+	if decoded.EventLogRollout.Status != "contract_ready" {
+		t.Fatalf("unexpected event-log rollout payload: %+v", decoded.EventLogRollout)
+	}
+	if !strings.Contains(decoded.Report.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Report.Markdown, "gpu workloads default to ray executor") || !strings.Contains(decoded.Report.Markdown, "Event-Log Rollout Readiness") || !strings.Contains(decoded.Report.Markdown, "Team breakdown") {
 		t.Fatalf("unexpected distributed markdown: %s", decoded.Report.Markdown)
 	}
 	if !strings.Contains(decoded.Report.ExportURL, "/v2/reports/distributed/export") {
@@ -383,7 +398,7 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 	if contentType := exportResponse.Header().Get("Content-Type"); !strings.Contains(contentType, "text/markdown") {
 		t.Fatalf("expected markdown export content type, got %q", contentType)
 	}
-	if !strings.Contains(exportResponse.Body.String(), "Executor Capacity") || !strings.Contains(exportResponse.Body.String(), "ray: gpu workloads default to ray executor") || !strings.Contains(exportResponse.Body.String(), "Takeover owners") {
+	if !strings.Contains(exportResponse.Body.String(), "Executor Capacity") || !strings.Contains(exportResponse.Body.String(), "ray: gpu workloads default to ray executor") || !strings.Contains(exportResponse.Body.String(), "Event-Log Rollout Readiness") || !strings.Contains(exportResponse.Body.String(), "Takeover owners") {
 		t.Fatalf("unexpected distributed export markdown: %s", exportResponse.Body.String())
 	}
 }

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -248,10 +248,18 @@ func TestAuditAndReplayEndpoints(t *testing.T) {
 func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	recorder := observability.NewRecorder()
 	server := &Server{
-		Recorder:  recorder,
-		Queue:     queue.NewMemoryQueue(),
-		EventPlan: events.NewDurabilityPlan("http", "broker_replicated", 5),
-		Now:       time.Now,
+		Recorder: recorder,
+		Queue:    queue.NewMemoryQueue(),
+		EventPlan: events.NewDurabilityPlanWithBrokerConfig("http", "broker_replicated", 5, events.BrokerRuntimeConfig{
+			Driver:             "kafka",
+			URLs:               []string{"kafka-1:9092", "kafka-2:9092"},
+			Topic:              "bigclaw.events",
+			ConsumerGroup:      "bigclaw-consumers",
+			PublishTimeout:     5 * time.Second,
+			ReplayLimit:        2048,
+			CheckpointInterval: 15 * time.Second,
+		}),
+		Now: time.Now,
 	}
 	response := httptest.NewRecorder()
 	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
@@ -271,6 +279,9 @@ func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	}
 	if !strings.Contains(response.Body.String(), "\"rollout_checks\"") {
 		t.Fatalf("expected rollout checks in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"rollout_readiness\"") || !strings.Contains(response.Body.String(), "\"status\":\"contract_ready\"") {
+		t.Fatalf("expected rollout readiness summary in payload, got %s", response.Body.String())
 	}
 	if !strings.Contains(response.Body.String(), "\"failure_domains\"") {
 		t.Fatalf("expected failure domains in payload, got %s", response.Body.String())
@@ -1690,9 +1701,18 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 		Recorder:  recorder,
 		Queue:     queue.NewMemoryQueue(),
 		Executors: []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
-		Control:   controller,
-		Worker:    fakeWorkerPoolStatus{},
-		Now:       func() time.Time { return time.Unix(1700007200, 0) },
+		EventPlan: events.NewDurabilityPlanWithBrokerConfig("http", "broker_replicated", 5, events.BrokerRuntimeConfig{
+			Driver:             "kafka",
+			URLs:               []string{"kafka-1:9092", "kafka-2:9092"},
+			Topic:              "bigclaw.events",
+			ConsumerGroup:      "bigclaw-consumers",
+			PublishTimeout:     5 * time.Second,
+			ReplayLimit:        2048,
+			CheckpointInterval: 15 * time.Second,
+		}),
+		Control: controller,
+		Worker:  fakeWorkerPoolStatus{},
+		Now:     func() time.Time { return time.Unix(1700007200, 0) },
 	}
 	handler := server.Handler()
 	base := time.Unix(1700000000, 0)
@@ -1763,6 +1783,10 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 					Count int    `json:"count"`
 				} `json:"takeover_owners"`
 			} `json:"cluster_health"`
+			EventLogRollout struct {
+				Status  string `json:"status"`
+				Summary string `json:"summary"`
+			} `json:"event_log_rollout"`
 			RolloutReport struct {
 				Markdown  string `json:"markdown"`
 				ExportURL string `json:"export_url"`
@@ -1799,7 +1823,10 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	if len(decoded.Diagnostics.ClusterHealth.TakeoverOwners) == 0 || decoded.Diagnostics.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("expected takeover owner rollup, got %+v", decoded.Diagnostics.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
+	if decoded.Diagnostics.EventLogRollout.Status != "contract_ready" || !strings.Contains(decoded.Diagnostics.EventLogRollout.Summary, "Replicated target metadata is configured") {
+		t.Fatalf("expected event-log rollout summary in diagnostics, got %+v", decoded.Diagnostics.EventLogRollout)
+	}
+	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Event-Log Rollout Readiness") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
 		t.Fatalf("unexpected rollout report payload: %+v", decoded.Diagnostics.RolloutReport)
 	}
 }

--- a/bigclaw-go/internal/api/v2.go
+++ b/bigclaw-go/internal/api/v2.go
@@ -1089,6 +1089,7 @@ func (s *Server) handleV2ControlCenter(w http.ResponseWriter, r *http.Request) {
 			"audit_limit": filters.AuditLimit,
 		},
 		"control":          s.Control.Snapshot(),
+		"event_durability": s.EventPlan,
 		"event_log":        s.eventLogCapabilities(r.Context()),
 		"summary":          summarizeControlCenter(queueTasks, filteredDeadLetters),
 		"queue":            map[string]any{"size": s.Queue.Size(context.Background()), "filtered_size": len(queueTasks), "dead_letters": len(filteredDeadLetters), "tasks": returnedQueueTasks, "cancellable": supportsQueueCancel(s.Queue)},

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -50,6 +50,26 @@ type BrokerBootstrapStatus struct {
 	ValidationErrors   []string `json:"validation_errors,omitempty"`
 }
 
+type CapabilityProbeSummary struct {
+	Publish    string `json:"publish"`
+	Replay     string `json:"replay"`
+	Checkpoint string `json:"checkpoint"`
+	Filtering  string `json:"filtering"`
+	Retention  string `json:"retention"`
+}
+
+type RolloutReadiness struct {
+	Phase             string                 `json:"phase"`
+	Status            string                 `json:"status"`
+	Summary           string                 `json:"summary"`
+	ReadinessNotes    []string               `json:"readiness_notes"`
+	RemainingChecks   []string               `json:"remaining_checks,omitempty"`
+	CurrentProbe      CapabilityProbeSummary `json:"current_probe"`
+	TargetProbe       CapabilityProbeSummary `json:"target_probe"`
+	BrokerRuntime     *BrokerBootstrapStatus `json:"broker_runtime,omitempty"`
+	EvidenceArtifacts []string               `json:"evidence_artifacts,omitempty"`
+}
+
 type DurabilityPlan struct {
 	Current              DurabilityProfile      `json:"current"`
 	Target               DurabilityProfile      `json:"target"`
@@ -61,6 +81,7 @@ type DurabilityPlan struct {
 	FailureDomains       []FailureDomain        `json:"failure_domains"`
 	VerificationEvidence []VerificationEvidence `json:"verification_evidence"`
 	BrokerBootstrap      *BrokerBootstrapStatus `json:"broker_bootstrap,omitempty"`
+	RolloutReadiness     RolloutReadiness       `json:"rollout_readiness"`
 }
 
 func NormalizeDurabilityBackend(value string) DurabilityBackend {
@@ -218,6 +239,7 @@ func NewDurabilityPlanWithBrokerConfig(currentBackend, targetBackend string, rep
 	if current.Replicated || target.Replicated {
 		plan.BrokerBootstrap = BrokerBootstrapStatusFromConfig(broker)
 	}
+	plan.RolloutReadiness = buildRolloutReadiness(plan)
 	return plan
 }
 
@@ -237,4 +259,98 @@ func BrokerBootstrapStatusFromConfig(cfg BrokerRuntimeConfig) *BrokerBootstrapSt
 	}
 	status.Ready = true
 	return status
+}
+
+func buildRolloutReadiness(plan DurabilityPlan) RolloutReadiness {
+	readiness := RolloutReadiness{
+		CurrentProbe:      capabilityProbeSummary(plan.Current.Backend),
+		TargetProbe:       capabilityProbeSummary(plan.Target.Backend),
+		BrokerRuntime:     plan.BrokerBootstrap,
+		EvidenceArtifacts: readinessArtifacts(plan.VerificationEvidence),
+	}
+	if !plan.Target.Replicated {
+		readiness.Phase = "current_backend"
+		readiness.Status = "current_backend_active"
+		readiness.Summary = "Current event-log backend is active; replicated durability rollout is not configured."
+		readiness.ReadinessNotes = []string{
+			"Current runtime exposes its active backend profile directly through event_durability for operator review.",
+			"Replicated publish acknowledgements and broker failover checks are not required until a broker_replicated target is selected.",
+		}
+		return readiness
+	}
+
+	readiness.Phase = "contract"
+	readiness.RemainingChecks = remainingCheckRequirements(plan.RolloutChecks)
+	readiness.ReadinessNotes = []string{
+		"Replicated durability remains in the contract-validation phase until a live broker adapter satisfies publish, replay, checkpoint, and retention checks.",
+		"Operator payloads should review broker bootstrap readiness together with rollout checks before claiming replicated durability.",
+	}
+	if plan.BrokerBootstrap == nil || !plan.BrokerBootstrap.Ready {
+		readiness.Status = "blocked"
+		readiness.Summary = "Replicated target is configured, but broker bootstrap validation is still blocking rollout readiness."
+		if plan.BrokerBootstrap != nil && len(plan.BrokerBootstrap.ValidationErrors) > 0 {
+			readiness.ReadinessNotes = append(readiness.ReadinessNotes, plan.BrokerBootstrap.ValidationErrors...)
+		}
+		return readiness
+	}
+
+	readiness.Status = "contract_ready"
+	readiness.Summary = "Replicated target metadata is configured and validated, but rollout remains gated on the documented failover and checkpoint evidence."
+	readiness.ReadinessNotes = append(readiness.ReadinessNotes,
+		"Broker runtime metadata is present so release/export payloads can attach target driver, topic, and consumer-group expectations.",
+	)
+	return readiness
+}
+
+func capabilityProbeSummary(backend DurabilityBackend) CapabilityProbeSummary {
+	switch backend {
+	case DurabilityBackendSQLite:
+		return CapabilityProbeSummary{
+			Publish:    "native",
+			Replay:     "native",
+			Checkpoint: "native",
+			Filtering:  "derived",
+			Retention:  "durable_single_node",
+		}
+	case DurabilityBackendHTTP:
+		return CapabilityProbeSummary{
+			Publish:    "native",
+			Replay:     "native",
+			Checkpoint: "native",
+			Filtering:  "derived",
+			Retention:  "durable_shared_service",
+		}
+	case DurabilityBackendBrokerReplicated:
+		return CapabilityProbeSummary{
+			Publish:    "native",
+			Replay:     "native",
+			Checkpoint: "native",
+			Filtering:  "derived",
+			Retention:  "replicated_log",
+		}
+	default:
+		return CapabilityProbeSummary{
+			Publish:    "native",
+			Replay:     "native",
+			Checkpoint: "unsupported",
+			Filtering:  "native",
+			Retention:  "process_memory",
+		}
+	}
+}
+
+func remainingCheckRequirements(checks []RolloutCheck) []string {
+	out := make([]string, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, check.Requirement)
+	}
+	return out
+}
+
+func readinessArtifacts(entries []VerificationEvidence) []string {
+	out := make([]string, 0)
+	for _, entry := range entries {
+		out = append(out, entry.Artifacts...)
+	}
+	return out
 }

--- a/bigclaw-go/internal/events/durability_test.go
+++ b/bigclaw-go/internal/events/durability_test.go
@@ -29,6 +29,12 @@ func TestNewDurabilityPlanForReplicatedTargetIncludesRolloutContract(t *testing.
 	if plan.VerificationEvidence[2].Artifacts[1] != "docs/reports/replicated-event-log-durability-rollout-contract.md" {
 		t.Fatalf("expected rollout contract artifact, got %+v", plan.VerificationEvidence[2])
 	}
+	if plan.RolloutReadiness.Status != "blocked" || plan.RolloutReadiness.Phase != "contract" {
+		t.Fatalf("expected blocked contract readiness without broker config, got %+v", plan.RolloutReadiness)
+	}
+	if len(plan.RolloutReadiness.RemainingChecks) != len(plan.RolloutChecks) {
+		t.Fatalf("expected remaining checks to mirror rollout checks, got %+v", plan.RolloutReadiness.RemainingChecks)
+	}
 }
 
 func TestNewDurabilityPlanWithBrokerConfigIncludesBootstrapStatus(t *testing.T) {
@@ -53,5 +59,69 @@ func TestNewDurabilityPlanWithBrokerConfigIncludesBootstrapStatus(t *testing.T) 
 	}
 	if plan.BrokerBootstrap.ReplayLimit != 2048 || plan.BrokerBootstrap.CheckpointInterval != "15s" {
 		t.Fatalf("unexpected broker bootstrap timings: %+v", plan.BrokerBootstrap)
+	}
+	if plan.RolloutReadiness.Status != "contract_ready" || plan.RolloutReadiness.BrokerRuntime == nil || !plan.RolloutReadiness.BrokerRuntime.Ready {
+		t.Fatalf("expected contract-ready rollout readiness, got %+v", plan.RolloutReadiness)
+	}
+}
+
+func TestNewDurabilityPlanRolloutReadinessByBackend(t *testing.T) {
+	cases := []struct {
+		name                string
+		current             string
+		target              string
+		wantStatus          string
+		wantCurrentProbe    string
+		wantCheckpointProbe string
+	}{
+		{
+			name:                "memory current backend",
+			current:             "memory",
+			target:              "memory",
+			wantStatus:          "current_backend_active",
+			wantCurrentProbe:    "process_memory",
+			wantCheckpointProbe: "unsupported",
+		},
+		{
+			name:                "sqlite current backend",
+			current:             "sqlite",
+			target:              "sqlite",
+			wantStatus:          "current_backend_active",
+			wantCurrentProbe:    "durable_single_node",
+			wantCheckpointProbe: "native",
+		},
+		{
+			name:                "http current backend",
+			current:             "http",
+			target:              "http",
+			wantStatus:          "current_backend_active",
+			wantCurrentProbe:    "durable_shared_service",
+			wantCheckpointProbe: "native",
+		},
+		{
+			name:                "broker replicated target",
+			current:             "http",
+			target:              "broker_replicated",
+			wantStatus:          "blocked",
+			wantCurrentProbe:    "durable_shared_service",
+			wantCheckpointProbe: "native",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			plan := NewDurabilityPlan(tc.current, tc.target, 3)
+			if plan.RolloutReadiness.Status != tc.wantStatus {
+				t.Fatalf("expected status %q, got %+v", tc.wantStatus, plan.RolloutReadiness)
+			}
+			if plan.RolloutReadiness.CurrentProbe.Retention != tc.wantCurrentProbe {
+				t.Fatalf("expected current retention probe %q, got %+v", tc.wantCurrentProbe, plan.RolloutReadiness.CurrentProbe)
+			}
+			if plan.RolloutReadiness.CurrentProbe.Checkpoint != tc.wantCheckpointProbe {
+				t.Fatalf("expected current checkpoint probe %q, got %+v", tc.wantCheckpointProbe, plan.RolloutReadiness.CurrentProbe)
+			}
+			if tc.target == "broker_replicated" && plan.RolloutReadiness.TargetProbe.Retention != "replicated_log" {
+				t.Fatalf("expected replicated target probe, got %+v", plan.RolloutReadiness.TargetProbe)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary
- add a machine-readable `rollout_readiness` summary to event durability payloads
- expose the durability plan in control-center responses and carry rollout readiness into distributed diagnostics/report exports
- add regression coverage for memory, sqlite, http, and replicated-target readiness states

## Validation
- go test ./internal/events ./internal/api