### PR TITLE
OPE-233: surface Ray readiness in distributed diagnostics

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -112,6 +112,8 @@ func main() {
 		Control:          controller,
 		SchedulerPolicy:  policyStore,
 		SchedulerRuntime: schedulerRuntime,
+		RuntimeConfig:    cfg,
+		ReportsDir:       "docs/reports",
 	}
 	httpServer := &http.Server{Addr: cfg.HTTPAddr, Handler: server.Handler()}
 	go func() {

--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -70,11 +73,37 @@ type distributedDiagnosticsReport struct {
 	ExportURL string `json:"export_url"`
 }
 
+type distributedRayEvidence struct {
+	SummaryPath         string `json:"summary_path,omitempty"`
+	CanonicalReportPath string `json:"canonical_report_path,omitempty"`
+	BundleReportPath    string `json:"bundle_report_path,omitempty"`
+	BundlePath          string `json:"bundle_path,omitempty"`
+	ServiceLogPath      string `json:"service_log_path,omitempty"`
+	AuditLogPath        string `json:"audit_log_path,omitempty"`
+}
+
+type distributedRayReadiness struct {
+	Configured                 bool                   `json:"configured"`
+	Address                    string                 `json:"address,omitempty"`
+	ValidationStatus           string                 `json:"validation_status,omitempty"`
+	LocalValidationStatus      string                 `json:"local_validation_status,omitempty"`
+	KubernetesValidationStatus string                 `json:"kubernetes_validation_status,omitempty"`
+	LatestRunID                string                 `json:"latest_run_id,omitempty"`
+	GeneratedAt                string                 `json:"generated_at,omitempty"`
+	TaskID                     string                 `json:"task_id,omitempty"`
+	LatestEventType            string                 `json:"latest_event_type,omitempty"`
+	LatestEventAt              string                 `json:"latest_event_at,omitempty"`
+	JobArtifacts               []string               `json:"job_artifacts,omitempty"`
+	Evidence                   distributedRayEvidence `json:"evidence,omitempty"`
+	Notes                      []string               `json:"notes,omitempty"`
+}
+
 type distributedDiagnostics struct {
 	Summary          distributedDiagnosticsSummary `json:"summary"`
 	RoutingReasons   []routingReasonSummary        `json:"routing_reasons"`
 	ExecutorCapacity []executorCapacityView        `json:"executor_capacity"`
 	ClusterHealth    clusterHealthRollup           `json:"cluster_health"`
+	RayReadiness     distributedRayReadiness       `json:"ray_readiness"`
 	RolloutReport    distributedDiagnosticsReport  `json:"rollout_report"`
 }
 
@@ -89,6 +118,48 @@ type distributedTaskAssignment struct {
 	Task           domain.Task
 	EffectiveState domain.TaskState
 	Executor       domain.ExecutorKind
+}
+
+type liveValidationArtifactSummary struct {
+	RunID       string                         `json:"run_id"`
+	GeneratedAt string                         `json:"generated_at"`
+	Status      string                         `json:"status"`
+	BundlePath  string                         `json:"bundle_path"`
+	Local       liveValidationComponentSummary `json:"local"`
+	Kubernetes  liveValidationComponentSummary `json:"kubernetes"`
+	Ray         liveValidationComponentSummary `json:"ray"`
+}
+
+type liveValidationComponentSummary struct {
+	Enabled             bool                     `json:"enabled"`
+	BundleReportPath    string                   `json:"bundle_report_path"`
+	CanonicalReportPath string                   `json:"canonical_report_path"`
+	Status              string                   `json:"status"`
+	TaskID              string                   `json:"task_id"`
+	ServiceLogPath      string                   `json:"service_log_path"`
+	AuditLogPath        string                   `json:"audit_log_path"`
+	Report              liveValidationReportBody `json:"report"`
+}
+
+type liveValidationReportBody struct {
+	Status liveValidationReportStatus `json:"status"`
+}
+
+type liveValidationReportStatus struct {
+	State       string                  `json:"state"`
+	TaskID      string                  `json:"task_id"`
+	LatestEvent liveValidationEvent     `json:"latest_event"`
+	Task        liveValidationTaskState `json:"task"`
+}
+
+type liveValidationTaskState struct {
+	ID string `json:"id"`
+}
+
+type liveValidationEvent struct {
+	Type      string         `json:"type"`
+	Timestamp string         `json:"timestamp"`
+	Payload   map[string]any `json:"payload"`
 }
 
 func (s *Server) handleV2DistributedReport(w http.ResponseWriter, r *http.Request) {
@@ -122,6 +193,7 @@ func (s *Server) handleV2DistributedReport(w http.ResponseWriter, r *http.Reques
 		"routing_reasons":   diagnostics.RoutingReasons,
 		"executor_capacity": diagnostics.ExecutorCapacity,
 		"cluster_health":    diagnostics.ClusterHealth,
+		"ray_readiness":     diagnostics.RayReadiness,
 		"report":            diagnostics.RolloutReport,
 	})
 }
