### PR TITLE
OPE-242: add control-center takeover history digest

### DIFF
--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -1683,6 +1683,79 @@ func TestV2ControlCenterIncludesMultiWorkerPoolSummary(t *testing.T) {
 	}
 }
 
+func TestV2ControlCenterIncludesTakeoverHistoryForActiveAndReleasedHandoffs(t *testing.T) {
+	recorder := observability.NewRecorder()
+	server := &Server{Recorder: recorder, Queue: queue.NewMemoryQueue(), Bus: events.NewBus(), Control: control.New(), Now: func() time.Time { return time.Unix(1700004100, 0) }}
+	handler := server.Handler()
+
+	for _, payload := range []map[string]any{
+		{"id": "task-history-1", "title": "History one", "priority": 1, "metadata": map[string]any{"team": "platform", "project": "alpha"}},
+		{"id": "task-history-2", "title": "History two", "priority": 1, "metadata": map[string]any{"team": "platform", "project": "alpha"}},
+		{"id": "task-history-3", "title": "History three", "priority": 1, "metadata": map[string]any{"team": "growth", "project": "beta"}},
+	} {
+		body, _ := json.Marshal(payload)
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/tasks", bytes.NewReader(body)))
+		if response.Code != http.StatusAccepted {
+			t.Fatalf("expected task create 202, got %d body=%s", response.Code, response.Body.String())
+		}
+	}
+
+	for _, requestBody := range [][]byte{
+		mustJSON(map[string]any{"action": "takeover", "task_id": "task-history-1", "actor": "alice", "role": "eng_lead", "viewer_team": "platform", "reviewer": "bob", "note": "started review"}),
+		mustJSON(map[string]any{"action": "takeover", "task_id": "task-history-2", "actor": "carol", "role": "eng_lead", "viewer_team": "platform", "reviewer": "dave", "note": "active handoff"}),
+		mustJSON(map[string]any{"action": "takeover", "task_id": "task-history-3", "actor": "erin", "role": "eng_lead", "viewer_team": "growth", "reviewer": "frank", "note": "other team"}),
+		mustJSON(map[string]any{"action": "release_takeover", "task_id": "task-history-1", "actor": "alice", "role": "eng_lead", "viewer_team": "platform", "note": "handoff complete"}),
+	} {
+		response := httptest.NewRecorder()
+		handler.ServeHTTP(response, httptest.NewRequest(http.MethodPost, "/v2/control-center/actions", bytes.NewReader(requestBody)))
+		if response.Code != http.StatusOK {
+			t.Fatalf("expected control action 200, got %d body=%s", response.Code, response.Body.String())
+		}
+	}
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v2/control-center?team=platform&project=alpha&limit=10&audit_limit=10", nil)
+	handler.ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected control center 200, got %d body=%s", response.Code, response.Body.String())
+	}
+
+	var decoded struct {
+		ActiveTakeovers []struct {
+			TaskID string `json:"task_id"`
+		} `json:"active_takeovers"`
+		TakeoverHistory []struct {
+			TaskID     string `json:"task_id"`
+			Active     bool   `json:"active"`
+			Owner      string `json:"owner"`
+			Reviewer   string `json:"reviewer"`
+			ReleasedAt string `json:"released_at"`
+			Notes      []struct {
+				Message string `json:"message"`
+			} `json:"notes"`
+		} `json:"takeover_history"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode control center history: %v", err)
+	}
+	if len(decoded.ActiveTakeovers) != 1 || decoded.ActiveTakeovers[0].TaskID != "task-history-2" {
+		t.Fatalf("expected one filtered active takeover, got %+v", decoded.ActiveTakeovers)
+	}
+	if len(decoded.TakeoverHistory) != 2 {
+		t.Fatalf("expected two filtered history entries, got %+v", decoded.TakeoverHistory)
+	}
+	if decoded.TakeoverHistory[0].TaskID != "task-history-1" || decoded.TakeoverHistory[1].TaskID != "task-history-2" {
+		t.Fatalf("expected released takeover first by recency, got %+v", decoded.TakeoverHistory)
+	}
+	if decoded.TakeoverHistory[0].Active || decoded.TakeoverHistory[0].ReleasedAt == "" || decoded.TakeoverHistory[0].Owner != "alice" || decoded.TakeoverHistory[0].Reviewer != "bob" {
+		t.Fatalf("expected released takeover closeout semantics preserved, got %+v", decoded.TakeoverHistory[0])
+	}
+	if len(decoded.TakeoverHistory[0].Notes) != 2 || decoded.TakeoverHistory[0].Notes[1].Message != "handoff complete" {
+		t.Fatalf("expected release note in takeover history, got %+v", decoded.TakeoverHistory[0].Notes)
+	}
+}
+
 func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	recorder := observability.NewRecorder()
 	controller := control.New()

--- a/bigclaw-go/internal/api/v2.go
+++ b/bigclaw-go/internal/api/v2.go
@@ -1096,6 +1096,7 @@ func (s *Server) handleV2ControlCenter(w http.ResponseWriter, r *http.Request) {
 		"queue_by_team":    sortedDashboardBreakdowns(queueByTeam),
 		"dead_letters":     limitTasks(filteredDeadLetters, filters.Limit),
 		"active_takeovers": s.filteredActiveTakeovers(filters),
+		"takeover_history": s.filteredTakeoverHistory(filters),
 		"recent_tasks":     overviews,
 		"audit":            auditEntries,
 		"audit_summary":    auditSummary,
@@ -2159,6 +2160,9 @@ func summarizeControlCenter(queueTasks []queueTaskOverview, deadLetters []domain
 }
 
 func (s *Server) filteredActiveTakeovers(filters controlCenterFilters) []control.Takeover {
+	if s.Control == nil {
+		return nil
+	}
 	takeovers := s.Control.ActiveTakeovers()
 	if filters.Team == "" && filters.Project == "" && filters.TaskID == "" && filters.State == "" && filters.RiskLevel == "" && filters.Priority == nil {
 		return takeovers
@@ -2175,6 +2179,35 @@ func (s *Server) filteredActiveTakeovers(filters controlCenterFilters) []control
 		filtered = append(filtered, takeover)
 	}
 	return filtered
+}
+
+func (s *Server) filteredTakeoverHistory(filters controlCenterFilters) []control.Takeover {
+	if s.Control == nil {
+		return nil
+	}
+	takeovers := s.Control.TakeoverHistory()
+	if filters.Team == "" && filters.Project == "" && filters.TaskID == "" && filters.State == "" && filters.RiskLevel == "" && filters.Priority == nil {
+		return limitTakeovers(takeovers, filters.Limit)
+	}
+	filtered := make([]control.Takeover, 0, len(takeovers))
+	for _, takeover := range takeovers {
+		task, ok := s.taskSnapshot(takeover.TaskID)
+		if !ok {
+			continue
+		}
+		if !matchesTaskFilters(task, effectiveTaskState(task.State, &takeover), filters) {
+			continue
+		}
+		filtered = append(filtered, takeover)
+	}
+	return limitTakeovers(filtered, filters.Limit)
+}
+
+func limitTakeovers(takeovers []control.Takeover, limit int) []control.Takeover {
+	if limit <= 0 || len(takeovers) <= limit {
+		return takeovers
+	}
+	return takeovers[:limit]
 }
 
 func (s *Server) controlActionAuditEntries(filters controlCenterFilters, authorization ControlAuthorization) []controlActionAuditEntry {

--- a/bigclaw-go/internal/control/controller.go
+++ b/bigclaw-go/internal/control/controller.go
@@ -194,12 +194,21 @@ func (c *Controller) ActiveTakeovers() []Takeover {
 			out = append(out, cloneTakeover(takeover))
 		}
 	}
-	sort.SliceStable(out, func(i, j int) bool {
-		if out[i].UpdatedAt.Equal(out[j].UpdatedAt) {
-			return out[i].TaskID < out[j].TaskID
+	sortTakeovers(out)
+	return out
+}
+
+func (c *Controller) TakeoverHistory() []Takeover {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Takeover, 0, len(c.takeovers))
+	for _, takeover := range c.takeovers {
+		if !takeover.Active && takeover.StartedAt.IsZero() && takeover.ReleasedAt.IsZero() {
+			continue
 		}
-		return out[i].UpdatedAt.After(out[j].UpdatedAt)
-	})
+		out = append(out, cloneTakeover(takeover))
+	}
+	sortTakeovers(out)
 	return out
 }
 
@@ -225,4 +234,13 @@ func cloneTakeover(takeover Takeover) Takeover {
 		clone.Notes = append([]Note(nil), takeover.Notes...)
 	}
 	return clone
+}
+
+func sortTakeovers(takeovers []Takeover) {
+	sort.SliceStable(takeovers, func(i, j int) bool {
+		if takeovers[i].UpdatedAt.Equal(takeovers[j].UpdatedAt) {
+			return takeovers[i].TaskID < takeovers[j].TaskID
+		}
+		return takeovers[i].UpdatedAt.After(takeovers[j].UpdatedAt)
+	})
 }

--- a/bigclaw-go/internal/control/controller_test.go
+++ b/bigclaw-go/internal/control/controller_test.go
@@ -46,3 +46,33 @@ func TestControllerPauseAndTakeoverLifecycle(t *testing.T) {
 		t.Fatalf("expected resumed snapshot, got %+v", snapshot)
 	}
 }
+
+func TestControllerTakeoverHistoryIncludesReleasedTakeoversInRecencyOrder(t *testing.T) {
+	controller := New()
+	base := time.Unix(1700000000, 0)
+
+	controller.Annotate("task-note-only", "ops", "comment without takeover", base)
+	controller.Takeover("task-older", "alice", "bob", "investigating", base.Add(time.Second))
+	controller.Takeover("task-active", "carol", "dave", "triaging", base.Add(2*time.Second))
+	released, ok := controller.Release("task-older", "alice", "handoff complete", base.Add(3*time.Second))
+	if !ok {
+		t.Fatal("expected release to succeed")
+	}
+
+	history := controller.TakeoverHistory()
+	if len(history) != 2 {
+		t.Fatalf("expected two historical takeovers, got %+v", history)
+	}
+	if history[0].TaskID != "task-older" || history[1].TaskID != "task-active" {
+		t.Fatalf("expected recency order [task-older task-active], got %+v", history)
+	}
+	if history[0].Active || history[0].ReleasedAt.IsZero() || history[0].Owner != "alice" || history[0].Reviewer != "bob" {
+		t.Fatalf("expected released takeover details preserved, got %+v", history[0])
+	}
+	if len(history[0].Notes) != 2 || history[0].Notes[1].Message != "handoff complete" {
+		t.Fatalf("expected release note preserved in history, got %+v", history[0].Notes)
+	}
+	if released.ReleasedAt != history[0].ReleasedAt {
+		t.Fatalf("expected released history timestamp to match returned takeover, got %+v history=%+v", released, history[0])
+	}
+}


### PR DESCRIPTION
## Summary
- add a controller takeover history view that keeps active and released handoffs in stable recency order
- expose filtered takeover history in the v2 control-center payload alongside active takeovers
- add regression coverage for ordering, release closeout semantics, and filtered control-center history responses

## Validation
- go test ./internal/control ./internal/api