### PR TITLE
OPE-239: normalize broker failover evidence bundle export

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -88,14 +88,19 @@ This starts two `bigclawd` processes against one SQLite queue and verifies there
 
 ## Broker failover and replay fault-injection pack
 
-The current repo does not yet ship a broker-backed event log or live failover harness, but the implementation-ready validation matrix now lives in `docs/reports/broker-failover-fault-injection-validation-pack.md`.
+The current repo does not yet ship a broker-backed event log or live failover harness, but the canonical planning bundle now lives in:
 
-Use that pack as the source of truth for:
+- `docs/reports/broker-failover-evidence-bundle.md`
+- `docs/reports/broker-failover-evidence-bundle.json`
+
+Use that bundle as the source of truth for:
 
 - broker leader or replica failover scenarios
 - replay resume and duplicate-delivery assertions
 - checkpoint fencing and stale-writer recovery rules
 - the minimum machine-readable report schema required before future broker durability work can be closed honestly
+
+Use `docs/reports/broker-failover-fault-injection-validation-pack.md` when you need the full scenario-by-scenario assertions behind the normalized bundle.
 
 ## Multi-subscriber takeover validation matrix
 

--- a/bigclaw-go/docs/reports/broker-failover-evidence-bundle.json
+++ b/bigclaw-go/docs/reports/broker-failover-evidence-bundle.json
@@ -1,0 +1,99 @@
+{
+  "generated_at": "2026-03-16T01:45:00Z",
+  "ticket": "OPE-239",
+  "title": "Broker failover and replay fault-injection evidence bundle",
+  "bundle_id": "broker-failover-fault-injection",
+  "status": "planning-ready",
+  "summary_path": "docs/reports/broker-failover-evidence-bundle.md",
+  "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
+  "rollout_contract_path": "docs/reports/replicated-event-log-durability-rollout-contract.md",
+  "supporting_reports": [
+    "docs/reports/event-bus-reliability-report.md",
+    "docs/reports/replay-retention-semantics-report.md",
+    "docs/reports/queue-reliability-report.md",
+    "docs/reports/lease-recovery-report.md"
+  ],
+  "review_surfaces": [
+    "docs/e2e-validation.md",
+    "docs/reports/live-validation-index.md",
+    "docs/reports/review-readiness.md"
+  ],
+  "scenarios": [
+    {
+      "scenario_id": "BF-01",
+      "title": "active broker leader restarts during publish burst",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-02",
+      "title": "broker follower or replica loss during publish and replay",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-03",
+      "title": "consumer process crashes after handling an event but before checkpoint write is confirmed",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-04",
+      "title": "checkpoint store leader changes while two consumers contend for one subscriber group",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-05",
+      "title": "producer timeout after broker commit ambiguity",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-06",
+      "title": "replay client disconnects during catch-up and reconnects to a new broker node",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-07",
+      "title": "retention or compaction boundary intersects a stale checkpoint",
+      "readiness": "planned"
+    },
+    {
+      "scenario_id": "BF-08",
+      "title": "split-brain style duplicate delivery window during failover",
+      "readiness": "planned"
+    }
+  ],
+  "minimum_report_schema": [
+    "scenario_id",
+    "backend",
+    "topology",
+    "fault_window",
+    "published_count",
+    "committed_count",
+    "replayed_count",
+    "duplicate_count",
+    "missing_event_ids",
+    "checkpoint_before_fault",
+    "checkpoint_after_recovery",
+    "lease_transitions",
+    "publish_outcomes",
+    "replay_resume_cursor",
+    "artifacts",
+    "result"
+  ],
+  "required_raw_artifacts": [
+    "publish attempt ledger with event id, trace id, attempt number, and client outcome",
+    "replay capture with durable sequence, event id, replay/live flag, and source node",
+    "checkpoint transition log with owner id, lease id, prior sequence, next sequence, and fence reason",
+    "fault timeline with exact injected action and node target",
+    "backend health snapshot before and after recovery"
+  ],
+  "future_bundle_contract": {
+    "bundle_root": "docs/reports/broker-failover-runs/<run_id>/",
+    "canonical_manifest_path": "docs/reports/broker-failover-evidence-bundle.json",
+    "canonical_index_path": "docs/reports/broker-failover-evidence-bundle.md",
+    "per_backend_report_pattern": "docs/reports/broker-failover-<backend>-report.json"
+  },
+  "notes": [
+    "This bundle is the canonical review-pack export surface for broker failover planning evidence.",
+    "No broker-backed event log, provider adapter, or executable failover harness ships in the current repo state.",
+    "Review surfaces may cite this bundle as planning-ready evidence, but must not claim live broker validation has passed."
+  ]
+}

