### PR TITLE
OPE-237 Normalize live validation bundle index

### DIFF
--- a/bigclaw-go/README.md
+++ b/bigclaw-go/README.md
@@ -82,7 +82,7 @@ This bootstrap now covers an MVP slice for all current Go rewrite planning ticke
 - `scripts/e2e/kubernetes_smoke.sh` runs a real Kubernetes smoke task through BigClaw
 - `scripts/e2e/ray_smoke.sh` runs a real Ray Jobs API smoke task through BigClaw
 - `scripts/e2e/run_task_smoke.py` is the generic submit/poll helper used by all wrappers
-- `scripts/e2e/export_validation_bundle.py` exports repo-native evidence bundles, latest report copies, and the validation index
+- `scripts/e2e/export_validation_bundle.py` exports repo-native evidence bundles, latest report copies, and a versioned validation-index contract
 - `scripts/migration/shadow_compare.py` compares primary vs shadow BigClaw endpoints
 - `scripts/benchmark/run_suite.sh` regenerates benchmark evidence
 - Full instructions live in `docs/e2e-validation.md` and `docs/migration-shadow.md`
@@ -99,7 +99,7 @@ curl localhost:8080/metrics
 
 ## One-shot validation
 
-Each `run_all.sh` invocation now creates a timestamped evidence bundle under `docs/reports/live-validation-runs/<run-id>/` so local, Kubernetes, and Ray logs stay isolated while the latest canonical reports remain easy to link in review notes.
+Each `run_all.sh` invocation now creates a timestamped evidence bundle under `docs/reports/live-validation-runs/<run-id>/` so local, Kubernetes, and Ray logs stay isolated while the latest canonical reports and stable `live_validation_bundle/v1` index stay easy to link in review notes.
 
 ```bash
 cd bigclaw-go

--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -57,7 +57,16 @@ export BIGCLAW_QUEUE_BACKEND=sqlite
 ./scripts/e2e/run_all.sh
 ```
 
-The script writes a consolidated summary to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, and creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`.
+The script writes a versioned bundle contract to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, and creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`.
+
+The canonical summary/index contract now stays stable around:
+- `schema_version`
+- `bundle.run_id`, `bundle.path`, `bundle.summary_path`, and `bundle.readme_path`
+- `components.<lane>.status`
+- `components.<lane>.artifacts.*` for bundle-local and canonical report/log paths
+- `components.<lane>.task`, `components.<lane>.report_summary`, and `components.<lane>.execution_artifacts`
+
+Raw executor-specific report bodies remain in the per-lane JSON artifacts inside the bundle instead of being embedded into the canonical summary.
 
 ## Mixed workload matrix
 