@@ -346,6 +418,7 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		RoutingReasons:   routingReasons,
 		ExecutorCapacity: executorCapacity,
 		ClusterHealth:    clusterHealth,
+		RayReadiness:     s.buildRayReadiness(),
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
 		Markdown:  renderDistributedDiagnosticsMarkdown(diagnostics, filters),
@@ -545,6 +618,112 @@ func taskRequiresTool(task domain.Task, tool string) bool {
 	return false
 }
 
+func (s *Server) buildRayReadiness() distributedRayReadiness {
+	readiness := distributedRayReadiness{
+		Configured: strings.TrimSpace(s.RuntimeConfig.RayAddress) != "",
+		Address:    strings.TrimSpace(s.RuntimeConfig.RayAddress),
+		Evidence: distributedRayEvidence{
+			SummaryPath: "docs/reports/live-validation-summary.json",
+		},
+	}
+	if readiness.Configured {
+		readiness.Notes = append(readiness.Notes, fmt.Sprintf("ray executor configured for %s", readiness.Address))
+	} else {
+		readiness.Notes = append(readiness.Notes, "ray executor address is not configured")
+	}
+	summary, err := s.loadLiveValidationSummary()
+	if err != nil {
+		report, reportErr := s.loadRayValidationReport()
+		if reportErr != nil {
+			readiness.Notes = append(readiness.Notes, "ray live-validation artifacts not found")
+			return readiness
+		}
+		readiness.Evidence.CanonicalReportPath = "docs/reports/ray-live-smoke-report.json"
+		populateRayReadinessFromComponent(&readiness, liveValidationComponentSummary{
+			CanonicalReportPath: readiness.Evidence.CanonicalReportPath,
+			Report:              report,
+		})
+		readiness.Notes = append(readiness.Notes, "loaded ray readiness from canonical smoke report without live-validation summary")
+		return readiness
+	}
+	readiness.LatestRunID = summary.RunID
+	readiness.GeneratedAt = summary.GeneratedAt
+	readiness.LocalValidationStatus = firstNonEmpty(summary.Local.Status, summary.Local.Report.Status.State)
+	readiness.KubernetesValidationStatus = firstNonEmpty(summary.Kubernetes.Status, summary.Kubernetes.Report.Status.State)
+	readiness.Evidence.BundlePath = summary.BundlePath
+	populateRayReadinessFromComponent(&readiness, summary.Ray)
+	switch {
+	case readiness.ValidationStatus == "succeeded":
+		readiness.Notes = append(readiness.Notes, "latest Ray live-validation bundle succeeded")
+	case readiness.ValidationStatus != "":
+		readiness.Notes = append(readiness.Notes, fmt.Sprintf("latest Ray live-validation bundle status is %s", readiness.ValidationStatus))
+	default:
+		readiness.Notes = append(readiness.Notes, "Ray live-validation bundle does not include a status")
+	}
+	if readiness.LocalValidationStatus != "" || readiness.KubernetesValidationStatus != "" {
+		readiness.Notes = append(readiness.Notes, fmt.Sprintf("companion validation states local=%s kubernetes=%s", firstNonEmpty(readiness.LocalValidationStatus, "unknown"), firstNonEmpty(readiness.KubernetesValidationStatus, "unknown")))
+	}
+	return readiness
+}
+
+func populateRayReadinessFromComponent(readiness *distributedRayReadiness, component liveValidationComponentSummary) {
+	readiness.ValidationStatus = firstNonEmpty(component.Status, component.Report.Status.State)
+	readiness.TaskID = firstNonEmpty(component.TaskID, component.Report.Status.TaskID, component.Report.Status.Task.ID)
+	readiness.LatestEventType = component.Report.Status.LatestEvent.Type
+	readiness.LatestEventAt = component.Report.Status.LatestEvent.Timestamp
+	readiness.JobArtifacts = stringSliceValue(component.Report.Status.LatestEvent.Payload["artifacts"])
+	readiness.Evidence.CanonicalReportPath = firstNonEmpty(readiness.Evidence.CanonicalReportPath, component.CanonicalReportPath)
+	readiness.Evidence.BundleReportPath = component.BundleReportPath
+	readiness.Evidence.ServiceLogPath = component.ServiceLogPath
+	readiness.Evidence.AuditLogPath = component.AuditLogPath
+}
+
+func (s *Server) loadLiveValidationSummary() (liveValidationArtifactSummary, error) {
+	var summary liveValidationArtifactSummary
+	content, err := os.ReadFile(filepath.Join(s.reportsDir(), "live-validation-summary.json"))
+	if err != nil {
+		return summary, err
+	}
+	if err := json.Unmarshal(content, &summary); err != nil {
+		return summary, err
+	}
+	return summary, nil
+}
+
+func (s *Server) loadRayValidationReport() (liveValidationReportBody, error) {
+	var report liveValidationReportBody
+	content, err := os.ReadFile(filepath.Join(s.reportsDir(), "ray-live-smoke-report.json"))
+	if err != nil {
+		return report, err
+	}
+	if err := json.Unmarshal(content, &report); err != nil {
+		return report, err
+	}
+	return report, nil
+}
+
+func (s *Server) reportsDir() string {
+	if strings.TrimSpace(s.ReportsDir) != "" {
+		return s.ReportsDir
+	}
+	return filepath.Join("docs", "reports")
+}
+
+func stringSliceValue(value any) []string {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		text, ok := item.(string)
+		if ok && strings.TrimSpace(text) != "" {
+			out = append(out, text)
+		}
+	}
+	return out
+}
+
 func distributedExportURL(filters controlCenterFilters) string {
 	values := url.Values{}
 	if filters.Team != "" {
@@ -654,6 +833,53 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 	}
 	lines = append(lines, "", "## Notes")
 	for _, note := range diagnostics.ClusterHealth.Notes {
+		lines = append(lines, "- "+note)
+	}
+	lines = append(lines, "", "## Ray Readiness")
+	lines = append(lines, fmt.Sprintf("- Configured: %t", diagnostics.RayReadiness.Configured))
+	if diagnostics.RayReadiness.Address != "" {
+		lines = append(lines, "- Address: "+diagnostics.RayReadiness.Address)
+	}
+	if diagnostics.RayReadiness.ValidationStatus != "" {
+		lines = append(lines, "- Validation status: "+diagnostics.RayReadiness.ValidationStatus)
+	}
+	if diagnostics.RayReadiness.LocalValidationStatus != "" || diagnostics.RayReadiness.KubernetesValidationStatus != "" {
+		lines = append(lines, fmt.Sprintf("- Companion validation: local=%s kubernetes=%s", firstNonEmpty(diagnostics.RayReadiness.LocalValidationStatus, "unknown"), firstNonEmpty(diagnostics.RayReadiness.KubernetesValidationStatus, "unknown")))
+	}
+	if diagnostics.RayReadiness.LatestRunID != "" {
+		lines = append(lines, "- Latest run: "+diagnostics.RayReadiness.LatestRunID)
+	}
+	if diagnostics.RayReadiness.GeneratedAt != "" {
+		lines = append(lines, "- Generated at: "+diagnostics.RayReadiness.GeneratedAt)
+	}
+	if diagnostics.RayReadiness.TaskID != "" {
+		lines = append(lines, "- Task ID: "+diagnostics.RayReadiness.TaskID)
+	}
+	if diagnostics.RayReadiness.LatestEventType != "" {
+		lines = append(lines, fmt.Sprintf("- Latest event: %s @ %s", diagnostics.RayReadiness.LatestEventType, firstNonEmpty(diagnostics.RayReadiness.LatestEventAt, "unknown")))
+	}
+	if len(diagnostics.RayReadiness.JobArtifacts) > 0 {
+		lines = append(lines, "- Job artifacts: "+strings.Join(diagnostics.RayReadiness.JobArtifacts, ", "))
+	}
+	if diagnostics.RayReadiness.Evidence.SummaryPath != "" {
+		lines = append(lines, "- Summary JSON: "+diagnostics.RayReadiness.Evidence.SummaryPath)
+	}
+	if diagnostics.RayReadiness.Evidence.CanonicalReportPath != "" {
+		lines = append(lines, "- Canonical report: "+diagnostics.RayReadiness.Evidence.CanonicalReportPath)
+	}
+	if diagnostics.RayReadiness.Evidence.BundleReportPath != "" {
+		lines = append(lines, "- Bundle report: "+diagnostics.RayReadiness.Evidence.BundleReportPath)
+	}
+	if diagnostics.RayReadiness.Evidence.BundlePath != "" {
+		lines = append(lines, "- Bundle path: "+diagnostics.RayReadiness.Evidence.BundlePath)
+	}
+	if diagnostics.RayReadiness.Evidence.ServiceLogPath != "" {
+		lines = append(lines, "- Service log: "+diagnostics.RayReadiness.Evidence.ServiceLogPath)
+	}
+	if diagnostics.RayReadiness.Evidence.AuditLogPath != "" {
+		lines = append(lines, "- Audit log: "+diagnostics.RayReadiness.Evidence.AuditLogPath)
+	}
+	for _, note := range diagnostics.RayReadiness.Notes {
 		lines = append(lines, "- "+note)
 	}
 	lines = append(lines, "")

--- a/bigclaw-go/internal/api/expansion_test.go
+++ b/bigclaw-go/internal/api/expansion_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"bigclaw-go/internal/config"
 	"bigclaw-go/internal/control"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
@@ -279,13 +280,16 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 	base := time.Date(2026, 3, 14, 9, 0, 0, 0, time.UTC)
 	recorder := observability.NewRecorder()
 	controller := control.New()
+	reportsDir := writeTestLiveValidationReports(t)
 	server := &Server{
-		Recorder:  recorder,
-		Queue:     queue.NewMemoryQueue(),
-		Executors: []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
-		Control:   controller,
-		Worker:    fakeWorkerPoolStatus{},
-		Now:       func() time.Time { return base.Add(6 * time.Hour) },
+		Recorder:      recorder,
+		Queue:         queue.NewMemoryQueue(),
+		Executors:     []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
+		Control:       controller,
+		Worker:        fakeWorkerPoolStatus{},
+		Now:           func() time.Time { return base.Add(6 * time.Hour) },
+		ReportsDir:    reportsDir,
+		RuntimeConfig: config.Config{RayAddress: "ray://127.0.0.1:10001"},
 	}
 	for _, task := range []domain.Task{
 		{ID: "report-local", TraceID: "trace-report-local", Title: "Local", State: domain.TaskSucceeded, Metadata: map[string]string{"team": "platform", "project": "apollo"}, UpdatedAt: base.Add(time.Minute)},
@@ -345,6 +349,16 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 				Count int    `json:"count"`
 			} `json:"takeover_owners"`
 		} `json:"cluster_health"`
