### PR TITLE
OPE-240: add durability backend comparison matrix

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -65,17 +65,29 @@ This report summarizes the current event bus reliability evidence and the next r
 
 - Runtime publish/subscribe remains in-process.
 - Audit/debug persistence is recorder-backed, with optional JSONL sinking.
-- The `events.DurabilityPlan` surface makes the active backend and the next replicated target explicit in bootstrap and `GET /debug/status`, including broker bootstrap readiness when a replicated target is configured.
+- The `events.DurabilityPlan` surface makes the active backend and the next replicated target explicit in bootstrap and `GET /debug/status`, including a code-backed `comparison` matrix covering `memory`, `sqlite`, `http`, and `broker_replicated`.
 - Default plan is `memory -> broker_replicated` with replication factor `3`, and env overrides exist for:
   - `BIGCLAW_EVENT_LOG_BACKEND`
   - `BIGCLAW_EVENT_LOG_TARGET_BACKEND`
   - `BIGCLAW_EVENT_LOG_REPLICATION_FACTOR`
 
-## Next backend targets
+## Normalized readiness matrix
 
-- `sqlite`: durable single-node append log with monotonic checkpoints but no replica quorum.
-- `http`: shared service-backed append log with single-writer ordering and shared subscriber state.
-- `broker_replicated`: quorum or partition-backed log with shared replay, replicated durability, and publisher ack requirements.
+The runtime `event_durability.comparison` payload is now the canonical comparison surface for operator-facing backend readiness. Each row carries:
+
+- `readiness`: whether the backend is the current runtime, a comparison candidate, or the declared target contract.
+- `capability_probe_backend` / `capability_probe_status`: the backend name and readiness language used by the backend capability catalog.
+- `runtime_selectors` and `required_config`: the bootstrap env selectors and config expected for that backend.
+- shared/replicated/replay/checkpoint/order semantics plus repo evidence links.
+
+| Backend | Readiness | Bootstrap | Probe language | Shared / replicated | Replay / checkpoints | Ordering scope |
+| --- | --- | --- | --- | --- | --- | --- |
+| `memory` | `current_runtime` or comparison candidate | implemented | `memory` / `implemented` | process-local / no | replay yes / checkpoints no | process-local publish order |
+| `sqlite` | comparison candidate | catalog-defined only | `sqlite` / `catalog_defined` | shared no / replicated no | replay yes / checkpoints yes | single-node append order |
+| `http` | comparison candidate or current runtime | catalog-defined only | `http` / `catalog_defined` | shared yes / replicated no | replay yes / checkpoints yes | single-writer service order |
+| `broker_replicated` | `target_contract` when selected | contract-only target | `broker` / `contract_validated` | shared yes / replicated yes | replay yes / checkpoints yes | partition or quorum log order |
+
+The matrix exists to keep rollout notes, review packs, and debug/control-plane payloads on one vocabulary instead of mixing runtime selector names with capability-probe names.
 
 ## Repo-native integration points
 
@@ -100,22 +112,13 @@ This report summarizes the current event bus reliability evidence and the next r
 4. Add a broker-backed implementation with partition-key rules for `trace_id` and explicit publisher ack / durability error handling.
 5. Validate cutover with replay, checkpoint monotonicity, SSE handoff, capability-matrix regression coverage, dedup-ledger persistence coverage, backend-capability probe validation, and multi-subscriber takeover fault-injection evidence under shared multi-node conditions.
 
-## Durability capability matrix
-
-| Backend | Implemented in bootstrap | Durable history | Publish | Replay | Checkpoint | Filtering | Required config |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `memory` | yes | no | native | native | unsupported | native | none |
-| `sqlite` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-| `http` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-| `broker` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-
 ## Validation contract
 
 - Startup validates `BIGCLAW_EVENT_BACKEND` against the backend catalog before queue/bootstrap wiring begins.
 - Durable backends must provide explicit event-log DSN, checkpoint DSN, and positive retention.
 - `BIGCLAW_EVENT_REQUIRE_REPLAY`, `BIGCLAW_EVENT_REQUIRE_CHECKPOINT`, and `BIGCLAW_EVENT_REQUIRE_FILTERING` express the runtime features operators expect from the selected backend.
 - Unsupported combinations fail fast with field-specific errors instead of silently downgrading runtime behavior.
