### PR TITLE
OPE-238: refresh distributed rollout review pack

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -147,6 +147,13 @@ This report summarizes the current event bus reliability evidence and the next r
   - live fanout must remain isolated from broker catch-up lag.
 - The same contract is surfaced in `events.DurabilityPlan`, so debug/control-plane payloads can show rollout checks, failure domains, and supporting evidence links before a live adapter exists.
 
+## Review-pack artifact contract
+
+- Local validation evidence should attach the normalized bundle manifest (`docs/reports/live-validation-runs/20260314T164647Z/README.md`), summary (`docs/reports/live-validation-runs/20260314T164647Z/summary.json`), and local bundle artifacts (`sqlite-smoke-report.json`, stdout/stderr, service log, audit log).
+- Service-backed executor evidence should attach the same bundle root plus the Kubernetes and Ray bundle reports and logs so reviewers can inspect executor-specific readiness without breaking per-run isolation.
+- Future replicated-durability review should attach this report, `docs/reports/replicated-event-log-durability-rollout-contract.md`, and `docs/reports/multi-subscriber-takeover-validation-report.md` beside the normalized live-validation bundle until a replicated backend emits its own timestamped validation pack.
+- This keeps Linear closeout comments and GitHub review artifacts stable: one timestamped validation directory for run evidence, plus a small fixed set of repo-native contract reports for durability and takeover readiness.
+
 ## Next adapter boundary
 
 - `internal/events/log.go` now defines the provider-neutral event-log and checkpoint contract for future broker-backed adapters.

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -47,6 +47,39 @@
 - `cd bigclaw-go && go test ./...`
 - `git push origin <branch> && git log -1 --stat`
 