--- a/bigclaw-go/docs/reports/broker-failover-evidence-bundle.md
+++ b/bigclaw-go/docs/reports/broker-failover-evidence-bundle.md
@@ -1,0 +1,83 @@
+# Broker Failover Evidence Bundle
+
+- Ticket: `OPE-239`
+- Status: `planning-ready`
+- Canonical manifest: `docs/reports/broker-failover-evidence-bundle.json`
+- Detailed scenario pack: `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- Rollout contract: `docs/reports/replicated-event-log-durability-rollout-contract.md`
+
+## Purpose
+
+This bundle is the stable review-pack and rollout-facing entrypoint for broker failover and replay fault-injection evidence.
+
+It normalizes the current planning-only artifacts into one canonical surface without implying that a broker-backed event log, live provider adapter, or executable failover harness already exists in the repo.
+
+## Canonical bundle contents
+
+- `docs/reports/broker-failover-evidence-bundle.json`
+  - machine-readable manifest for review packs and future automation
+- `docs/reports/broker-failover-fault-injection-validation-pack.md`
+  - provider-neutral scenario matrix, assertions, and pass/fail rules
+- `docs/reports/replicated-event-log-durability-rollout-contract.md`
+  - rollout gates and operator-facing runtime expectations for replicated durability
+- `docs/reports/event-bus-reliability-report.md`
+  - current baseline reliability evidence and portability constraints
+- `docs/reports/replay-retention-semantics-report.md`
+  - retention-boundary and stale-checkpoint recovery expectations
+
+## Scenario coverage
+
+| Scenario ID | Coverage | Current readiness |
+| --- | --- | --- |
+| `BF-01` | leader restart during publish burst | planning-ready |
+| `BF-02` | follower or replica loss during publish and replay | planning-ready |
+| `BF-03` | consumer crash before checkpoint confirmation | planning-ready |
+| `BF-04` | checkpoint leader change during consumer contention | planning-ready |
+| `BF-05` | producer timeout with ambiguous commit outcome | planning-ready |
+| `BF-06` | replay reconnect to a different broker node | planning-ready |
+| `BF-07` | retention boundary intersects a stale checkpoint | planning-ready |
+| `BF-08` | duplicate-delivery window during failover | planning-ready |
+
+## Machine-readable report contract
+
+Future executable reports should emit at least:
+
+- `scenario_id`
+- `backend`
+- `topology`
+- `fault_window`
+- `published_count`
+- `committed_count`
+- `replayed_count`
+- `duplicate_count`
+- `missing_event_ids`
+- `checkpoint_before_fault`
+- `checkpoint_after_recovery`
+- `lease_transitions`
+- `publish_outcomes`
+- `replay_resume_cursor`
+- `artifacts`
+- `result`
+
+Required raw artifacts remain:
+
+- publish attempt ledger with event id, trace id, attempt number, and client outcome
+- replay capture with durable sequence, event id, replay/live flag, and source node
+- checkpoint transition log with owner id, lease id, prior sequence, next sequence, and fence reason
+- fault timeline with exact injected action and node target
+- backend health snapshot before and after recovery
+
+## Future live export shape
+
+When a broker-backed harness exists, the canonical export surface should stay anchored here:
+
+- canonical manifest: `docs/reports/broker-failover-evidence-bundle.json`
+- canonical index: `docs/reports/broker-failover-evidence-bundle.md`
+- per-run bundle root: `docs/reports/broker-failover-runs/<run_id>/`
+- per-backend report pattern: `docs/reports/broker-failover-<backend>-report.json`
+
+## Current usage rules
+
+- review packs may cite this bundle as the canonical broker failover evidence surface
+- rollout docs may point here for planned failover, replay, and checkpoint-fencing expectations
+- no document should claim live broker validation has passed until executable artifacts populate the future bundle shape above

--- a/bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md
+++ b/bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md
@@ -1,5 +1,11 @@
 # Broker Failover And Replay Fault-Injection Validation Pack
 
+## Canonical Evidence Bundle
+
+Use `docs/reports/broker-failover-evidence-bundle.md` and `docs/reports/broker-failover-evidence-bundle.json` as the stable review-pack export surface for this validation work.
+
+This document remains the detailed scenario matrix behind that bundle and should not be referenced as the only broker-failover artifact set anymore.
+
 ## Scope
 
 This pack defines the minimum provider-neutral validation required before BigClaw claims broker-backed durability beyond the current local SQLite coordination proof.
@@ -120,8 +126,9 @@ Each scenario report should include at least:
 
 - add `scripts/e2e/broker_failover_validation.py` or equivalent once a broker-backed event log exists
 - write reports to `docs/reports/broker-failover-<backend>-report.json`
-- keep one markdown summary that rolls up the latest scenario outcomes across backends
-- link the live report from `docs/e2e-validation.md` beside the current SQLite and multi-node validation commands
+- refresh `docs/reports/broker-failover-evidence-bundle.json` as the canonical machine-readable manifest
+- keep `docs/reports/broker-failover-evidence-bundle.md` as the stable markdown summary across backends
+- link the canonical bundle from `docs/e2e-validation.md` beside the current SQLite and multi-node validation commands
 
 ## Exit Criteria For Future Implementation Ticket
 

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -47,6 +47,14 @@
 - `cd bigclaw-go && go test ./...`
 - `git push origin <branch> && git log -1 --stat`
 
+## Broker failover planning bundle
+
+- Status: `planning-ready`
+- Canonical bundle: `docs/reports/broker-failover-evidence-bundle.md`
+- Manifest: `docs/reports/broker-failover-evidence-bundle.json`
+- Detailed scenario pack: `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- Note: this is a normalized planning artifact set only; no live broker-backed validation run is recorded in this index yet
+
 ## Recent bundles
 
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -4,13 +4,13 @@
 
 This report defines the rollout contract for `OPE-222` / `BIG-PAR-035`: the minimum runtime, operator, and validation expectations BigClaw must satisfy before claiming a replicated broker-backed or quorum-backed event log.
 