-- Backends declared in the matrix but not yet wired into the bootstrap runtime are rejected explicitly so planning assumptions cannot masquerade as implemented support.
+- Backends declared in the comparison matrix but not yet wired into the bootstrap runtime are rejected explicitly so planning assumptions cannot masquerade as implemented support.
 
 ## Consumer dedup ledger contract
 
@@ -140,12 +143,12 @@ This report summarizes the current event bus reliability evidence and the next r
 
 ## Replicated rollout contract
 
-- `docs/reports/replicated-event-log-durability-rollout-contract.md` now captures the minimum rollout gates for a broker-backed or quorum-backed adapter, and `event_durability` now includes broker bootstrap readiness for those targets:
+- `docs/reports/replicated-event-log-durability-rollout-contract.md` now captures the minimum rollout gates for a broker-backed or quorum-backed adapter, and `event_durability` now includes broker bootstrap readiness plus the normalized comparison row for that target:
   - replicated publish acknowledgements must distinguish committed, rejected, and ambiguous outcomes;
   - replay and checkpoint state must share the same durable sequence domain across failover;
   - retention boundaries must be operator-visible before resumable recovery is claimed;
   - live fanout must remain isolated from broker catch-up lag.
-- The same contract is surfaced in `events.DurabilityPlan`, so debug/control-plane payloads can show rollout checks, failure domains, and supporting evidence links before a live adapter exists.
+- The same contract is surfaced in `events.DurabilityPlan`, so debug/control-plane payloads can show rollout checks, failure domains, supporting evidence links, and the current-vs-target matrix before a live adapter exists.
 
 ## Next adapter boundary
 

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -9,8 +9,20 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 ## Current baseline
 
 - `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads, including broker bootstrap readiness derived from configured driver / URLs / topic settings.
+- The same payload now exposes a normalized `comparison` matrix so `memory`, `sqlite`, `http`, and `broker_replicated` can be reviewed with one set of readiness, probe, config, and evidence fields.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
 - `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
+
+## Comparison-row expectations
+
+The `broker_replicated` row in `event_durability.comparison` is the operator-facing summary for this contract. It must keep these fields stable:
+
+- `readiness`: `target_contract` until a real bootstrap implementation exists.
+- `capability_probe_backend`: `broker`, matching the backend capability catalog.
+- `capability_probe_status`: `contract_validated`, meaning config and rollout language are wired even though bootstrap support is not.
+- `runtime_selectors`: target/runtime selectors for `BIGCLAW_EVENT_LOG_TARGET_BACKEND=broker_replicated` and future `BIGCLAW_EVENT_LOG_BACKEND=broker`.
+- `required_config`: replication factor plus broker driver, URLs, topic, consumer group, publish timeout, replay limit, checkpoint interval, and catalog DSN/retention requirements.
+- `evidence`: repo-native rollout and fault-injection reports.
 
 ## Runtime contract
 
@@ -63,6 +75,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - active backend and target backend
 - replication factor or quorum expectation
 - whether publisher acknowledgement is required before success is reported