+## Normalized evidence bundle contract
+
+- Stable bundle root: `docs/reports/live-validation-runs/20260314T164647Z`
+- Bundle manifest: `docs/reports/live-validation-runs/20260314T164647Z/README.md`
+- Machine-readable summary: `docs/reports/live-validation-runs/20260314T164647Z/summary.json`
+- Canonical per-executor reports stay pinned at:
+  - `docs/reports/sqlite-smoke-report.json`
+  - `docs/reports/kubernetes-live-smoke-report.json`
+  - `docs/reports/ray-live-smoke-report.json`
+- Per-run isolation stays in the bundle so Linear closeout comments and GitHub review artifacts can link one timestamped directory without mixing evidence from later reruns.
+
+## Review-pack artifact set
+
+### Local backend
+
+- Review summary: `docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json`
+- Closeout logs: `docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log`, `docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log`, `docs/reports/live-validation-runs/20260314T164647Z/local.service.log`
+- Audit trail: `docs/reports/live-validation-runs/20260314T164647Z/local.audit.jsonl`
+
+### Service-backed executors
+
+- Kubernetes readiness: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json`
+- Kubernetes logs and audit trail: `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log`, `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log`, `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.service.log`, `docs/reports/live-validation-runs/20260314T164647Z/kubernetes.audit.jsonl`
+- Ray readiness: `docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json`
+- Ray logs and audit trail: `docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log`, `docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log`, `docs/reports/live-validation-runs/20260314T164647Z/ray.service.log`, `docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl`
+
+### Future replicated durability review
+
+- Runtime and rollout contract: `docs/reports/event-bus-reliability-report.md`
+- Replicated target gate: `docs/reports/replicated-event-log-durability-rollout-contract.md`
+- Shared failover and takeover evidence contract: `docs/reports/multi-subscriber-takeover-validation-report.md`
+- Reviewers should attach these repo-native reports alongside the normalized live-validation bundle until a concrete replicated backend emits its own timestamped validation pack.
+
 ## Recent bundles
 
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -24,6 +24,21 @@
 - `OPE-183`
   - Event bus evidence includes replay-first subscriptions, webhook fanout, recorder sink coverage, and SSE replay/filter behavior by task or trace.
   - Supporting report: `docs/reports/event-bus-reliability-report.md`.
+- `OPE-233`
+  - Distributed diagnostics now include Ray executor readiness and latest live-validation references without sending reviewers back to raw run logs first.
+  - Supporting reports: `docs/reports/ray-live-smoke-report.json` and `docs/reports/live-validation-index.md`.
+- `OPE-234`
+  - Replicated event-log rollout readiness is captured as an operator-facing contract with explicit failure domains, rollout phases, and validation gates.
+  - Supporting reports: `docs/reports/replicated-event-log-durability-rollout-contract.md` and `docs/reports/event-bus-reliability-report.md`.
+- `OPE-236`
+  - Distributed diagnostics now include Kubernetes executor readiness and the latest bundled live-validation evidence.
+  - Supporting reports: `docs/reports/kubernetes-live-smoke-report.json` and `docs/reports/live-validation-index.md`.
+- `OPE-237`
+  - Live validation now exposes one normalized, timestamped evidence bundle with stable per-executor canonical report paths and isolated per-run logs.
+  - Supporting reports: `docs/reports/live-validation-index.md` and `docs/reports/live-validation-runs/20260314T164647Z/README.md`.
+- `OPE-238`
+  - The distributed rollout review pack now tells reviewers exactly which local, service-backed, and future replicated-durability artifacts belong in Linear closeout comments and GitHub review attachments.
+  - Supporting reports: `docs/reports/review-readiness.md`, `docs/reports/live-validation-index.md`, `docs/reports/event-bus-reliability-report.md`, and `docs/openclaw-parallel-gap-analysis.md`.
 - `OPE-184`
   - Audit and debug surfaces include trace summary endpoints, trace timeline lookup, worker lifecycle snapshots, and `trace_count` metrics visibility.
   - Supporting report: `docs/reports/go-control-plane-observability-report.md`.
@@ -42,3 +57,4 @@
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- The replicated durability track is still contract-first; until a live broker-backed adapter exists, reviewers should treat the normalized validation bundle plus the replicated rollout contract as the release-ready evidence set.

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -44,6 +44,12 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
   - rollout metadata lives in `bigclaw-go/internal/events/durability.go` so debug/control-plane payloads can advertise checks, failure domains, evidence links, and broker bootstrap readiness;
   - `bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md` defines the minimum publish-ack, replay/checkpoint, retention-boundary, and failover expectations before a replicated adapter can be called rollout-ready.
 
+### Current review-pack baseline
+
+- `OPE-233`, `OPE-236`, and `OPE-237` now leave one normalized live-validation bundle rooted at `bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z`, with per-executor canonical reports kept stable for Ray, Kubernetes, and local validation.
+- `OPE-234` keeps replicated durability readiness in repo-native form through `bigclaw-go/docs/reports/event-bus-reliability-report.md` and `bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md`.
+- `OPE-238` turns those inputs into one review-pack contract so release review, Linear closeout, and GitHub PR review can all point at the same isolated artifact set instead of mixing raw logs from multiple runs.
+
 ## Recommended BigClaw parallel mainline
 
 1. Multi-worker and multi-node control-plane observability.

--- a/docs/parallel-refill-queue.json
+++ b/docs/parallel-refill-queue.json
@@ -38,15 +38,14 @@
       "OPE-231",
       "OPE-232",
       "OPE-233",
-      "OPE-234"
-    ],
-    "active": [
+      "OPE-234",
       "OPE-236",
       "OPE-237"
     ],
-    "standby": [
+    "active": [
       "OPE-238"
-    ]
+    ],
+    "standby": []
   },
   "issue_order": [
     "OPE-236",
@@ -58,19 +57,19 @@
       "identifier": "OPE-236",
       "title": "BIG-PAR-049 kubernetes executor live readiness rollup in distributed diagnostics",
       "track": "Distributed Diagnostics",
-      "status": "In Progress"
+      "status": "Done"
     },
     {
       "identifier": "OPE-237",
       "title": "BIG-PAR-050 normalize live-validation evidence bundle index",
       "track": "Validation Matrix",
-      "status": "In Progress"
+      "status": "Done"
     },
     {
       "identifier": "OPE-238",
       "title": "BIG-PAR-051 distributed rollout review-pack refresh",
       "track": "Review Pack",
-      "status": "Todo"
+      "status": "In Progress"
     }
   ]
 }

--- a/docs/parallel-refill-queue.md
+++ b/docs/parallel-refill-queue.md
@@ -46,11 +46,12 @@ manual operator can refill the next parallel-safe issues in a stable order.
   - `OPE-233` — Ray executor live readiness rollup in distributed diagnostics
   - `OPE-234` — replicated event-log rollout readiness summary
   - `OPE-235` — shared-queue takeover evidence bundle refresh
-- Active:
   - `OPE-236` — kubernetes executor live readiness rollup in distributed diagnostics
   - `OPE-237` — normalize live-validation evidence bundle index
-- Standby:
+- Active:
   - `OPE-238` — distributed rollout review-pack refresh
+- Standby:
+  - none
 
 ## Canonical refill order
 


### PR DESCRIPTION
## Summary
- refresh the distributed rollout review-pack docs so reviewers can attach one stable artifact set for local, Kubernetes, Ray, and replicated-durability review
- document the normalized live-validation bundle contract and the expected closeout/GitHub review attachments
- sync the repo refill queue metadata with Linear so OPE-238 is the active slice

## Validation
- python3 -m json.tool docs/parallel-refill-queue.json >/dev/null
- git rev-parse HEAD
- git rev-parse origin/dcjcloud/ope-238-big-par-051-distributed-rollout-review-pack-refresh
- git log -1 --stat