-It builds on the provider-neutral adapter boundary in `docs/reports/broker-event-log-adapter-contract.md`, the retention semantics in `docs/reports/replay-retention-semantics-report.md`, and the failover scenarios in `docs/reports/broker-failover-fault-injection-validation-pack.md`.
+It builds on the provider-neutral adapter boundary in `docs/reports/broker-event-log-adapter-contract.md`, the retention semantics in `docs/reports/replay-retention-semantics-report.md`, and the canonical broker failover evidence bundle at `docs/reports/broker-failover-evidence-bundle.md`.
 
 ## Current baseline
 
 - `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads, including broker bootstrap readiness derived from configured driver / URLs / topic settings.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
-- `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
+- `docs/reports/event-bus-reliability-report.md` and the broker failover bundle (`docs/reports/broker-failover-evidence-bundle.md`, `docs/reports/broker-failover-evidence-bundle.json`) describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
 
 ## Runtime contract
 
@@ -37,7 +37,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 | Phase | Goal | Exit condition |
 | --- | --- | --- |
 | `contract` | keep provider-neutral append/replay/checkpoint expectations stable | runtime plan and docs expose rollout checks, failure domains, and verification evidence |
-| `stubbed_validation` | prove failover and checkpoint accounting with deterministic harnesses | scenario runner can emit the report shape in `broker-failover-fault-injection-validation-pack.md` |
+| `stubbed_validation` | prove failover and checkpoint accounting with deterministic harnesses | scenario runner can emit the report shape anchored by `docs/reports/broker-failover-evidence-bundle.json` |
 | `single_backend_trial` | wire one replicated adapter without changing callers | one provider backend can publish, replay, and checkpoint behind the existing event-log contract |
 | `rollout_ready` | claim operator-safe replicated durability | pass failover, retention-boundary, and checkpoint-fencing evidence for the chosen provider |
 
@@ -72,7 +72,7 @@ The current repo-native source for these signals is the `event_durability` paylo
 ## Validation evidence required before a live adapter lands
 
 - debug/control-plane payload proving the active runtime advertises the replicated rollout contract and broker bootstrap readiness state
-- failover validation artifacts matching the scenario matrix in `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- failover validation artifacts matching the normalized bundle contract in `docs/reports/broker-failover-evidence-bundle.json`
 - replay retention diagnostics proving expired checkpoints are surfaced explicitly
 - checkpoint takeover evidence proving stale writers cannot regress durable progress
 
@@ -83,5 +83,6 @@ The current repo-native source for these signals is the `event_durability` paylo
 - `internal/api/server_test.go`
 - `cmd/bigclawd/main.go`
 - `docs/reports/event-bus-reliability-report.md`
-- `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- `docs/reports/broker-failover-evidence-bundle.md`
+- `docs/reports/broker-failover-evidence-bundle.json`
 - `docs/reports/replay-retention-semantics-report.md`

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -42,3 +42,4 @@
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Broker-backed failover validation is still unimplemented, but the normalized planning bundle now lives at `docs/reports/broker-failover-evidence-bundle.md` and `docs/reports/broker-failover-evidence-bundle.json` so review packs can reference one stable artifact set without overstating runtime support.


### PR DESCRIPTION
## Summary
- add a canonical broker failover evidence bundle manifest and markdown index
- repoint the broker failover validation pack and rollout docs at the normalized bundle surface
- refresh validation and review references without claiming live broker-backed validation exists

## Validation
- python3 -m json.tool bigclaw-go/docs/reports/broker-failover-evidence-bundle.json >/dev/null
- git diff --check
