### PR TITLE
OPE-241: refresh distributed closure readiness scorecard

### DIFF
--- a/bigclaw-go/docs/reports/epic-closure-readiness-report.md
+++ b/bigclaw-go/docs/reports/epic-closure-readiness-report.md
@@ -18,6 +18,13 @@
 - Explicit executor pinning to `ray` also succeeded.
 - Supporting report: `docs/reports/mixed-workload-validation-report.md`
 
+## Distributed Review Surfaces
+
+- The latest bundled live-validation artifact is `docs/reports/live-validation-runs/20260314T164647Z`, generated on `2026-03-14T16:46:57.671520+00:00`.
+- `docs/reports/live-validation-index.md` exposes the canonical bundle path, per-executor logs, and closeout commands for local, Kubernetes, and Ray validation.
+- `docs/reports/review-readiness.md` now acts as the repo-native closeout scorecard for executor readiness, validation bundles, closure evidence, and durability rollout posture.
+- `docs/reports/event-bus-reliability-report.md` and `docs/reports/replicated-event-log-durability-rollout-contract.md` provide the operator-facing durability rollout evidence linked from the same scorecard.
+
 ## Multi-Node Coordination
 
 - Two `bigclawd` processes shared one SQLite queue and completed `200` tasks with `0` duplicate starts and `0` duplicate completions.
@@ -36,10 +43,12 @@ This does not magically turn the system into production-grade distributed infras
 
 ## Artifacts
 
+- `docs/reports/review-readiness.md`
 - `docs/reports/benchmark-readiness-report.md`
 - `docs/reports/long-duration-soak-report.md`
 - `docs/reports/mixed-workload-validation-report.md`
 - `docs/reports/multi-node-coordination-report.md`
+- `docs/reports/live-validation-index.md`
 - `docs/reports/soak-local-1000x24.json`
 - `docs/reports/soak-local-2000x24.json`
 - `docs/reports/mixed-workload-matrix-report.json`

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -156,3 +156,9 @@ This report summarizes the current event bus reliability evidence and the next r
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+
+## Review-pack alignment
+
+- `docs/reports/review-readiness.md` treats this report as the canonical durability-readiness input for distributed closeout.
+- `docs/reports/live-validation-index.md` covers the current executor validation bundle, while this report and `docs/reports/replicated-event-log-durability-rollout-contract.md` cover the broker-target durability posture that is intentionally still pre-rollout.
+- `docs/reports/broker-failover-fault-injection-validation-pack.md` remains the required follow-on evidence pack before any operator-facing claim can move from `contract_ready` to live replicated durability readiness.

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -47,6 +47,12 @@
 - `cd bigclaw-go && go test ./...`
 - `git push origin <branch> && git log -1 --stat`
 
+## Review Readiness Links
+
+- `docs/reports/review-readiness.md` uses this index as the canonical validation-bundle reference for distributed closeout.
+- `docs/reports/epic-closure-readiness-report.md` summarizes how this bundle complements soak, mixed-workload, and multi-node coordination evidence.
+- `docs/reports/event-bus-reliability-report.md` and `docs/reports/replicated-event-log-durability-rollout-contract.md` cover the durability-rollout side of the same review pack.
+
 ## Recent bundles
 
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -1,6 +1,31 @@
 # Review Readiness Matrix
 
-## Done
+## Distributed Closure Scorecard
+
+This document is the stable closeout scorecard for the distributed readiness slices completed through `2026-03-14`. It links the operator-facing artifact set needed for release, reliability, and milestone review without requiring Linear comments to restate the evidence by hand.
+
+| Surface | Status | Latest evidence | Review-ready meaning |
+| --- | --- | --- | --- |
+| Executor readiness | ready | `docs/reports/kubernetes-live-smoke-report.json`, `docs/reports/ray-live-smoke-report.json`, `docs/reports/mixed-workload-validation-report.md` | Real Kubernetes and Ray smoke runs passed, and mixed-workload routing proved local / Kubernetes / Ray selection in one control-plane matrix. |
+| Validation bundle | ready | `docs/reports/live-validation-index.md`, `docs/reports/live-validation-summary.json`, `docs/reports/live-validation-runs/20260314T164647Z/summary.json` | The latest repo-native bundle (`20260314T164647Z`, generated `2026-03-14T16:46:57.671520+00:00`) exposes canonical bundle paths, per-executor logs, and closeout commands. |
+| Closure and coordination | ready | `docs/reports/epic-closure-readiness-report.md`, `docs/reports/multi-node-coordination-report.md`, `docs/reports/long-duration-soak-report.md` | Same-day closure evidence covers longer local soak, mixed workload execution, and concrete two-node shared-queue coordination. |
+| Event bus durability rollout | contract_ready | `docs/reports/event-bus-reliability-report.md`, `docs/reports/replicated-event-log-durability-rollout-contract.md`, `docs/reports/broker-failover-fault-injection-validation-pack.md` | The current runtime exposes the replicated durability plan and rollout checks, while the failover pack defines the validation required before any live broker-backed durability claim is made. |
+| Review-pack artifact stability | ready | `docs/reports/review-readiness.md`, `docs/reports/epic-closure-readiness-report.md`, `docs/reports/event-bus-reliability-report.md`, `docs/reports/live-validation-index.md` | Distributed closeout can point to one repo-native artifact set instead of ad-hoc summary prose. |
+
+## Stable Artifact Set
+
+- `docs/reports/review-readiness.md`
+- `docs/reports/epic-closure-readiness-report.md`
+- `docs/reports/live-validation-index.md`
+- `docs/reports/live-validation-summary.json`
+- `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/replicated-event-log-durability-rollout-contract.md`
+- `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- `docs/reports/mixed-workload-validation-report.md`
+- `docs/reports/kubernetes-live-smoke-report.json`
+- `docs/reports/ray-live-smoke-report.json`
+
+## Baseline Coverage
 
 - `OPE-176`
   - ADR and migration boundary docs exist.
@@ -42,3 +67,4 @@
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Replicated broker-backed durability remains intentionally pre-rollout until the failover and checkpoint-fencing pack is backed by a live adapter.


### PR DESCRIPTION
## Summary
- turn `docs/reports/review-readiness.md` into the stable distributed closure scorecard
- align the epic closure, event-bus reliability, and live-validation index reports to the same review-pack artifact set
- link executor readiness, latest validation bundle evidence, and replicated durability rollout posture from one repo-native surface

## Validation
- `cd bigclaw-go && go test ./...`
- verified all referenced report artifacts exist
- confirmed local and remote branch SHAs match at `a9dc1c7b88b2f67cfc348d265fedcf86d2b5e827`