+		RayReadiness struct {
+			Configured       bool     `json:"configured"`
+			ValidationStatus string   `json:"validation_status"`
+			TaskID           string   `json:"task_id"`
+			JobArtifacts     []string `json:"job_artifacts"`
+			Evidence         struct {
+				SummaryPath         string `json:"summary_path"`
+				CanonicalReportPath string `json:"canonical_report_path"`
+			} `json:"evidence"`
+		} `json:"ray_readiness"`
 		Report struct {
 			Markdown  string `json:"markdown"`
 			ExportURL string `json:"export_url"`
@@ -368,7 +382,13 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 	if len(decoded.ClusterHealth.TakeoverOwners) == 0 || decoded.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("unexpected takeover owner breakdown: %+v", decoded.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Report.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Report.Markdown, "gpu workloads default to ray executor") || !strings.Contains(decoded.Report.Markdown, "Team breakdown") {
+	if !decoded.RayReadiness.Configured || decoded.RayReadiness.ValidationStatus != "succeeded" || decoded.RayReadiness.TaskID != "ray-smoke-1773506812" || len(decoded.RayReadiness.JobArtifacts) != 1 || decoded.RayReadiness.JobArtifacts[0] != "ray://jobs/bigclaw-ray-smoke-1773506812" {
+		t.Fatalf("unexpected ray readiness payload: %+v", decoded.RayReadiness)
+	}
+	if decoded.RayReadiness.Evidence.SummaryPath != "docs/reports/live-validation-summary.json" || decoded.RayReadiness.Evidence.CanonicalReportPath != "docs/reports/ray-live-smoke-report.json" {
+		t.Fatalf("unexpected ray readiness evidence: %+v", decoded.RayReadiness.Evidence)
+	}
+	if !strings.Contains(decoded.Report.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Report.Markdown, "gpu workloads default to ray executor") || !strings.Contains(decoded.Report.Markdown, "Team breakdown") || !strings.Contains(decoded.Report.Markdown, "## Ray Readiness") || !strings.Contains(decoded.Report.Markdown, "docs/reports/ray-live-smoke-report.json") {
 		t.Fatalf("unexpected distributed markdown: %s", decoded.Report.Markdown)
 	}
 	if !strings.Contains(decoded.Report.ExportURL, "/v2/reports/distributed/export") {
@@ -383,7 +403,7 @@ func TestV2DistributedReportBuildsCapacityViewAndMarkdownExport(t *testing.T) {
 	if contentType := exportResponse.Header().Get("Content-Type"); !strings.Contains(contentType, "text/markdown") {
 		t.Fatalf("expected markdown export content type, got %q", contentType)
 	}
-	if !strings.Contains(exportResponse.Body.String(), "Executor Capacity") || !strings.Contains(exportResponse.Body.String(), "ray: gpu workloads default to ray executor") || !strings.Contains(exportResponse.Body.String(), "Takeover owners") {
+	if !strings.Contains(exportResponse.Body.String(), "Executor Capacity") || !strings.Contains(exportResponse.Body.String(), "ray: gpu workloads default to ray executor") || !strings.Contains(exportResponse.Body.String(), "Takeover owners") || !strings.Contains(exportResponse.Body.String(), "Ray Readiness") || !strings.Contains(exportResponse.Body.String(), "docs/reports/live-validation-summary.json") {
 		t.Fatalf("unexpected distributed export markdown: %s", exportResponse.Body.String())
 	}
 }

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"bigclaw-go/internal/config"
 	"bigclaw-go/internal/control"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
@@ -44,6 +45,8 @@ type Server struct {
 	FlowStore        *flow.Store
 	SchedulerPolicy  *scheduler.PolicyStore
 	SchedulerRuntime *scheduler.Scheduler
+	RuntimeConfig    config.Config
+	ReportsDir       string
 }
 
 type checkpointDiagnostics struct {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"bigclaw-go/internal/config"
 	"bigclaw-go/internal/control"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
@@ -42,6 +43,106 @@ func (fakeWorkerPoolStatus) Snapshots() []worker.Status {
 		{WorkerID: "worker-b", State: "leased", CurrentExecutor: domain.ExecutorKubernetes, SuccessfulRuns: 3, LeaseRenewals: 2, LastResult: "warming", PreemptionActive: true, CurrentPreemptionTaskID: "task-low", CurrentPreemptionWorkerID: "worker-low", LastPreemptedTaskID: "task-low", LastPreemptionAt: time.Unix(1700000100, 0), LastPreemptionReason: "preempted by urgent task task-urgent (priority=1)", PreemptionsIssued: 1},
 		{WorkerID: "worker-c", State: "idle", SuccessfulRuns: 8, LeaseRenewals: 0, LastResult: "idle"},
 	}
+}
+
+func writeTestLiveValidationReports(t *testing.T) string {
+	t.Helper()
+	reportsDir := filepath.Join(t.TempDir(), "docs", "reports")
+	if err := os.MkdirAll(reportsDir, 0o755); err != nil {
+		t.Fatalf("mkdir reports dir: %v", err)
+	}
+	summary := `{
+  "run_id": "20260314T164647Z",
+  "generated_at": "2026-03-14T16:46:57.671520+00:00",
+  "status": "succeeded",
+  "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
+  "local": {
+    "enabled": true,
+    "status": "succeeded",
+    "task_id": "local-smoke-1773506812",
+    "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
+    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
+    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log",
+    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl",
+    "report": {
+      "status": {
+        "state": "succeeded",
+        "task_id": "local-smoke-1773506812",
+        "latest_event": {
+          "type": "task.completed",
+          "timestamp": "2026-03-15T00:46:52.591566+08:00",
+          "payload": {
+            "artifacts": ["stdout.log"]
+          }
+        }
+      }
+    }
+  },
+  "kubernetes": {
+    "enabled": true,
+    "status": "succeeded",
+    "task_id": "kubernetes-smoke-1773506812",
+    "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
+    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
+    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log",
+    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl",
+    "report": {
+      "status": {
+        "state": "succeeded",
+        "task_id": "kubernetes-smoke-1773506812",
+        "latest_event": {
+          "type": "task.completed",
+          "timestamp": "2026-03-15T00:46:55.000000+08:00",
+          "payload": {
+            "artifacts": ["job.log"]
+          }
+        }
+      }
+    }
+  },
+  "ray": {
+    "enabled": true,
+    "status": "succeeded",
+    "task_id": "ray-smoke-1773506812",
+    "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
+    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
+    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log",
+    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
+    "report": {
+      "status": {
+        "state": "succeeded",
+        "task_id": "ray-smoke-1773506812",
+        "latest_event": {
+          "type": "task.completed",
+          "timestamp": "2026-03-15T00:46:56.003827+08:00",
+          "payload": {
+            "artifacts": ["ray://jobs/bigclaw-ray-smoke-1773506812"]
+          }
+        }
+      }
+    }
+  }
+}`
+	rayReport := `{
+  "status": {
+    "state": "succeeded",
+    "task_id": "ray-smoke-1773506812",
+    "latest_event": {
+      "type": "task.completed",
+      "timestamp": "2026-03-15T00:46:56.003827+08:00",
+      "payload": {
+        "artifacts": ["ray://jobs/bigclaw-ray-smoke-1773506812"]
+      }
+    }
+  }
+}`
+	if err := os.WriteFile(filepath.Join(reportsDir, "live-validation-summary.json"), []byte(summary), 0o644); err != nil {
+		t.Fatalf("write live validation summary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(reportsDir, "ray-live-smoke-report.json"), []byte(rayReport), 0o644); err != nil {
+		t.Fatalf("write ray validation report: %v", err)
+	}
+	return reportsDir
 }
 
 type blockingEventLog struct {
@@ -1686,13 +1787,16 @@ func TestV2ControlCenterIncludesMultiWorkerPoolSummary(t *testing.T) {
 func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	recorder := observability.NewRecorder()
 	controller := control.New()
+	reportsDir := writeTestLiveValidationReports(t)
 	server := &Server{
-		Recorder:  recorder,
-		Queue:     queue.NewMemoryQueue(),
-		Executors: []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
-		Control:   controller,
-		Worker:    fakeWorkerPoolStatus{},
-		Now:       func() time.Time { return time.Unix(1700007200, 0) },
+		Recorder:      recorder,
+		Queue:         queue.NewMemoryQueue(),
+		Executors:     []domain.ExecutorKind{domain.ExecutorLocal, domain.ExecutorKubernetes, domain.ExecutorRay},
+		Control:       controller,
+		Worker:        fakeWorkerPoolStatus{},
+		Now:           func() time.Time { return time.Unix(1700007200, 0) },
+		ReportsDir:    reportsDir,
+		RuntimeConfig: config.Config{RayAddress: "ray://127.0.0.1:10001"},
 	}
 	handler := server.Handler()
 	base := time.Unix(1700000000, 0)
@@ -1763,6 +1867,21 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 					Count int    `json:"count"`
 				} `json:"takeover_owners"`
 			} `json:"cluster_health"`
+			RayReadiness struct {
+				Configured                 bool     `json:"configured"`
+				Address                    string   `json:"address"`
+				ValidationStatus           string   `json:"validation_status"`
+				LocalValidationStatus      string   `json:"local_validation_status"`
+				KubernetesValidationStatus string   `json:"kubernetes_validation_status"`
+				LatestRunID                string   `json:"latest_run_id"`
+				TaskID                     string   `json:"task_id"`
+				JobArtifacts               []string `json:"job_artifacts"`
+				Evidence                   struct {
+					SummaryPath         string `json:"summary_path"`
+					CanonicalReportPath string `json:"canonical_report_path"`
+					BundleReportPath    string `json:"bundle_report_path"`
+				} `json:"evidence"`
+			} `json:"ray_readiness"`
 			RolloutReport struct {
 				Markdown  string `json:"markdown"`
 				ExportURL string `json:"export_url"`
@@ -1799,7 +1918,16 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	if len(decoded.Diagnostics.ClusterHealth.TakeoverOwners) == 0 || decoded.Diagnostics.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("expected takeover owner rollup, got %+v", decoded.Diagnostics.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
+	if !decoded.Diagnostics.RayReadiness.Configured || decoded.Diagnostics.RayReadiness.Address != "ray://127.0.0.1:10001" || decoded.Diagnostics.RayReadiness.ValidationStatus != "succeeded" || decoded.Diagnostics.RayReadiness.LocalValidationStatus != "succeeded" || decoded.Diagnostics.RayReadiness.KubernetesValidationStatus != "succeeded" || decoded.Diagnostics.RayReadiness.LatestRunID != "20260314T164647Z" || decoded.Diagnostics.RayReadiness.TaskID != "ray-smoke-1773506812" {
+		t.Fatalf("unexpected ray readiness payload: %+v", decoded.Diagnostics.RayReadiness)
+	}
+	if len(decoded.Diagnostics.RayReadiness.JobArtifacts) != 1 || decoded.Diagnostics.RayReadiness.JobArtifacts[0] != "ray://jobs/bigclaw-ray-smoke-1773506812" {
+		t.Fatalf("unexpected ray readiness artifacts: %+v", decoded.Diagnostics.RayReadiness.JobArtifacts)
+	}
+	if decoded.Diagnostics.RayReadiness.Evidence.SummaryPath != "docs/reports/live-validation-summary.json" || decoded.Diagnostics.RayReadiness.Evidence.CanonicalReportPath != "docs/reports/ray-live-smoke-report.json" || decoded.Diagnostics.RayReadiness.Evidence.BundleReportPath != "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json" {
+		t.Fatalf("unexpected ray readiness evidence: %+v", decoded.Diagnostics.RayReadiness.Evidence)
+	}
+	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Ray Readiness") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/ray-live-smoke-report.json") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
 		t.Fatalf("unexpected rollout report payload: %+v", decoded.Diagnostics.RolloutReport)
 	}
 }


### PR DESCRIPTION
## Summary
- add a `ray_readiness` section to distributed diagnostics and report exports
- load Ray readiness from runtime config plus canonical live-validation artifacts under `docs/reports`
- cover the control-center and distributed report endpoints with isolated regression fixtures

## Validation
- cd bigclaw-go && go test ./internal/api -run 'TestV2ControlCenterIncludesDistributedDiagnostics|TestV2DistributedReportBuildsCapacityViewAndMarkdownExport'
- cd bigclaw-go && go test ./...