+- normalized backend comparison rows showing readiness, probe language, runtime selectors, and required config
 - rollout checks and their failure modes
 - failure-domain summaries
 - references to the supporting validation pack and rollout contract documents

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -272,6 +272,12 @@ func TestDebugStatusIncludesEventDurabilityPlan(t *testing.T) {
 	if !strings.Contains(response.Body.String(), "\"rollout_checks\"") {
 		t.Fatalf("expected rollout checks in payload, got %s", response.Body.String())
 	}
+	if !strings.Contains(response.Body.String(), "\"comparison\"") {
+		t.Fatalf("expected comparison matrix in payload, got %s", response.Body.String())
+	}
+	if !strings.Contains(response.Body.String(), "\"capability_probe_backend\":\"broker\"") {
+		t.Fatalf("expected broker probe language in payload, got %s", response.Body.String())
+	}
 	if !strings.Contains(response.Body.String(), "\"failure_domains\"") {
 		t.Fatalf("expected failure domains in payload, got %s", response.Body.String())
 	}

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -21,6 +21,25 @@ type DurabilityProfile struct {
 	OrderingScope       string            `json:"ordering_scope"`
 }
 
+type DurabilityComparisonRow struct {
+	Backend                DurabilityBackend `json:"backend"`
+	Readiness              string            `json:"readiness"`
+	SelectedCurrent        bool              `json:"selected_current"`
+	SelectedTarget         bool              `json:"selected_target"`
+	ImplementedInBootstrap bool              `json:"implemented_in_bootstrap"`
+	CapabilityProbeBackend string            `json:"capability_probe_backend"`
+	CapabilityProbeStatus  string            `json:"capability_probe_status"`
+	RuntimeSelectors       []string          `json:"runtime_selectors"`
+	RequiredConfig         []string          `json:"required_config"`
+	OrderingScope          string            `json:"ordering_scope"`
+	Shared                 bool              `json:"shared"`
+	Replicated             bool              `json:"replicated"`
+	Replay                 bool              `json:"replay"`
+	SubscriberState        bool              `json:"subscriber_state"`
+	MonotonicCheckpoint    bool              `json:"monotonic_checkpoint"`
+	Evidence               []string          `json:"evidence"`
+}
+
 type RolloutCheck struct {
 	Name        string `json:"name"`
 	Requirement string `json:"requirement"`
@@ -51,16 +70,17 @@ type BrokerBootstrapStatus struct {
 }
 
 type DurabilityPlan struct {
-	Current              DurabilityProfile      `json:"current"`
-	Target               DurabilityProfile      `json:"target"`
-	ReplicationFactor    int                    `json:"replication_factor"`
-	RequiresPublisherAck bool                   `json:"requires_publisher_ack"`
-	MigrationConstraints []string               `json:"migration_constraints"`
-	IntegrationPoints    []string               `json:"integration_points"`
-	RolloutChecks        []RolloutCheck         `json:"rollout_checks"`
-	FailureDomains       []FailureDomain        `json:"failure_domains"`
-	VerificationEvidence []VerificationEvidence `json:"verification_evidence"`
-	BrokerBootstrap      *BrokerBootstrapStatus `json:"broker_bootstrap,omitempty"`
+	Current              DurabilityProfile         `json:"current"`
+	Target               DurabilityProfile         `json:"target"`
+	Comparison           []DurabilityComparisonRow `json:"comparison"`
+	ReplicationFactor    int                       `json:"replication_factor"`
+	RequiresPublisherAck bool                      `json:"requires_publisher_ack"`
+	MigrationConstraints []string                  `json:"migration_constraints"`
+	IntegrationPoints    []string                  `json:"integration_points"`
+	RolloutChecks        []RolloutCheck            `json:"rollout_checks"`
+	FailureDomains       []FailureDomain           `json:"failure_domains"`
+	VerificationEvidence []VerificationEvidence    `json:"verification_evidence"`
+	BrokerBootstrap      *BrokerBootstrapStatus    `json:"broker_bootstrap,omitempty"`
 }
 
 func NormalizeDurabilityBackend(value string) DurabilityBackend {
@@ -129,6 +149,7 @@ func NewDurabilityPlanWithBrokerConfig(currentBackend, targetBackend string, rep
 	plan := DurabilityPlan{
 		Current:              current,
 		Target:               target,
+		Comparison:           durabilityComparison(current.Backend, target.Backend),
 		ReplicationFactor:    replicationFactor,
 		RequiresPublisherAck: target.Replicated,
 		MigrationConstraints: []string{
@@ -219,6 +240,158 @@ func NewDurabilityPlanWithBrokerConfig(currentBackend, targetBackend string, rep
 		plan.BrokerBootstrap = BrokerBootstrapStatusFromConfig(broker)
 	}
 	return plan
+}
+
+func durabilityComparison(current, target DurabilityBackend) []DurabilityComparisonRow {
+	backends := []DurabilityBackend{
+		DurabilityBackendMemory,
+		DurabilityBackendSQLite,
+		DurabilityBackendHTTP,
+		DurabilityBackendBrokerReplicated,
+	}
+	rows := make([]DurabilityComparisonRow, 0, len(backends))
+	for _, backend := range backends {
+		rows = append(rows, durabilityComparisonRow(backend, current, target))
+	}
+	return rows
+}
+
+func durabilityComparisonRow(backend, current, target DurabilityBackend) DurabilityComparisonRow {
+	profile := DurabilityProfileForBackend(backend)
+	row := DurabilityComparisonRow{
+		Backend:                backend,
+		SelectedCurrent:        backend == current,
+		SelectedTarget:         backend == target,
+		OrderingScope:          profile.OrderingScope,
+		Shared:                 profile.Shared,
+		Replicated:             profile.Replicated,
+		Replay:                 profile.Replay,
+		SubscriberState:        profile.SubscriberState,
+		MonotonicCheckpoint:    profile.MonotonicCheckpoint,
+		CapabilityProbeBackend: durabilityProbeBackend(backend),
+		CapabilityProbeStatus:  durabilityProbeStatus(backend),
+		RuntimeSelectors:       durabilityRuntimeSelectors(backend),
+		RequiredConfig:         durabilityRequiredConfig(backend),
+		Evidence:               durabilityEvidence(backend),
+	}
+
+	if backend == current {
+		row.Readiness = "current_runtime"
+	} else if backend == target {
+		row.Readiness = "target_contract"
+	} else {
+		row.Readiness = "comparison_candidate"
+	}
+
+	if catalog, ok := Catalog()[BackendKind(row.CapabilityProbeBackend)]; ok {
+		row.ImplementedInBootstrap = catalog.Implemented
+	}
+	return row
+}
+
+func durabilityProbeBackend(backend DurabilityBackend) string {
+	switch backend {
+	case DurabilityBackendBrokerReplicated:
+		return string(BackendBroker)
+	case DurabilityBackendSQLite:
+		return string(BackendSQLite)
+	case DurabilityBackendHTTP:
+		return string(BackendHTTP)
+	default:
+		return string(BackendMemory)
+	}
+}
+
+func durabilityProbeStatus(backend DurabilityBackend) string {
+	switch backend {
+	case DurabilityBackendBrokerReplicated:
+		return "contract_validated"
+	case DurabilityBackendSQLite, DurabilityBackendHTTP:
+		return "catalog_defined"
+	default:
+		return "implemented"
+	}
+}
+
+func durabilityRuntimeSelectors(backend DurabilityBackend) []string {
+	switch backend {
+	case DurabilityBackendSQLite:
+		return []string{
+			"BIGCLAW_EVENT_LOG_SQLITE_PATH",
+			"BIGCLAW_EVENT_LOG_BACKEND=sqlite",
+		}
+	case DurabilityBackendHTTP:
+		return []string{
+			"BIGCLAW_EVENT_LOG_REMOTE_URL",
+			"BIGCLAW_EVENT_LOG_BACKEND=http",
+		}
+	case DurabilityBackendBrokerReplicated:
+		return []string{
+			"BIGCLAW_EVENT_LOG_TARGET_BACKEND=broker_replicated",
+			"BIGCLAW_EVENT_LOG_BACKEND=broker",
+		}
+	default:
+		return []string{"BIGCLAW_EVENT_LOG_BACKEND=memory"}
+	}
+}
+
+func durabilityRequiredConfig(backend DurabilityBackend) []string {
+	switch backend {
+	case DurabilityBackendSQLite:
+		return []string{
+			"BIGCLAW_EVENT_LOG_SQLITE_PATH",
+			"BIGCLAW_EVENT_RETENTION",
+			"BIGCLAW_EVENT_BACKEND=sqlite",
+			"BIGCLAW_EVENT_LOG_DSN",
+			"BIGCLAW_EVENT_CHECKPOINT_DSN",
+		}
+	case DurabilityBackendHTTP:
+		return []string{
+			"BIGCLAW_EVENT_LOG_REMOTE_URL",
+			"BIGCLAW_EVENT_RETENTION",
+			"BIGCLAW_EVENT_BACKEND=http",
+			"BIGCLAW_EVENT_LOG_DSN",
+			"BIGCLAW_EVENT_CHECKPOINT_DSN",
+		}
+	case DurabilityBackendBrokerReplicated:
+		return []string{
+			"BIGCLAW_EVENT_LOG_TARGET_BACKEND=broker_replicated",
+			"BIGCLAW_EVENT_LOG_REPLICATION_FACTOR",
+			"BIGCLAW_EVENT_LOG_BROKER_DRIVER",
+			"BIGCLAW_EVENT_LOG_BROKER_URLS",
+			"BIGCLAW_EVENT_LOG_BROKER_TOPIC",
+			"BIGCLAW_EVENT_LOG_CONSUMER_GROUP",
+			"BIGCLAW_EVENT_LOG_PUBLISH_TIMEOUT",
+			"BIGCLAW_EVENT_LOG_REPLAY_LIMIT",
+			"BIGCLAW_EVENT_LOG_CHECKPOINT_INTERVAL",
+			"BIGCLAW_EVENT_BACKEND=broker",
+			"BIGCLAW_EVENT_LOG_DSN",
+			"BIGCLAW_EVENT_CHECKPOINT_DSN",
+			"BIGCLAW_EVENT_RETENTION",
+		}
+	default:
+		return []string{"BIGCLAW_EVENT_BACKEND=memory"}
+	}
+}
+
+func durabilityEvidence(backend DurabilityBackend) []string {
+	switch backend {
+	case DurabilityBackendBrokerReplicated:
+		return []string{
+			"docs/reports/replicated-event-log-durability-rollout-contract.md",
+			"docs/reports/broker-failover-fault-injection-validation-pack.md",
+		}
+	case DurabilityBackendSQLite, DurabilityBackendHTTP:
+		return []string{
+			"internal/events/backend_contract.go",
+			"docs/reports/event-bus-reliability-report.md",
+		}
+	default:
+		return []string{
+			"internal/events/memory_log.go",
+			"docs/reports/event-bus-reliability-report.md",
+		}
+	}
 }
 
 func BrokerBootstrapStatusFromConfig(cfg BrokerRuntimeConfig) *BrokerBootstrapStatus {

--- a/bigclaw-go/internal/events/durability_test.go
+++ b/bigclaw-go/internal/events/durability_test.go
@@ -29,6 +29,18 @@ func TestNewDurabilityPlanForReplicatedTargetIncludesRolloutContract(t *testing.
 	if plan.VerificationEvidence[2].Artifacts[1] != "docs/reports/replicated-event-log-durability-rollout-contract.md" {
 		t.Fatalf("expected rollout contract artifact, got %+v", plan.VerificationEvidence[2])
 	}
+	if len(plan.Comparison) != 4 {
+		t.Fatalf("expected four comparison backends, got %+v", plan.Comparison)
+	}
+	if plan.Comparison[1].Backend != DurabilityBackendSQLite || plan.Comparison[1].Readiness != "comparison_candidate" {
+		t.Fatalf("unexpected sqlite comparison row: %+v", plan.Comparison[1])
+	}
+	if !plan.Comparison[2].SelectedCurrent || plan.Comparison[2].CapabilityProbeBackend != "http" {
+		t.Fatalf("expected http row to be current backend, got %+v", plan.Comparison[2])
+	}
+	if !plan.Comparison[3].SelectedTarget || !plan.Comparison[3].Replicated || plan.Comparison[3].CapabilityProbeStatus != "contract_validated" {
+		t.Fatalf("expected broker row to describe replicated target, got %+v", plan.Comparison[3])
+	}
 }
 
 func TestNewDurabilityPlanWithBrokerConfigIncludesBootstrapStatus(t *testing.T) {

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -42,6 +42,7 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 
 - `OPE-222` now makes the replicated durability rollout contract explicit in repo-native form:
   - rollout metadata lives in `bigclaw-go/internal/events/durability.go` so debug/control-plane payloads can advertise checks, failure domains, evidence links, and broker bootstrap readiness;
+  - the same file now emits a normalized comparison matrix covering `memory`, `sqlite`, `http`, and `broker_replicated`, so reports and closeout notes can compare current-vs-target durability without rewording backend capability names by hand;
   - `bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md` defines the minimum publish-ack, replay/checkpoint, retention-boundary, and failover expectations before a replicated adapter can be called rollout-ready.
 
 ## Recommended BigClaw parallel mainline


### PR DESCRIPTION
## Summary
- add a code-backed durability backend comparison matrix to `events.DurabilityPlan`
- surface the matrix in debug status coverage and align probe/runtime selector language
- refresh the durability readiness reports to reference the normalized comparison shape

## Validation
- go test ./internal/events ./internal/api
- git rev-parse HEAD
- git rev-parse origin/$(git branch --show-current)
- git log -1 --stat