--- a/bigclaw-go/docs/reports/live-validation-index.json
+++ b/bigclaw-go/docs/reports/live-validation-index.json
@@ -1,638 +1,122 @@
 {
+  "schema_version": "live_validation_bundle/v1",
   "latest": {
+    "schema_version": "live_validation_bundle/v1",
     "run_id": "20260314T164647Z",
-    "generated_at": "2026-03-14T16:46:57.671520+00:00",
+    "generated_at": "2026-03-15T16:14:13.522935+00:00",
     "status": "succeeded",
-    "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
     "closeout_commands": [
       "cd bigclaw-go && ./scripts/e2e/run_all.sh",
       "cd bigclaw-go && go test ./...",
       "git push origin <branch> && git log -1 --stat"
     ],
-    "local": {
-      "enabled": true,
-      "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
-      "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
-      "report": {
-        "autostarted": true,
-        "base_url": "http://127.0.0.1:53346",
+    "bundle": {
+      "run_id": "20260314T164647Z",
+      "path": "docs/reports/live-validation-runs/20260314T164647Z",
+      "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+      "readme_path": "docs/reports/live-validation-runs/20260314T164647Z/README.md"
+    },
+    "components": {
+      "local": {
+        "name": "local",
+        "enabled": true,
+        "status": "succeeded",
+        "artifacts": {
+          "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
+          "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
+          "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
+          "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
+          "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log",
+          "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl"
+        },
         "task": {
           "id": "local-smoke-1773506812",
           "trace_id": "local-smoke-1773506812",
-          "title": "SQLite smoke",
-          "state": "queued",
-          "required_executor": "local",
-          "entrypoint": "echo hello from sqlite",
-          "metadata": {
-            "executor": "local",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571701+08:00",
-          "updated_at": "2026-03-15T00:46:52.571701+08:00"
+          "state": "succeeded"
         },
-        "status": {
-          "events": [
-            {
-              "id": "local-smoke-1773506812-queued",
-              "type": "task.queued",
-              "task_id": "local-smoke-1773506812",
-              "trace_id": "local-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.571701+08:00",
-              "payload": {
-                "executor": "local",
-                "title": "SQLite smoke"
-              }
-            },
-            {
-              "id": "local-smoke-1773506812-leased",
-              "type": "task.leased",
-              "task_id": "local-smoke-1773506812",
-              "trace_id": "local-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.579603+08:00"
-            },
-            {
-              "id": "local-smoke-1773506812-routed",
-              "type": "scheduler.routed",
-              "task_id": "local-smoke-1773506812",
-              "trace_id": "local-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.57972+08:00",
-              "payload": {
-                "executor": "local",
-                "quota": {
-                  "TenantID": "",
-                  "ConcurrentLimit": 32,
-                  "CurrentRunning": 0,
-                  "BudgetRemaining": 1000,
-                  "QueueDepth": 0,
-                  "MaxQueueDepth": 0,
-                  "PreemptibleExecutions": 0
-                },
-                "reason": "required executor=local"
-              }
-            },
-            {
-              "id": "local-smoke-1773506812-started",
-              "type": "task.started",
-              "task_id": "local-smoke-1773506812",
-              "trace_id": "local-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.579798+08:00",
-              "payload": {
-                "executor": "local",
-                "required_tools": null
-              }
-            },
-            {
-              "id": "local-smoke-1773506812-completed",
-              "type": "task.completed",
-              "task_id": "local-smoke-1773506812",
-              "trace_id": "local-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.591566+08:00",
-              "payload": {
-                "artifacts": [
-                  "stdout.log"
-                ],
-                "executor": "local",
-                "finished_at": "2026-03-14T16:46:52Z",
-                "message": "local execution completed"
-              }
-            }
-          ],
-          "latest_event": {
-            "id": "local-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.591566+08:00",
-            "payload": {
-              "artifacts": [
-                "stdout.log"
-              ],
-              "executor": "local",
-              "finished_at": "2026-03-14T16:46:52Z",
-              "message": "local execution completed"
-            }
-          },
-          "state": "succeeded",
-          "task": {
-            "id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "title": "SQLite smoke",
-            "state": "succeeded",
-            "required_executor": "local",
-            "entrypoint": "echo hello from sqlite",
-            "metadata": {
-              "executor": "local",
-              "smoke_test": "true"
-            },
-            "execution_timeout_seconds": 180,
-            "created_at": "2026-03-15T00:46:52.571701+08:00",
-            "updated_at": "2026-03-15T00:46:52.591566+08:00"
-          },
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812"
+        "control_plane": {
+          "base_url": "http://127.0.0.1:53346"
         },
-        "events": [
-          {
-            "id": "local-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571701+08:00",
-            "payload": {
-              "executor": "local",
-              "title": "SQLite smoke"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579603+08:00"
-          },
-          {
-            "id": "local-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.57972+08:00",
-            "payload": {
-              "executor": "local",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=local"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579798+08:00",
-            "payload": {
-              "executor": "local",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.591566+08:00",
-            "payload": {
-              "artifacts": [
-                "stdout.log"
-              ],
-              "executor": "local",
-              "finished_at": "2026-03-14T16:46:52Z",
-              "message": "local execution completed"
-            }
-          }
-        ],
-        "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-        "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-4debbv7g.log"
+        "report_summary": {
+          "latest_event_type": "task.completed"
+        },
+        "execution_artifacts": [
+          "stdout.log"
+        ]
       },
-      "status": "succeeded",
-      "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
-      "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
-      "task_id": "local-smoke-1773506812",
-      "base_url": "http://127.0.0.1:53346",
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-      "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl",
-      "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log"
-    },
-    "kubernetes": {
-      "enabled": true,
-      "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
-      "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
-      "report": {
-        "autostarted": true,
-        "base_url": "http://127.0.0.1:53344",
+      "kubernetes": {
+        "name": "kubernetes",
+        "enabled": true,
+        "status": "succeeded",
+        "artifacts": {
+          "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
+          "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
+          "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
+          "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
+          "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log",
+          "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl"
+        },
         "task": {
           "id": "kubernetes-smoke-1773506812",
           "trace_id": "kubernetes-smoke-1773506812",
-          "title": "Kubernetes smoke test",
-          "state": "queued",
-          "required_executor": "kubernetes",
-          "container_image": "alpine:3.20",
-          "entrypoint": "echo hello from kubernetes",
-          "metadata": {
-            "executor": "kubernetes",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.567439+08:00",
-          "updated_at": "2026-03-15T00:46:52.567439+08:00"
+          "state": "succeeded"
         },
-        "status": {
-          "events": [
-            {
-              "id": "kubernetes-smoke-1773506812-queued",
-              "type": "task.queued",
-              "task_id": "kubernetes-smoke-1773506812",
-              "trace_id": "kubernetes-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.567439+08:00",
-              "payload": {
-                "executor": "kubernetes",
-                "title": "Kubernetes smoke test"
-              }
-            },
-            {
-              "id": "kubernetes-smoke-1773506812-leased",
-              "type": "task.leased",
-              "task_id": "kubernetes-smoke-1773506812",
-              "trace_id": "kubernetes-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.576384+08:00"
-            },
-            {
-              "id": "kubernetes-smoke-1773506812-routed",
-              "type": "scheduler.routed",
-              "task_id": "kubernetes-smoke-1773506812",
-              "trace_id": "kubernetes-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.576479+08:00",
-              "payload": {
-                "executor": "kubernetes",
-                "quota": {
-                  "TenantID": "",
-                  "ConcurrentLimit": 32,
-                  "CurrentRunning": 0,
-                  "BudgetRemaining": 1000,
-                  "QueueDepth": 0,
-                  "MaxQueueDepth": 0,
-                  "PreemptibleExecutions": 0
-                },
-                "reason": "required executor=kubernetes"
-              }
-            },
-            {
-              "id": "kubernetes-smoke-1773506812-started",
-              "type": "task.started",
-              "task_id": "kubernetes-smoke-1773506812",
-              "trace_id": "kubernetes-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.577808+08:00",
-              "payload": {
-                "executor": "kubernetes",
-                "required_tools": null
-              }
-            },
-            {
-              "id": "kubernetes-smoke-1773506812-completed",
-              "type": "task.completed",
-              "task_id": "kubernetes-smoke-1773506812",
-              "trace_id": "kubernetes-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:56.646488+08:00",
-              "payload": {
-                "artifacts": [
-                  "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-                  "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-                ],
-                "executor": "kubernetes",
-                "finished_at": "2026-03-14T16:46:56Z",
-                "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-              }
-            }
-          ],
-          "latest_event": {
-            "id": "kubernetes-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.646488+08:00",
-            "payload": {
-              "artifacts": [
-                "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-                "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-              ],
-              "executor": "kubernetes",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-            }
-          },
-          "state": "succeeded",
-          "task": {
-            "id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "title": "Kubernetes smoke test",
-            "state": "succeeded",
-            "required_executor": "kubernetes",
-            "container_image": "alpine:3.20",
-            "entrypoint": "echo hello from kubernetes",
-            "metadata": {
-              "executor": "kubernetes",
-              "smoke_test": "true"
-            },
-            "execution_timeout_seconds": 180,
-            "created_at": "2026-03-15T00:46:52.567439+08:00",
-            "updated_at": "2026-03-15T00:46:56.646488+08:00"
-          },
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812"
+        "control_plane": {
+          "base_url": "http://127.0.0.1:53344"
         },
-        "events": [
-          {
-            "id": "kubernetes-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.567439+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "title": "Kubernetes smoke test"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576384+08:00"
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576479+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=kubernetes"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.577808+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.646488+08:00",
-            "payload": {
-              "artifacts": [
-                "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-                "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-              ],
-              "executor": "kubernetes",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-            }
-          }
-        ],
-        "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-        "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-qtjud5_3.log"
+        "report_summary": {
+          "latest_event_type": "task.completed"
+        },
+        "execution_artifacts": [
+          "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
+          "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
+        ]
       },
-      "status": "succeeded",
-      "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
-      "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
-      "task_id": "kubernetes-smoke-1773506812",
-      "base_url": "http://127.0.0.1:53344",
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-      "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl",
-      "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log"
-    },
-    "ray": {
-      "enabled": true,
-      "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
-      "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
-      "report": {
-        "autostarted": true,
-        "base_url": "http://127.0.0.1:53347",
+      "ray": {
+        "name": "ray",
+        "enabled": true,
+        "status": "succeeded",
+        "artifacts": {
+          "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
+          "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
+          "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
+          "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
+          "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log",
+          "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl"
+        },
         "task": {
           "id": "ray-smoke-1773506812",
           "trace_id": "ray-smoke-1773506812",
-          "title": "Ray smoke test",
-          "state": "queued",
-          "required_executor": "ray",
-          "entrypoint": "python -c \"print('hello from ray')\"",
-          "metadata": {
-            "executor": "ray",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571917+08:00",
-          "updated_at": "2026-03-15T00:46:52.571917+08:00"
+          "state": "succeeded"
         },
-        "status": {
-          "events": [
-            {
-              "id": "ray-smoke-1773506812-queued",
-              "type": "task.queued",
-              "task_id": "ray-smoke-1773506812",
-              "trace_id": "ray-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.571917+08:00",
-              "payload": {
-                "executor": "ray",
-                "title": "Ray smoke test"
-              }
-            },
-            {
-              "id": "ray-smoke-1773506812-leased",
-              "type": "task.leased",
-              "task_id": "ray-smoke-1773506812",
-              "trace_id": "ray-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.665974+08:00"
-            },
-            {
-              "id": "ray-smoke-1773506812-routed",
-              "type": "scheduler.routed",
-              "task_id": "ray-smoke-1773506812",
-              "trace_id": "ray-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.666096+08:00",
-              "payload": {
-                "executor": "ray",
-                "quota": {
-                  "TenantID": "",
-                  "ConcurrentLimit": 32,
-                  "CurrentRunning": 0,
-                  "BudgetRemaining": 1000,
-                  "QueueDepth": 0,
-                  "MaxQueueDepth": 0,
-                  "PreemptibleExecutions": 0
-                },
-                "reason": "required executor=ray"
-              }
-            },
-            {
-              "id": "ray-smoke-1773506812-started",
-              "type": "task.started",
-              "task_id": "ray-smoke-1773506812",
-              "trace_id": "ray-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:52.666214+08:00",
-              "payload": {
-                "executor": "ray",
-                "required_tools": null
-              }
-            },
-            {
-              "id": "ray-smoke-1773506812-completed",
-              "type": "task.completed",
-              "task_id": "ray-smoke-1773506812",
-              "trace_id": "ray-smoke-1773506812",
-              "timestamp": "2026-03-15T00:46:56.003827+08:00",
-              "payload": {
-                "artifacts": [
-                  "ray://jobs/bigclaw-ray-smoke-1773506812"
-                ],
-                "executor": "ray",
-                "finished_at": "2026-03-14T16:46:56Z",
-                "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-              }
-            }
-          ],
-          "latest_event": {
-            "id": "ray-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.003827+08:00",
-            "payload": {
-              "artifacts": [
-                "ray://jobs/bigclaw-ray-smoke-1773506812"
-              ],
-              "executor": "ray",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-            }
-          },
-          "state": "succeeded",
-          "task": {
-            "id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "title": "Ray smoke test",
-            "state": "succeeded",
-            "required_executor": "ray",
-            "entrypoint": "python -c \"print('hello from ray')\"",
-            "metadata": {
-              "executor": "ray",
-              "smoke_test": "true"
-            },
-            "execution_timeout_seconds": 180,
-            "created_at": "2026-03-15T00:46:52.571917+08:00",
-            "updated_at": "2026-03-15T00:46:56.003827+08:00"
-          },
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812"
+        "control_plane": {
+          "base_url": "http://127.0.0.1:53347"
         },
-        "events": [
-          {
-            "id": "ray-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571917+08:00",
-            "payload": {
-              "executor": "ray",
-              "title": "Ray smoke test"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.665974+08:00"
-          },
-          {
-            "id": "ray-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666096+08:00",
-            "payload": {
-              "executor": "ray",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=ray"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666214+08:00",
-            "payload": {
-              "executor": "ray",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.003827+08:00",
-            "payload": {
-              "artifacts": [
-                "ray://jobs/bigclaw-ray-smoke-1773506812"
-              ],
-              "executor": "ray",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-            }
-          }
-        ],
-        "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-        "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-v8eiu2gv.log"
-      },
-      "status": "succeeded",
-      "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
-      "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
-      "task_id": "ray-smoke-1773506812",
-      "base_url": "http://127.0.0.1:53347",
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-      "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
-      "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
-    },
-    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+        "report_summary": {
+          "latest_event_type": "task.completed"
+        },
+        "execution_artifacts": [
+          "ray://jobs/bigclaw-ray-smoke-1773506812"
+        ]
+      }
+    }
   },
-  "recent_runs": [
+  "recent_bundles": [
     {
       "run_id": "20260314T164647Z",
-      "generated_at": "2026-03-14T16:46:57.671520+00:00",
+      "generated_at": "2026-03-15T16:14:13.522935+00:00",
       "status": "succeeded",
       "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
-      "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+      "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+      "readme_path": "docs/reports/live-validation-runs/20260314T164647Z/README.md"
     },
     {
       "run_id": "20260314T163430Z",
       "generated_at": "2026-03-14T16:34:42.080370+00:00",
       "status": "succeeded",
       "bundle_path": "docs/reports/live-validation-runs/20260314T163430Z",
-      "summary_path": "docs/reports/live-validation-runs/20260314T163430Z/summary.json"
+      "summary_path": "docs/reports/live-validation-runs/20260314T163430Z/summary.json",
+      "readme_path": ""
     }
   ]
 }

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -1,45 +1,56 @@
 # Live Validation Index
 
+- Schema: `live_validation_bundle/v1`
 - Latest run: `20260314T164647Z`
-- Generated at: `2026-03-14T16:46:57.671520+00:00`
+- Generated at: `2026-03-15T16:14:13.522935+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260314T164647Z`
-- Summary JSON: `docs/reports/live-validation-runs/20260314T164647Z/summary.json`
+- Bundle summary: `docs/reports/live-validation-runs/20260314T164647Z/summary.json`
+- Bundle README: `docs/reports/live-validation-runs/20260314T164647Z/README.md`
 
-## Latest bundle artifacts
+## Component bundles
 
 ### local
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json`
-- Latest report: `docs/reports/sqlite-smoke-report.json`
+- Canonical report: `docs/reports/sqlite-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/local.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl`
 - Task ID: `local-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `stdout.log`
 
 ### kubernetes
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json`
-- Latest report: `docs/reports/kubernetes-live-smoke-report.json`
+- Canonical report: `docs/reports/kubernetes-live-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl`
 - Task ID: `kubernetes-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812, k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv`
 
 ### ray
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json`
-- Latest report: `docs/reports/ray-live-smoke-report.json`
+- Canonical report: `docs/reports/ray-live-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/ray.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl`
 - Task ID: `ray-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `ray://jobs/bigclaw-ray-smoke-1773506812`
 
 ## Workflow closeout commands
 
@@ -49,5 +60,5 @@
 
 ## Recent bundles
 
-- `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
+- `20260314T164647Z` · `succeeded` · `2026-03-15T16:14:13.522935+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`

--- a/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/README.md
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/README.md
@@ -1,45 +1,56 @@
 # Live Validation Index
 
+- Schema: `live_validation_bundle/v1`
 - Latest run: `20260314T164647Z`
-- Generated at: `2026-03-14T16:46:57.671520+00:00`
+- Generated at: `2026-03-15T16:14:13.522935+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260314T164647Z`
-- Summary JSON: `docs/reports/live-validation-runs/20260314T164647Z/summary.json`
+- Bundle summary: `docs/reports/live-validation-runs/20260314T164647Z/summary.json`
+- Bundle README: `docs/reports/live-validation-runs/20260314T164647Z/README.md`
 
-## Latest bundle artifacts
+## Component bundles
 
 ### local
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json`
-- Latest report: `docs/reports/sqlite-smoke-report.json`
+- Canonical report: `docs/reports/sqlite-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/local.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl`
 - Task ID: `local-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `stdout.log`
 
 ### kubernetes
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json`
-- Latest report: `docs/reports/kubernetes-live-smoke-report.json`
+- Canonical report: `docs/reports/kubernetes-live-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl`
 - Task ID: `kubernetes-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812, k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv`
 
 ### ray
 - Enabled: `True`
 - Status: `succeeded`
 - Bundle report: `docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json`
-- Latest report: `docs/reports/ray-live-smoke-report.json`
+- Canonical report: `docs/reports/ray-live-smoke-report.json`
 - Stdout log: `docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log`
 - Stderr log: `docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log`
 - Service log: `docs/reports/live-validation-runs/20260314T164647Z/ray.service.log`
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl`
 - Task ID: `ray-smoke-1773506812`
+- Task state: `succeeded`
+- Latest event: `task.completed`
+- Execution artifacts: `ray://jobs/bigclaw-ray-smoke-1773506812`
 
 ## Workflow closeout commands
 
@@ -49,5 +60,5 @@
 
 ## Recent bundles
 
-- `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
+- `20260314T164647Z` · `succeeded` · `2026-03-15T16:14:13.522935+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`

--- a/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/summary.json
@@ -1,620 +1,101 @@
 {
+  "schema_version": "live_validation_bundle/v1",
   "run_id": "20260314T164647Z",
-  "generated_at": "2026-03-14T16:46:57.671520+00:00",
+  "generated_at": "2026-03-15T16:14:13.522935+00:00",
   "status": "succeeded",
-  "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
   "closeout_commands": [
     "cd bigclaw-go && ./scripts/e2e/run_all.sh",
     "cd bigclaw-go && go test ./...",
     "git push origin <branch> && git log -1 --stat"
   ],
-  "local": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
-    "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53346",
+  "bundle": {
+    "run_id": "20260314T164647Z",
+    "path": "docs/reports/live-validation-runs/20260314T164647Z",
+    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+    "readme_path": "docs/reports/live-validation-runs/20260314T164647Z/README.md"
+  },
+  "components": {
+    "local": {
+      "name": "local",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
+        "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl"
+      },
       "task": {
         "id": "local-smoke-1773506812",
         "trace_id": "local-smoke-1773506812",
-        "title": "SQLite smoke",
-        "state": "queued",
-        "required_executor": "local",
-        "entrypoint": "echo hello from sqlite",
-        "metadata": {
-          "executor": "local",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.571701+08:00",
-        "updated_at": "2026-03-15T00:46:52.571701+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "local-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571701+08:00",
-            "payload": {
-              "executor": "local",
-              "title": "SQLite smoke"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579603+08:00"
-          },
-          {
-            "id": "local-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.57972+08:00",
-            "payload": {
-              "executor": "local",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=local"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579798+08:00",
-            "payload": {
-              "executor": "local",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.591566+08:00",
-            "payload": {
-              "artifacts": [
-                "stdout.log"
-              ],
-              "executor": "local",
-              "finished_at": "2026-03-14T16:46:52Z",
-              "message": "local execution completed"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "local-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.591566+08:00",
-          "payload": {
-            "artifacts": [
-              "stdout.log"
-            ],
-            "executor": "local",
-            "finished_at": "2026-03-14T16:46:52Z",
-            "message": "local execution completed"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "title": "SQLite smoke",
-          "state": "succeeded",
-          "required_executor": "local",
-          "entrypoint": "echo hello from sqlite",
-          "metadata": {
-            "executor": "local",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571701+08:00",
-          "updated_at": "2026-03-15T00:46:52.591566+08:00"
-        },
-        "task_id": "local-smoke-1773506812",
-        "trace_id": "local-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53346"
       },
-      "events": [
-        {
-          "id": "local-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.571701+08:00",
-          "payload": {
-            "executor": "local",
-            "title": "SQLite smoke"
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.579603+08:00"
-        },
-        {
-          "id": "local-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.57972+08:00",
-          "payload": {
-            "executor": "local",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=local"
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.579798+08:00",
-          "payload": {
-            "executor": "local",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.591566+08:00",
-          "payload": {
-            "artifacts": [
-              "stdout.log"
-            ],
-            "executor": "local",
-            "finished_at": "2026-03-14T16:46:52Z",
-            "message": "local execution completed"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-4debbv7g.log"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "stdout.log"
+      ]
     },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
-    "task_id": "local-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53346",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log"
-  },
-  "kubernetes": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
-    "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53344",
+    "kubernetes": {
+      "name": "kubernetes",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
+        "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl"
+      },
       "task": {
         "id": "kubernetes-smoke-1773506812",
         "trace_id": "kubernetes-smoke-1773506812",
-        "title": "Kubernetes smoke test",
-        "state": "queued",
-        "required_executor": "kubernetes",
-        "container_image": "alpine:3.20",
-        "entrypoint": "echo hello from kubernetes",
-        "metadata": {
-          "executor": "kubernetes",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.567439+08:00",
-        "updated_at": "2026-03-15T00:46:52.567439+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "kubernetes-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.567439+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "title": "Kubernetes smoke test"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576384+08:00"
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576479+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=kubernetes"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.577808+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.646488+08:00",
-            "payload": {
-              "artifacts": [
-                "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-                "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-              ],
-              "executor": "kubernetes",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "kubernetes-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.646488+08:00",
-          "payload": {
-            "artifacts": [
-              "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-              "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-            ],
-            "executor": "kubernetes",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "title": "Kubernetes smoke test",
-          "state": "succeeded",
-          "required_executor": "kubernetes",
-          "container_image": "alpine:3.20",
-          "entrypoint": "echo hello from kubernetes",
-          "metadata": {
-            "executor": "kubernetes",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.567439+08:00",
-          "updated_at": "2026-03-15T00:46:56.646488+08:00"
-        },
-        "task_id": "kubernetes-smoke-1773506812",
-        "trace_id": "kubernetes-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53344"
       },
-      "events": [
-        {
-          "id": "kubernetes-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.567439+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "title": "Kubernetes smoke test"
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.576384+08:00"
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.576479+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=kubernetes"
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.577808+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.646488+08:00",
-          "payload": {
-            "artifacts": [
-              "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-              "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-            ],
-            "executor": "kubernetes",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-qtjud5_3.log"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
+        "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
+      ]
     },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
-    "task_id": "kubernetes-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53344",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log"
-  },
-  "ray": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
-    "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53347",
+    "ray": {
+      "name": "ray",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
+        "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl"
+      },
       "task": {
         "id": "ray-smoke-1773506812",
         "trace_id": "ray-smoke-1773506812",
-        "title": "Ray smoke test",
-        "state": "queued",
-        "required_executor": "ray",
-        "entrypoint": "python -c \"print('hello from ray')\"",
-        "metadata": {
-          "executor": "ray",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.571917+08:00",
-        "updated_at": "2026-03-15T00:46:52.571917+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "ray-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571917+08:00",
-            "payload": {
-              "executor": "ray",
-              "title": "Ray smoke test"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.665974+08:00"
-          },
-          {
-            "id": "ray-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666096+08:00",
-            "payload": {
-              "executor": "ray",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=ray"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666214+08:00",
-            "payload": {
-              "executor": "ray",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.003827+08:00",
-            "payload": {
-              "artifacts": [
-                "ray://jobs/bigclaw-ray-smoke-1773506812"
-              ],
-              "executor": "ray",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "ray-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.003827+08:00",
-          "payload": {
-            "artifacts": [
-              "ray://jobs/bigclaw-ray-smoke-1773506812"
-            ],
-            "executor": "ray",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "title": "Ray smoke test",
-          "state": "succeeded",
-          "required_executor": "ray",
-          "entrypoint": "python -c \"print('hello from ray')\"",
-          "metadata": {
-            "executor": "ray",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571917+08:00",
-          "updated_at": "2026-03-15T00:46:56.003827+08:00"
-        },
-        "task_id": "ray-smoke-1773506812",
-        "trace_id": "ray-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53347"
       },
-      "events": [
-        {
-          "id": "ray-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.571917+08:00",
-          "payload": {
-            "executor": "ray",
-            "title": "Ray smoke test"
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.665974+08:00"
-        },
-        {
-          "id": "ray-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.666096+08:00",
-          "payload": {
-            "executor": "ray",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=ray"
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.666214+08:00",
-          "payload": {
-            "executor": "ray",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.003827+08:00",
-          "payload": {
-            "artifacts": [
-              "ray://jobs/bigclaw-ray-smoke-1773506812"
-            ],
-            "executor": "ray",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-v8eiu2gv.log"
-    },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
-    "task_id": "ray-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53347",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
-  },
-  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "ray://jobs/bigclaw-ray-smoke-1773506812"
+      ]
+    }
+  }
 }

--- a/bigclaw-go/docs/reports/live-validation-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-summary.json
@@ -1,620 +1,101 @@
 {
+  "schema_version": "live_validation_bundle/v1",
   "run_id": "20260314T164647Z",
-  "generated_at": "2026-03-14T16:46:57.671520+00:00",
+  "generated_at": "2026-03-15T16:14:13.522935+00:00",
   "status": "succeeded",
-  "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
   "closeout_commands": [
     "cd bigclaw-go && ./scripts/e2e/run_all.sh",
     "cd bigclaw-go && go test ./...",
     "git push origin <branch> && git log -1 --stat"
   ],
-  "local": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
-    "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53346",
+  "bundle": {
+    "run_id": "20260314T164647Z",
+    "path": "docs/reports/live-validation-runs/20260314T164647Z",
+    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+    "readme_path": "docs/reports/live-validation-runs/20260314T164647Z/README.md"
+  },
+  "components": {
+    "local": {
+      "name": "local",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json",
+        "canonical_report_path": "docs/reports/sqlite-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl"
+      },
       "task": {
         "id": "local-smoke-1773506812",
         "trace_id": "local-smoke-1773506812",
-        "title": "SQLite smoke",
-        "state": "queued",
-        "required_executor": "local",
-        "entrypoint": "echo hello from sqlite",
-        "metadata": {
-          "executor": "local",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.571701+08:00",
-        "updated_at": "2026-03-15T00:46:52.571701+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "local-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571701+08:00",
-            "payload": {
-              "executor": "local",
-              "title": "SQLite smoke"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579603+08:00"
-          },
-          {
-            "id": "local-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.57972+08:00",
-            "payload": {
-              "executor": "local",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=local"
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.579798+08:00",
-            "payload": {
-              "executor": "local",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "local-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "local-smoke-1773506812",
-            "trace_id": "local-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.591566+08:00",
-            "payload": {
-              "artifacts": [
-                "stdout.log"
-              ],
-              "executor": "local",
-              "finished_at": "2026-03-14T16:46:52Z",
-              "message": "local execution completed"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "local-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.591566+08:00",
-          "payload": {
-            "artifacts": [
-              "stdout.log"
-            ],
-            "executor": "local",
-            "finished_at": "2026-03-14T16:46:52Z",
-            "message": "local execution completed"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "title": "SQLite smoke",
-          "state": "succeeded",
-          "required_executor": "local",
-          "entrypoint": "echo hello from sqlite",
-          "metadata": {
-            "executor": "local",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571701+08:00",
-          "updated_at": "2026-03-15T00:46:52.591566+08:00"
-        },
-        "task_id": "local-smoke-1773506812",
-        "trace_id": "local-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53346"
       },
-      "events": [
-        {
-          "id": "local-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.571701+08:00",
-          "payload": {
-            "executor": "local",
-            "title": "SQLite smoke"
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.579603+08:00"
-        },
-        {
-          "id": "local-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.57972+08:00",
-          "payload": {
-            "executor": "local",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=local"
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.579798+08:00",
-          "payload": {
-            "executor": "local",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "local-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "local-smoke-1773506812",
-          "trace_id": "local-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.591566+08:00",
-          "payload": {
-            "artifacts": [
-              "stdout.log"
-            ],
-            "executor": "local",
-            "finished_at": "2026-03-14T16:46:52Z",
-            "message": "local execution completed"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-4debbv7g.log"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "stdout.log"
+      ]
     },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log",
-    "task_id": "local-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53346",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-0a6f2beb",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/local.service.log"
-  },
-  "kubernetes": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
-    "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53344",
+    "kubernetes": {
+      "name": "kubernetes",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json",
+        "canonical_report_path": "docs/reports/kubernetes-live-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl"
+      },
       "task": {
         "id": "kubernetes-smoke-1773506812",
         "trace_id": "kubernetes-smoke-1773506812",
-        "title": "Kubernetes smoke test",
-        "state": "queued",
-        "required_executor": "kubernetes",
-        "container_image": "alpine:3.20",
-        "entrypoint": "echo hello from kubernetes",
-        "metadata": {
-          "executor": "kubernetes",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.567439+08:00",
-        "updated_at": "2026-03-15T00:46:52.567439+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "kubernetes-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.567439+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "title": "Kubernetes smoke test"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576384+08:00"
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.576479+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=kubernetes"
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.577808+08:00",
-            "payload": {
-              "executor": "kubernetes",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "kubernetes-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "kubernetes-smoke-1773506812",
-            "trace_id": "kubernetes-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.646488+08:00",
-            "payload": {
-              "artifacts": [
-                "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-                "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-              ],
-              "executor": "kubernetes",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "kubernetes-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.646488+08:00",
-          "payload": {
-            "artifacts": [
-              "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-              "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-            ],
-            "executor": "kubernetes",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "title": "Kubernetes smoke test",
-          "state": "succeeded",
-          "required_executor": "kubernetes",
-          "container_image": "alpine:3.20",
-          "entrypoint": "echo hello from kubernetes",
-          "metadata": {
-            "executor": "kubernetes",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.567439+08:00",
-          "updated_at": "2026-03-15T00:46:56.646488+08:00"
-        },
-        "task_id": "kubernetes-smoke-1773506812",
-        "trace_id": "kubernetes-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53344"
       },
-      "events": [
-        {
-          "id": "kubernetes-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.567439+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "title": "Kubernetes smoke test"
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.576384+08:00"
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.576479+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=kubernetes"
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.577808+08:00",
-          "payload": {
-            "executor": "kubernetes",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "kubernetes-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "kubernetes-smoke-1773506812",
-          "trace_id": "kubernetes-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.646488+08:00",
-          "payload": {
-            "artifacts": [
-              "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
-              "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
-            ],
-            "executor": "kubernetes",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "kubernetes job bigclaw-kubernetes-smoke-1773506812-1773506812 succeeded: hello from kubernetes"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-qtjud5_3.log"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "k8s://jobs/ray/bigclaw-kubernetes-smoke-1773506812-1773506812",
+        "k8s://pods/ray/bigclaw-kubernetes-smoke-1773506812-1773506812-krbvv"
+      ]
     },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log",
-    "task_id": "kubernetes-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53344",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-zwon1z4t",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log"
-  },
-  "ray": {
-    "enabled": true,
-    "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
-    "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
-    "report": {
-      "autostarted": true,
-      "base_url": "http://127.0.0.1:53347",
+    "ray": {
+      "name": "ray",
+      "enabled": true,
+      "status": "succeeded",
+      "artifacts": {
+        "bundle_report_path": "docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json",
+        "canonical_report_path": "docs/reports/ray-live-smoke-report.json",
+        "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
+        "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
+        "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log",
+        "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl"
+      },
       "task": {
         "id": "ray-smoke-1773506812",
         "trace_id": "ray-smoke-1773506812",
-        "title": "Ray smoke test",
-        "state": "queued",
-        "required_executor": "ray",
-        "entrypoint": "python -c \"print('hello from ray')\"",
-        "metadata": {
-          "executor": "ray",
-          "smoke_test": "true"
-        },
-        "execution_timeout_seconds": 180,
-        "created_at": "2026-03-15T00:46:52.571917+08:00",
-        "updated_at": "2026-03-15T00:46:52.571917+08:00"
+        "state": "succeeded"
       },
-      "status": {
-        "events": [
-          {
-            "id": "ray-smoke-1773506812-queued",
-            "type": "task.queued",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.571917+08:00",
-            "payload": {
-              "executor": "ray",
-              "title": "Ray smoke test"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-leased",
-            "type": "task.leased",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.665974+08:00"
-          },
-          {
-            "id": "ray-smoke-1773506812-routed",
-            "type": "scheduler.routed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666096+08:00",
-            "payload": {
-              "executor": "ray",
-              "quota": {
-                "TenantID": "",
-                "ConcurrentLimit": 32,
-                "CurrentRunning": 0,
-                "BudgetRemaining": 1000,
-                "QueueDepth": 0,
-                "MaxQueueDepth": 0,
-                "PreemptibleExecutions": 0
-              },
-              "reason": "required executor=ray"
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-started",
-            "type": "task.started",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:52.666214+08:00",
-            "payload": {
-              "executor": "ray",
-              "required_tools": null
-            }
-          },
-          {
-            "id": "ray-smoke-1773506812-completed",
-            "type": "task.completed",
-            "task_id": "ray-smoke-1773506812",
-            "trace_id": "ray-smoke-1773506812",
-            "timestamp": "2026-03-15T00:46:56.003827+08:00",
-            "payload": {
-              "artifacts": [
-                "ray://jobs/bigclaw-ray-smoke-1773506812"
-              ],
-              "executor": "ray",
-              "finished_at": "2026-03-14T16:46:56Z",
-              "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-            }
-          }
-        ],
-        "latest_event": {
-          "id": "ray-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.003827+08:00",
-          "payload": {
-            "artifacts": [
-              "ray://jobs/bigclaw-ray-smoke-1773506812"
-            ],
-            "executor": "ray",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-          }
-        },
-        "state": "succeeded",
-        "task": {
-          "id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "title": "Ray smoke test",
-          "state": "succeeded",
-          "required_executor": "ray",
-          "entrypoint": "python -c \"print('hello from ray')\"",
-          "metadata": {
-            "executor": "ray",
-            "smoke_test": "true"
-          },
-          "execution_timeout_seconds": 180,
-          "created_at": "2026-03-15T00:46:52.571917+08:00",
-          "updated_at": "2026-03-15T00:46:56.003827+08:00"
-        },
-        "task_id": "ray-smoke-1773506812",
-        "trace_id": "ray-smoke-1773506812"
+      "control_plane": {
+        "base_url": "http://127.0.0.1:53347"
       },
-      "events": [
-        {
-          "id": "ray-smoke-1773506812-queued",
-          "type": "task.queued",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.571917+08:00",
-          "payload": {
-            "executor": "ray",
-            "title": "Ray smoke test"
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-leased",
-          "type": "task.leased",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.665974+08:00"
-        },
-        {
-          "id": "ray-smoke-1773506812-routed",
-          "type": "scheduler.routed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.666096+08:00",
-          "payload": {
-            "executor": "ray",
-            "quota": {
-              "TenantID": "",
-              "ConcurrentLimit": 32,
-              "CurrentRunning": 0,
-              "BudgetRemaining": 1000,
-              "QueueDepth": 0,
-              "MaxQueueDepth": 0,
-              "PreemptibleExecutions": 0
-            },
-            "reason": "required executor=ray"
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-started",
-          "type": "task.started",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:52.666214+08:00",
-          "payload": {
-            "executor": "ray",
-            "required_tools": null
-          }
-        },
-        {
-          "id": "ray-smoke-1773506812-completed",
-          "type": "task.completed",
-          "task_id": "ray-smoke-1773506812",
-          "trace_id": "ray-smoke-1773506812",
-          "timestamp": "2026-03-15T00:46:56.003827+08:00",
-          "payload": {
-            "artifacts": [
-              "ray://jobs/bigclaw-ray-smoke-1773506812"
-            ],
-            "executor": "ray",
-            "finished_at": "2026-03-14T16:46:56Z",
-            "message": "ray job bigclaw-ray-smoke-1773506812 succeeded: 2026-03-14 09:46:52,857\tINFO job_manager.py:579 -- Runtime env is setting up.\nRunning entrypoint for job bigclaw-ray-smoke-1773506812: python -c \"print('hello from ray')\"\nhello from ray"
-          }
-        }
-      ],
-      "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-e2e-v8eiu2gv.log"
-    },
-    "status": "succeeded",
-    "stdout_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log",
-    "stderr_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log",
-    "task_id": "ray-smoke-1773506812",
-    "base_url": "http://127.0.0.1:53347",
-    "state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-state-dmvx6qwa",
-    "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
-    "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
-  },
-  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+      "report_summary": {
+        "latest_event_type": "task.completed"
+      },
+      "execution_artifacts": [
+        "ray://jobs/bigclaw-ray-smoke-1773506812"
+      ]
+    }
+  }
 }

--- a/bigclaw-go/scripts/e2e/export_validation_bundle.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 
+SCHEMA_VERSION = 'live_validation_bundle/v1'
 LATEST_REPORTS = {
     'local': 'docs/reports/sqlite-smoke-report.json',
     'kubernetes': 'docs/reports/kubernetes-live-smoke-report.json',
@@ -32,9 +33,15 @@ def relpath(path: Path, root: Path) -> str:
         return str(path)
 
 
+def same_path(source: Path, destination: Path) -> bool:
+    return source.expanduser().resolve() == destination.expanduser().resolve()
+
+
 def copy_text_artifact(source: Path, destination: Path) -> str:
     if not source.exists():
         return ''
+    if same_path(source, destination):
+        return str(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
     return str(destination)
@@ -43,6 +50,8 @@ def copy_text_artifact(source: Path, destination: Path) -> str:
 def copy_json_artifact(source: Path, destination: Path) -> str:
     if not source.exists():
         return ''
+    if same_path(source, destination):
+        return str(destination)
     payload = read_json(source)
     if payload is None:
         return ''
@@ -65,7 +74,23 @@ def component_status(report: Optional[dict[str, Any]]) -> str:
     return 'unknown'
 
 
-def build_component_section(
+def first_artifact_list(report: dict[str, Any]) -> list[str]:
+    status = report.get('status')
+    if isinstance(status, dict):
+        latest_event = status.get('latest_event')
+        if isinstance(latest_event, dict):
+            payload = latest_event.get('payload')
+            if isinstance(payload, dict):
+                artifacts = payload.get('artifacts')
+                if isinstance(artifacts, list):
+                    return [str(item) for item in artifacts]
+    artifacts = report.get('artifacts')
+    if isinstance(artifacts, list):
+        return [str(item) for item in artifacts]
+    return []
+
+
+def build_component_contract(
     *,
     name: str,
     enabled: bool,
@@ -76,50 +101,128 @@ def build_component_section(
     stderr_path: Path,
 ) -> dict[str, Any]:
     latest_report_path = root / LATEST_REPORTS[name]
-    section: dict[str, Any] = {
-        'enabled': enabled,
-        'bundle_report_path': relpath(report_path, root),
+    artifacts = {
+        'bundle_report_path': relpath(report_path, root) if enabled else '',
         'canonical_report_path': LATEST_REPORTS[name],
+        'stdout_path': '',
+        'stderr_path': '',
+        'service_log_path': '',
+        'audit_log_path': '',
+    }
+    section: dict[str, Any] = {
+        'name': name,
+        'enabled': enabled,
+        'status': 'skipped',
+        'artifacts': artifacts,
+        'task': {
+            'id': '',
+            'trace_id': '',
+            'state': '',
+        },
+        'control_plane': {
+            'base_url': '',
+        },
+        'report_summary': {
+            'latest_event_type': '',
+        },
+        'execution_artifacts': [],
     }
     if not enabled:
-        section['status'] = 'skipped'
         return section
 
     report = read_json(report_path)
-    section['report'] = report
     section['status'] = component_status(report)
+    if not isinstance(report, dict):
+        return section
 
     copied_latest = copy_json_artifact(report_path, latest_report_path)
     if copied_latest:
-        section['canonical_report_path'] = relpath(Path(copied_latest), root)
+        section['artifacts']['canonical_report_path'] = relpath(Path(copied_latest), root)
 
     stdout_copy = copy_text_artifact(stdout_path, bundle_dir / f'{name}.stdout.log')
     stderr_copy = copy_text_artifact(stderr_path, bundle_dir / f'{name}.stderr.log')
     if stdout_copy:
-        section['stdout_path'] = relpath(Path(stdout_copy), root)
+        section['artifacts']['stdout_path'] = relpath(Path(stdout_copy), root)
     if stderr_copy:
-        section['stderr_path'] = relpath(Path(stderr_copy), root)
+        section['artifacts']['stderr_path'] = relpath(Path(stderr_copy), root)
 
-    if isinstance(report, dict):
-        task = report.get('task')
-        if isinstance(task, dict) and task.get('id'):
-            section['task_id'] = task['id']
-        base_url = report.get('base_url')
-        if base_url:
-            section['base_url'] = base_url
-        state_dir = report.get('state_dir')
-        if state_dir:
-            section['state_dir'] = state_dir
-            audit_source = Path(state_dir) / 'audit.jsonl'
-            audit_copy = copy_text_artifact(audit_source, bundle_dir / f'{name}.audit.jsonl')
-            if audit_copy:
-                section['audit_log_path'] = relpath(Path(audit_copy), root)
-        service_log = report.get('service_log')
-        if service_log:
-            service_copy = copy_text_artifact(Path(service_log), bundle_dir / f'{name}.service.log')
-            if service_copy:
-                section['service_log_path'] = relpath(Path(service_copy), root)
+    task = report.get('task')
+    if isinstance(task, dict):
+        section['task']['id'] = str(task.get('id', ''))
+        section['task']['trace_id'] = str(task.get('trace_id', ''))
+        section['task']['state'] = str(task.get('state', ''))
+    base_url = report.get('base_url')
+    if base_url:
+        section['control_plane']['base_url'] = str(base_url)
+
+    status = report.get('status')
+    if isinstance(status, dict):
+        latest_event = status.get('latest_event')
+        if isinstance(latest_event, dict):
+            section['report_summary']['latest_event_type'] = str(latest_event.get('type', ''))
+        task_state = status.get('state')
+        if task_state:
+            section['task']['state'] = str(task_state)
+
+    section['execution_artifacts'] = first_artifact_list(report)
+
+    state_dir = report.get('state_dir')
+    if state_dir:
+        audit_source = Path(state_dir) / 'audit.jsonl'
+        audit_copy = copy_text_artifact(audit_source, bundle_dir / f'{name}.audit.jsonl')
+        if audit_copy:
+            section['artifacts']['audit_log_path'] = relpath(Path(audit_copy), root)
+    existing_audit_copy = bundle_dir / f'{name}.audit.jsonl'
+    if not section['artifacts']['audit_log_path'] and existing_audit_copy.exists():
+        section['artifacts']['audit_log_path'] = relpath(existing_audit_copy, root)
+    service_log = report.get('service_log')
+    if service_log:
+        service_copy = copy_text_artifact(Path(service_log), bundle_dir / f'{name}.service.log')
+        if service_copy:
+            section['artifacts']['service_log_path'] = relpath(Path(service_copy), root)
+    existing_service_copy = bundle_dir / f'{name}.service.log'
+    if not section['artifacts']['service_log_path'] and existing_service_copy.exists():
+        section['artifacts']['service_log_path'] = relpath(existing_service_copy, root)
+
     return section
+
+
+def build_component_section(
+    *,
+    name: str,
+    enabled: bool,
+    root: Path,
+    bundle_dir: Path,
+    report_path: Path,
+    stdout_path: Path,
+    stderr_path: Path,
+) -> dict[str, Any]:
+    return build_component_contract(
+        name=name,
+        enabled=enabled,
+        root=root,
+        bundle_dir=bundle_dir,
+        report_path=report_path,
+        stdout_path=stdout_path,
+        stderr_path=stderr_path,
+    )
+
+
+def summary_bundle(summary: dict[str, Any]) -> dict[str, str]:
+    bundle = summary.get('bundle')
+    if isinstance(bundle, dict):
+        return {
+            'run_id': str(bundle.get('run_id', '')),
+            'path': str(bundle.get('path', '')),
+            'summary_path': str(bundle.get('summary_path', '')),
+            'readme_path': str(bundle.get('readme_path', '')),
+        }
+    return {
+        'run_id': str(summary.get('run_id', '')),
+        'path': str(summary.get('bundle_path', '')),
+        'summary_path': str(summary.get('summary_path', '')),
+        'readme_path': str(summary.get('readme_path', '')),
+    }
 
 
 def build_recent_runs(bundle_root: Path, root: Path, limit: int = 8) -> list[dict[str, Any]]:
@@ -137,48 +240,60 @@ def build_recent_runs(bundle_root: Path, root: Path, limit: int = 8) -> list[dic
     runs.sort(key=lambda item: item[0], reverse=True)
     items: list[dict[str, Any]] = []
     for _, summary in runs[:limit]:
+        bundle = summary_bundle(summary)
         items.append(
             {
-                'run_id': summary.get('run_id', ''),
+                'run_id': bundle['run_id'],
                 'generated_at': summary.get('generated_at', ''),
                 'status': summary.get('status', 'unknown'),
-                'bundle_path': summary.get('bundle_path', ''),
-                'summary_path': summary.get('summary_path', ''),
+                'bundle_path': bundle['path'],
+                'summary_path': bundle['summary_path'],
+                'readme_path': bundle['readme_path'],
             }
         )
     return items
 
 
 def render_index(summary: dict[str, Any], recent_runs: list[dict[str, Any]]) -> str:
+    bundle = summary['bundle']
     lines = [
         '# Live Validation Index',
         '',
-        f"- Latest run: `{summary['run_id']}`",
+        f"- Schema: `{summary['schema_version']}`",
+        f"- Latest run: `{bundle['run_id']}`",
         f"- Generated at: `{summary['generated_at']}`",
         f"- Status: `{summary['status']}`",
-        f"- Bundle: `{summary['bundle_path']}`",
-        f"- Summary JSON: `{summary['summary_path']}`",
+        f"- Bundle: `{bundle['path']}`",
+        f"- Bundle summary: `{bundle['summary_path']}`",
+        f"- Bundle README: `{bundle['readme_path']}`",
         '',
-        '## Latest bundle artifacts',
+        '## Component bundles',
         '',
     ]
     for name in ('local', 'kubernetes', 'ray'):
-        section = summary[name]
+        section = summary['components'][name]
+        artifacts = section['artifacts']
         lines.append(f"### {name}")
         lines.append(f"- Enabled: `{section['enabled']}`")
         lines.append(f"- Status: `{section['status']}`")
-        lines.append(f"- Bundle report: `{section['bundle_report_path']}`")
-        lines.append(f"- Latest report: `{section['canonical_report_path']}`")
-        if section.get('stdout_path'):
-            lines.append(f"- Stdout log: `{section['stdout_path']}`")
-        if section.get('stderr_path'):
-            lines.append(f"- Stderr log: `{section['stderr_path']}`")
-        if section.get('service_log_path'):
-            lines.append(f"- Service log: `{section['service_log_path']}`")
-        if section.get('audit_log_path'):
-            lines.append(f"- Audit log: `{section['audit_log_path']}`")
-        if section.get('task_id'):
-            lines.append(f"- Task ID: `{section['task_id']}`")
+        lines.append(f"- Bundle report: `{artifacts['bundle_report_path']}`")
+        lines.append(f"- Canonical report: `{artifacts['canonical_report_path']}`")
+        if artifacts.get('stdout_path'):
+            lines.append(f"- Stdout log: `{artifacts['stdout_path']}`")
+        if artifacts.get('stderr_path'):
+            lines.append(f"- Stderr log: `{artifacts['stderr_path']}`")
+        if artifacts.get('service_log_path'):
+            lines.append(f"- Service log: `{artifacts['service_log_path']}`")
+        if artifacts.get('audit_log_path'):
+            lines.append(f"- Audit log: `{artifacts['audit_log_path']}`")
+        if section['task'].get('id'):
+            lines.append(f"- Task ID: `{section['task']['id']}`")
+        if section['task'].get('state'):
+            lines.append(f"- Task state: `{section['task']['state']}`")
+        if section['report_summary'].get('latest_event_type'):
+            lines.append(f"- Latest event: `{section['report_summary']['latest_event_type']}`")
+        if section['execution_artifacts']:
+            lines.append(f"- Execution artifacts: `{', '.join(section['execution_artifacts'])}`")
         lines.append('')
 
     lines.extend(['## Workflow closeout commands', ''])
@@ -228,17 +343,26 @@ def main() -> int:
     bundle_dir.mkdir(parents=True, exist_ok=True)
 
     summary = {
+        'schema_version': SCHEMA_VERSION,
         'run_id': args.run_id,
         'generated_at': datetime.now(timezone.utc).isoformat(),
         'status': 'succeeded' if args.validation_status == '0' else 'failed',
-        'bundle_path': relpath(bundle_dir, root),
         'closeout_commands': [
             'cd bigclaw-go && ./scripts/e2e/run_all.sh',
             'cd bigclaw-go && go test ./...',
             'git push origin <branch> && git log -1 --stat',
         ],
     }
-    summary['local'] = build_component_section(
+    bundle_summary_path = bundle_dir / 'summary.json'
+    bundle_readme_path = bundle_dir / 'README.md'
+    summary['bundle'] = {
+        'run_id': args.run_id,
+        'path': relpath(bundle_dir, root),
+        'summary_path': relpath(bundle_summary_path, root),
+        'readme_path': relpath(bundle_readme_path, root),
+    }
+    summary['components'] = {}
+    summary['components']['local'] = build_component_section(
         name='local',
         enabled=args.run_local == '1',
         root=root,
@@ -247,7 +371,7 @@ def main() -> int:
         stdout_path=Path(args.local_stdout_path),
         stderr_path=Path(args.local_stderr_path),
     )
-    summary['kubernetes'] = build_component_section(
+    summary['components']['kubernetes'] = build_component_section(
         name='kubernetes',
         enabled=args.run_kubernetes == '1',
         root=root,
@@ -256,7 +380,7 @@ def main() -> int:
         stdout_path=Path(args.kubernetes_stdout_path),
         stderr_path=Path(args.kubernetes_stderr_path),
     )
-    summary['ray'] = build_component_section(
+    summary['components']['ray'] = build_component_section(
         name='ray',
         enabled=args.run_ray == '1',
         root=root,
@@ -265,22 +389,23 @@ def main() -> int:
         stdout_path=Path(args.ray_stdout_path),
         stderr_path=Path(args.ray_stderr_path),
     )
-
-    bundle_summary_path = bundle_dir / 'summary.json'
     canonical_summary_path = root / args.summary_path
-    summary['summary_path'] = relpath(bundle_summary_path, root)
     write_json(bundle_summary_path, summary)
     write_json(canonical_summary_path, summary)
 
     bundle_root = bundle_dir.parent
     recent_runs = build_recent_runs(bundle_root, root)
-    manifest = {'latest': summary, 'recent_runs': recent_runs}
+    manifest = {
+        'schema_version': SCHEMA_VERSION,
+        'latest': summary,
+        'recent_bundles': recent_runs,
+    }
     write_json(root / args.manifest_path, manifest)
 
     index_text = render_index(summary, recent_runs)
     (root / args.index_path).parent.mkdir(parents=True, exist_ok=True)
     (root / args.index_path).write_text(index_text, encoding='utf-8')
-    (bundle_dir / 'README.md').write_text(index_text, encoding='utf-8')
+    bundle_readme_path.write_text(index_text, encoding='utf-8')
 
     print(json.dumps(summary, ensure_ascii=False, indent=2))
     return 0 if summary['status'] == 'succeeded' else 1

--- a/bigclaw-go/scripts/e2e/test_export_validation_bundle.py
+++ b/bigclaw-go/scripts/e2e/test_export_validation_bundle.py
@@ -1,0 +1,140 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name('export_validation_bundle.py')
+
+
+def write_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + '\n', encoding='utf-8')
+
+
+def report_payload(name: str) -> dict:
+    return {
+        'base_url': f'http://127.0.0.1/{name}',
+        'task': {
+            'id': f'{name}-task',
+            'trace_id': f'{name}-trace',
+            'state': 'succeeded',
+        },
+        'status': {
+            'state': 'succeeded',
+            'latest_event': {
+                'type': 'task.completed',
+                'payload': {
+                    'artifacts': [f'{name}://artifact/1'],
+                },
+            },
+        },
+        'state_dir': '/tmp/should-not-leak',
+        'service_log': '/tmp/should-not-leak/service.log',
+    }
+
+
+class ExportValidationBundleTest(unittest.TestCase):
+    def test_cli_emits_stable_bundle_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            root = Path(tmp_dir)
+            bundle_dir = root / 'docs/reports/live-validation-runs/20260316T000000Z'
+            bundle_dir.mkdir(parents=True, exist_ok=True)
+
+            previous_bundle = root / 'docs/reports/live-validation-runs/20260315T000000Z'
+            write_json(
+                previous_bundle / 'summary.json',
+                {
+                    'run_id': '20260315T000000Z',
+                    'generated_at': '2026-03-15T00:00:00+00:00',
+                    'status': 'succeeded',
+                    'bundle_path': 'docs/reports/live-validation-runs/20260315T000000Z',
+                    'summary_path': 'docs/reports/live-validation-runs/20260315T000000Z/summary.json',
+                },
+            )
+
+            local_report = bundle_dir / 'sqlite-smoke-report.json'
+            k8s_report = bundle_dir / 'kubernetes-live-smoke-report.json'
+            ray_report = bundle_dir / 'ray-live-smoke-report.json'
+            write_json(local_report, report_payload('local'))
+            write_json(k8s_report, report_payload('kubernetes'))
+            write_json(ray_report, report_payload('ray'))
+
+            local_out = root / 'tmp/local.out'
+            local_err = root / 'tmp/local.err'
+            k8s_out = root / 'tmp/k8s.out'
+            k8s_err = root / 'tmp/k8s.err'
+            ray_out = root / 'tmp/ray.out'
+            ray_err = root / 'tmp/ray.err'
+            for path in (local_out, local_err, k8s_out, k8s_err, ray_out, ray_err):
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(f'{path.name}\n', encoding='utf-8')
+
+            completed = subprocess.run(
+                [
+                    'python3',
+                    str(SCRIPT_PATH),
+                    '--go-root',
+                    str(root),
+                    '--run-id',
+                    '20260316T000000Z',
+                    '--bundle-dir',
+                    'docs/reports/live-validation-runs/20260316T000000Z',
+                    '--validation-status',
+                    '0',
+                    '--local-report-path',
+                    str(local_report.relative_to(root)),
+                    '--local-stdout-path',
+                    str(local_out),
+                    '--local-stderr-path',
+                    str(local_err),
+                    '--kubernetes-report-path',
+                    str(k8s_report.relative_to(root)),
+                    '--kubernetes-stdout-path',
+                    str(k8s_out),
+                    '--kubernetes-stderr-path',
+                    str(k8s_err),
+                    '--ray-report-path',
+                    str(ray_report.relative_to(root)),
+                    '--ray-stdout-path',
+                    str(ray_out),
+                    '--ray-stderr-path',
+                    str(ray_err),
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+            summary = json.loads((root / 'docs/reports/live-validation-summary.json').read_text(encoding='utf-8'))
+            manifest = json.loads((root / 'docs/reports/live-validation-index.json').read_text(encoding='utf-8'))
+            index_text = (root / 'docs/reports/live-validation-index.md').read_text(encoding='utf-8')
+
+            self.assertEqual(summary['schema_version'], 'live_validation_bundle/v1')
+            self.assertEqual(summary['bundle']['run_id'], '20260316T000000Z')
+            self.assertEqual(
+                summary['bundle']['summary_path'],
+                'docs/reports/live-validation-runs/20260316T000000Z/summary.json',
+            )
+            self.assertEqual(
+                summary['components']['local']['artifacts']['bundle_report_path'],
+                'docs/reports/live-validation-runs/20260316T000000Z/sqlite-smoke-report.json',
+            )
+            self.assertEqual(summary['components']['local']['task']['id'], 'local-task')
+            self.assertEqual(summary['components']['local']['report_summary']['latest_event_type'], 'task.completed')
+            self.assertEqual(summary['components']['local']['execution_artifacts'], ['local://artifact/1'])
+            self.assertNotIn('/tmp/should-not-leak', json.dumps(summary))
+
+            self.assertEqual(manifest['schema_version'], 'live_validation_bundle/v1')
+            self.assertEqual(manifest['latest']['bundle']['readme_path'], 'docs/reports/live-validation-runs/20260316T000000Z/README.md')
+            self.assertEqual(manifest['recent_bundles'][0]['run_id'], '20260316T000000Z')
+            self.assertEqual(manifest['recent_bundles'][1]['run_id'], '20260315T000000Z')
+            self.assertIn('- Schema: `live_validation_bundle/v1`', index_text)
+            self.assertIn('- Bundle README: `docs/reports/live-validation-runs/20260316T000000Z/README.md`', index_text)
+            self.assertIn('local://artifact/1', index_text)
+            self.assertIn('"schema_version": "live_validation_bundle/v1"', completed.stdout)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize the live-validation exporter around a versioned `live_validation_bundle/v1` contract
- keep bundle-level artifact paths stable while removing raw report bodies and host-specific temp paths from the canonical summary/index
- add a deterministic CLI regression test and refresh the checked-in live-validation bundle artifacts/docs

## Validation
- python3 -m unittest scripts.e2e.test_export_validation_bundle
- python3 -m py_compile scripts/e2e/export_validation_bundle.py scripts/e2e/test_export_validation_bundle.py
- python3 scripts/e2e/export_validation_bundle.py --go-root "$PWD" --run-id 20260314T164647Z --bundle-dir docs/reports/live-validation-runs/20260314T164647Z --validation-status 0 --local-report-path docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json --local-stdout-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log" --local-stderr-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log" --kubernetes-report-path docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json --kubernetes-stdout-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log" --kubernetes-stderr-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log" --ray-report-path docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json --ray-stdout-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log" --ray-stderr-path "$PWD/docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log"
- git log -1 --stat