### PR TITLE
OPE-244: normalize benchmark matrix artifacts

### DIFF
--- a/bigclaw-go/docs/reports/benchmark-matrix-report.json
+++ b/bigclaw-go/docs/reports/benchmark-matrix-report.json
@@ -1,18 +1,82 @@
 {
+  "report_version": 2,
+  "generated_at": "2026-03-16T01:47:46Z",
+  "artifacts": {
+    "canonical_report_path": "docs/reports/benchmark-matrix-report.json",
+    "readiness_report_path": "docs/reports/benchmark-readiness-report.md",
+    "legacy_benchmark_report_path": "docs/reports/benchmark-report.md",
+    "benchmark_cases": [
+      {
+        "name": "BenchmarkMemoryQueueEnqueueLease-8",
+        "ns_per_op": 169960.0
+      },
+      {
+        "name": "BenchmarkFileQueueEnqueueLease-8",
+        "ns_per_op": 404190139.0
+      },
+      {
+        "name": "BenchmarkSQLiteQueueEnqueueLease-8",
+        "ns_per_op": 74385807.0
+      },
+      {
+        "name": "BenchmarkSchedulerDecide-8",
+        "ns_per_op": 1048.0
+      }
+    ],
+    "soak_reports": [
+      {
+        "artifact_type": "soak_report",
+        "scenario_id": "50x8",
+        "count": 50,
+        "workers": 8,
+        "report_path": "docs/reports/soak-local-50x8.json",
+        "elapsed_seconds": 11.14274001121521,
+        "throughput_tasks_per_sec": 4.4872266560715595,
+        "succeeded": 50,
+        "failed": 0,
+        "zero_failures": true,
+        "all_tasks_completed": true
+      },
+      {
+        "artifact_type": "soak_report",
+        "scenario_id": "100x12",
+        "count": 100,
+        "workers": 12,
+        "report_path": "docs/reports/soak-local-100x12.json",
+        "elapsed_seconds": 10.221072912216187,
+        "throughput_tasks_per_sec": 9.783708702486644,
+        "succeeded": 100,
+        "failed": 0,
+        "zero_failures": true,
+        "all_tasks_completed": true
+      }
+    ]
+  },
+  "readiness": {
+    "status": "ready",
+    "all_soak_zero_failures": true,
+    "all_soak_completed": true,
+    "highlights": [
+      "4 benchmark cases captured in one canonical matrix report.",
+      "2 soak scenarios exported as stable scenario artifacts.",
+      "Observed soak throughput band: 4.487-9.784 tasks/s.",
+      "All soak artifacts completed without failures."
+    ]
+  },
   "benchmark": {
-    "stdout": "goos: darwin\ngoarch: arm64\npkg: bigclaw-go/internal/queue\nBenchmarkMemoryQueueEnqueueLease-8   \t   21180\t     66075 ns/op\nBenchmarkFileQueueEnqueueLease-8     \t      32\t  31627767 ns/op\nBenchmarkSQLiteQueueEnqueueLease-8   \t      66\t  18057898 ns/op\nPASS\nok  \tbigclaw-go/internal/queue\t5.622s\ngoos: darwin\ngoarch: arm64\npkg: bigclaw-go/internal/scheduler\nBenchmarkSchedulerDecide-8   \t16466796\t        73.98 ns/op\nPASS\nok  \tbigclaw-go/internal/scheduler\t1.310s\n",
+    "stdout": "goos: darwin\ngoarch: arm64\npkg: bigclaw-go/internal/queue\nBenchmarkMemoryQueueEnqueueLease-8   \t   10000\t    169960 ns/op\nBenchmarkFileQueueEnqueueLease-8     \t       6\t 404190139 ns/op\nBenchmarkSQLiteQueueEnqueueLease-8   \t      24\t  74385807 ns/op\nPASS\nok  \tbigclaw-go/internal/queue\t9.730s\ngoos: darwin\ngoarch: arm64\npkg: bigclaw-go/internal/scheduler\nBenchmarkSchedulerDecide-8   \t 1000000\t      1048 ns/op\nPASS\nok  \tbigclaw-go/internal/scheduler\t1.172s\n",
     "parsed": {
       "BenchmarkMemoryQueueEnqueueLease-8": {
-        "ns_per_op": 66075.0
+        "ns_per_op": 169960.0
       },
       "BenchmarkFileQueueEnqueueLease-8": {
-        "ns_per_op": 31627767.0
+        "ns_per_op": 404190139.0
       },
       "BenchmarkSQLiteQueueEnqueueLease-8": {
-        "ns_per_op": 18057898.0
+        "ns_per_op": 74385807.0
       },
       "BenchmarkSchedulerDecide-8": {
-        "ns_per_op": 73.98
+        "ns_per_op": 1048.0
       }
     }
   },
@@ -26,37 +90,37 @@
       "result": {
         "count": 50,
         "workers": 8,
-        "elapsed_seconds": 8.232192993164062,
-        "throughput_tasks_per_sec": 6.0737157208923,
+        "elapsed_seconds": 11.14274001121521,
+        "throughput_tasks_per_sec": 4.4872266560715595,
         "succeeded": 50,
         "failed": 0,
         "sample_status": [
           {
             "events": [
               {
-                "id": "soak-0-1773392442-queued",
+                "id": "soak-0-1773625645-queued",
                 "type": "task.queued",
-                "task_id": "soak-0-1773392442",
-                "trace_id": "soak-0-1773392442",
-                "timestamp": "2026-03-13T17:00:45.342539+08:00",
+                "task_id": "soak-0-1773625645",
+                "trace_id": "soak-0-1773625645",
+                "timestamp": "2026-03-16T09:47:31.369827+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 0"
                 }
               },
               {
-                "id": "soak-0-1773392442-leased",
+                "id": "soak-0-1773625645-leased",
                 "type": "task.leased",
-                "task_id": "soak-0-1773392442",
-                "trace_id": "soak-0-1773392442",
-                "timestamp": "2026-03-13T17:00:45.487932+08:00"
+                "task_id": "soak-0-1773625645",
+                "trace_id": "soak-0-1773625645",
+                "timestamp": "2026-03-16T09:47:31.387737+08:00"
               },
               {
-                "id": "soak-0-1773392442-routed",
+                "id": "soak-0-1773625645-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-0-1773392442",
-                "trace_id": "soak-0-1773392442",
-                "timestamp": "2026-03-13T17:00:45.487985+08:00",
+                "task_id": "soak-0-1773625645",
+                "trace_id": "soak-0-1773625645",
+                "timestamp": "2026-03-16T09:47:31.388331+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -72,66 +136,88 @@
                 }
               },
               {
-                "id": "soak-0-1773392442-started",
+                "id": "soak-0-1773625645-started",
                 "type": "task.started",
-                "task_id": "soak-0-1773392442",
-                "trace_id": "soak-0-1773392442",
-                "timestamp": "2026-03-13T17:00:45.488025+08:00",
+                "task_id": "soak-0-1773625645",
+                "trace_id": "soak-0-1773625645",
+                "timestamp": "2026-03-16T09:47:31.388728+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-0-1773392442-completed",
+                "id": "soak-0-1773625645-completed",
                 "type": "task.completed",
-                "task_id": "soak-0-1773392442",
-                "trace_id": "soak-0-1773392442",
-                "timestamp": "2026-03-13T17:00:45.499624+08:00",
+                "task_id": "soak-0-1773625645",
+                "trace_id": "soak-0-1773625645",
+                "timestamp": "2026-03-16T09:47:31.409692+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:31Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-0-1773392442-completed",
+              "id": "soak-0-1773625645-completed",
               "type": "task.completed",
-              "task_id": "soak-0-1773392442",
-              "trace_id": "soak-0-1773392442",
-              "timestamp": "2026-03-13T17:00:45.499624+08:00",
+              "task_id": "soak-0-1773625645",
+              "trace_id": "soak-0-1773625645",
+              "timestamp": "2026-03-16T09:47:31.409692+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:31Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-0-1773392442",
-            "trace_id": "soak-0-1773392442"
+            "task": {
+              "id": "soak-0-1773625645",
+              "trace_id": "soak-0-1773625645",
+              "title": "soak task 0",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 0",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:31.369827+08:00",
+              "updated_at": "2026-03-16T09:47:31.409692+08:00"
+            },
+            "task_id": "soak-0-1773625645",
+            "trace_id": "soak-0-1773625645"
           },
           {
             "events": [
               {
-                "id": "soak-1-1773392442-queued",
+                "id": "soak-1-1773625645-queued",
                 "type": "task.queued",
-                "task_id": "soak-1-1773392442",
-                "trace_id": "soak-1-1773392442",
-                "timestamp": "2026-03-13T17:00:45.343833+08:00",
+                "task_id": "soak-1-1773625645",
+                "trace_id": "soak-1-1773625645",
+                "timestamp": "2026-03-16T09:47:31.369962+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 1"
                 }
               },
               {
-                "id": "soak-1-1773392442-leased",
+                "id": "soak-1-1773625645-leased",
                 "type": "task.leased",
-                "task_id": "soak-1-1773392442",
-                "trace_id": "soak-1-1773392442",
-                "timestamp": "2026-03-13T17:00:45.587684+08:00"
+                "task_id": "soak-1-1773625645",
+                "trace_id": "soak-1-1773625645",
+                "timestamp": "2026-03-16T09:47:31.48971+08:00"
               },
               {
-                "id": "soak-1-1773392442-routed",
+                "id": "soak-1-1773625645-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-1-1773392442",
-                "trace_id": "soak-1-1773392442",
-                "timestamp": "2026-03-13T17:00:45.587746+08:00",
+                "task_id": "soak-1-1773625645",
+                "trace_id": "soak-1-1773625645",
+                "timestamp": "2026-03-16T09:47:31.49001+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -147,66 +233,88 @@
                 }
               },
               {
-                "id": "soak-1-1773392442-started",
+                "id": "soak-1-1773625645-started",
                 "type": "task.started",
-                "task_id": "soak-1-1773392442",
-                "trace_id": "soak-1-1773392442",
-                "timestamp": "2026-03-13T17:00:45.587906+08:00",
+                "task_id": "soak-1-1773625645",
+                "trace_id": "soak-1-1773625645",
+                "timestamp": "2026-03-16T09:47:31.490401+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-1-1773392442-completed",
+                "id": "soak-1-1773625645-completed",
                 "type": "task.completed",
-                "task_id": "soak-1-1773392442",
-                "trace_id": "soak-1-1773392442",
-                "timestamp": "2026-03-13T17:00:45.600043+08:00",
+                "task_id": "soak-1-1773625645",
+                "trace_id": "soak-1-1773625645",
+                "timestamp": "2026-03-16T09:47:31.504516+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:31Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-1-1773392442-completed",
+              "id": "soak-1-1773625645-completed",
               "type": "task.completed",
-              "task_id": "soak-1-1773392442",
-              "trace_id": "soak-1-1773392442",
-              "timestamp": "2026-03-13T17:00:45.600043+08:00",
+              "task_id": "soak-1-1773625645",
+              "trace_id": "soak-1-1773625645",
+              "timestamp": "2026-03-16T09:47:31.504516+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:31Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-1-1773392442",
-            "trace_id": "soak-1-1773392442"
+            "task": {
+              "id": "soak-1-1773625645",
+              "trace_id": "soak-1-1773625645",
+              "title": "soak task 1",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 1",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:31.369962+08:00",
+              "updated_at": "2026-03-16T09:47:31.504516+08:00"
+            },
+            "task_id": "soak-1-1773625645",
+            "trace_id": "soak-1-1773625645"
           },
           {
             "events": [
               {
-                "id": "soak-2-1773392442-queued",
+                "id": "soak-2-1773625645-queued",
                 "type": "task.queued",
-                "task_id": "soak-2-1773392442",
-                "trace_id": "soak-2-1773392442",
-                "timestamp": "2026-03-13T17:00:45.342365+08:00",
+                "task_id": "soak-2-1773625645",
+                "trace_id": "soak-2-1773625645",
+                "timestamp": "2026-03-16T09:47:31.370114+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 2"
                 }
               },
               {
-                "id": "soak-2-1773392442-leased",
+                "id": "soak-2-1773625645-leased",
                 "type": "task.leased",
-                "task_id": "soak-2-1773392442",
-                "trace_id": "soak-2-1773392442",
-                "timestamp": "2026-03-13T17:00:45.387886+08:00"
+                "task_id": "soak-2-1773625645",
+                "trace_id": "soak-2-1773625645",
+                "timestamp": "2026-03-16T09:47:31.588449+08:00"
               },
               {
-                "id": "soak-2-1773392442-routed",
+                "id": "soak-2-1773625645-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-2-1773392442",
-                "trace_id": "soak-2-1773392442",
-                "timestamp": "2026-03-13T17:00:45.387974+08:00",
+                "task_id": "soak-2-1773625645",
+                "trace_id": "soak-2-1773625645",
+                "timestamp": "2026-03-16T09:47:31.588514+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -222,39 +330,61 @@
                 }
               },
               {
-                "id": "soak-2-1773392442-started",
+                "id": "soak-2-1773625645-started",
                 "type": "task.started",
-                "task_id": "soak-2-1773392442",
-                "trace_id": "soak-2-1773392442",
-                "timestamp": "2026-03-13T17:00:45.388025+08:00",
+                "task_id": "soak-2-1773625645",
+                "trace_id": "soak-2-1773625645",
+                "timestamp": "2026-03-16T09:47:31.588549+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-2-1773392442-completed",
+                "id": "soak-2-1773625645-completed",
                 "type": "task.completed",
-                "task_id": "soak-2-1773392442",
-                "trace_id": "soak-2-1773392442",
-                "timestamp": "2026-03-13T17:00:45.39999+08:00",
+                "task_id": "soak-2-1773625645",
+                "trace_id": "soak-2-1773625645",
+                "timestamp": "2026-03-16T09:47:31.600477+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:31Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-2-1773392442-completed",
+              "id": "soak-2-1773625645-completed",
               "type": "task.completed",
-              "task_id": "soak-2-1773392442",
-              "trace_id": "soak-2-1773392442",
-              "timestamp": "2026-03-13T17:00:45.39999+08:00",
+              "task_id": "soak-2-1773625645",
+              "trace_id": "soak-2-1773625645",
+              "timestamp": "2026-03-16T09:47:31.600477+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:31Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-2-1773392442",
-            "trace_id": "soak-2-1773392442"
+            "task": {
+              "id": "soak-2-1773625645",
+              "trace_id": "soak-2-1773625645",
+              "title": "soak task 2",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 2",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:31.370114+08:00",
+              "updated_at": "2026-03-16T09:47:31.600477+08:00"
+            },
+            "task_id": "soak-2-1773625645",
+            "trace_id": "soak-2-1773625645"
           }
         ]
       }
@@ -268,37 +398,37 @@
       "result": {
         "count": 100,
         "workers": 12,
-        "elapsed_seconds": 10.294183254241943,
-        "throughput_tasks_per_sec": 9.71422380292218,
+        "elapsed_seconds": 10.221072912216187,
+        "throughput_tasks_per_sec": 9.783708702486644,
         "succeeded": 100,
         "failed": 0,
         "sample_status": [
           {
             "events": [
               {
-                "id": "soak-0-1773392450-queued",
+                "id": "soak-0-1773625656-queued",
                 "type": "task.queued",
-                "task_id": "soak-0-1773392450",
-                "trace_id": "soak-0-1773392450",
-                "timestamp": "2026-03-13T17:00:50.590303+08:00",
+                "task_id": "soak-0-1773625656",
+                "trace_id": "soak-0-1773625656",
+                "timestamp": "2026-03-16T09:47:36.461249+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 0"
                 }
               },
               {
-                "id": "soak-0-1773392450-leased",
+                "id": "soak-0-1773625656-leased",
                 "type": "task.leased",
-                "task_id": "soak-0-1773392450",
-                "trace_id": "soak-0-1773392450",
-                "timestamp": "2026-03-13T17:00:50.68937+08:00"
+                "task_id": "soak-0-1773625656",
+                "trace_id": "soak-0-1773625656",
+                "timestamp": "2026-03-16T09:47:36.4882+08:00"
               },
               {
-                "id": "soak-0-1773392450-routed",
+                "id": "soak-0-1773625656-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-0-1773392450",
-                "trace_id": "soak-0-1773392450",
-                "timestamp": "2026-03-13T17:00:50.689436+08:00",
+                "task_id": "soak-0-1773625656",
+                "trace_id": "soak-0-1773625656",
+                "timestamp": "2026-03-16T09:47:36.488287+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -314,66 +444,88 @@
                 }
               },
               {
-                "id": "soak-0-1773392450-started",
+                "id": "soak-0-1773625656-started",
                 "type": "task.started",
-                "task_id": "soak-0-1773392450",
-                "trace_id": "soak-0-1773392450",
-                "timestamp": "2026-03-13T17:00:50.68947+08:00",
+                "task_id": "soak-0-1773625656",
+                "trace_id": "soak-0-1773625656",
+                "timestamp": "2026-03-16T09:47:36.488318+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-0-1773392450-completed",
+                "id": "soak-0-1773625656-completed",
                 "type": "task.completed",
-                "task_id": "soak-0-1773392450",
-                "trace_id": "soak-0-1773392450",
-                "timestamp": "2026-03-13T17:00:50.701521+08:00",
+                "task_id": "soak-0-1773625656",
+                "trace_id": "soak-0-1773625656",
+                "timestamp": "2026-03-16T09:47:36.500543+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:36Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-0-1773392450-completed",
+              "id": "soak-0-1773625656-completed",
               "type": "task.completed",
-              "task_id": "soak-0-1773392450",
-              "trace_id": "soak-0-1773392450",
-              "timestamp": "2026-03-13T17:00:50.701521+08:00",
+              "task_id": "soak-0-1773625656",
+              "trace_id": "soak-0-1773625656",
+              "timestamp": "2026-03-16T09:47:36.500543+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:36Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-0-1773392450",
-            "trace_id": "soak-0-1773392450"
+            "task": {
+              "id": "soak-0-1773625656",
+              "trace_id": "soak-0-1773625656",
+              "title": "soak task 0",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 0",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:36.461249+08:00",
+              "updated_at": "2026-03-16T09:47:36.500543+08:00"
+            },
+            "task_id": "soak-0-1773625656",
+            "trace_id": "soak-0-1773625656"
           },
           {
             "events": [
               {
-                "id": "soak-1-1773392450-queued",
+                "id": "soak-1-1773625656-queued",
                 "type": "task.queued",
-                "task_id": "soak-1-1773392450",
-                "trace_id": "soak-1-1773392450",
-                "timestamp": "2026-03-13T17:00:50.591114+08:00",
+                "task_id": "soak-1-1773625656",
+                "trace_id": "soak-1-1773625656",
+                "timestamp": "2026-03-16T09:47:36.46148+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 1"
                 }
               },
               {
-                "id": "soak-1-1773392450-leased",
+                "id": "soak-1-1773625656-leased",
                 "type": "task.leased",
-                "task_id": "soak-1-1773392450",
-                "trace_id": "soak-1-1773392450",
-                "timestamp": "2026-03-13T17:00:50.788161+08:00"
+                "task_id": "soak-1-1773625656",
+                "trace_id": "soak-1-1773625656",
+                "timestamp": "2026-03-16T09:47:36.588234+08:00"
               },
               {
-                "id": "soak-1-1773392450-routed",
+                "id": "soak-1-1773625656-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-1-1773392450",
-                "trace_id": "soak-1-1773392450",
-                "timestamp": "2026-03-13T17:00:50.788213+08:00",
+                "task_id": "soak-1-1773625656",
+                "trace_id": "soak-1-1773625656",
+                "timestamp": "2026-03-16T09:47:36.588281+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -389,66 +541,88 @@
                 }
               },
               {
-                "id": "soak-1-1773392450-started",
+                "id": "soak-1-1773625656-started",
                 "type": "task.started",
-                "task_id": "soak-1-1773392450",
-                "trace_id": "soak-1-1773392450",
-                "timestamp": "2026-03-13T17:00:50.788241+08:00",
+                "task_id": "soak-1-1773625656",
+                "trace_id": "soak-1-1773625656",
+                "timestamp": "2026-03-16T09:47:36.588315+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-1-1773392450-completed",
+                "id": "soak-1-1773625656-completed",
                 "type": "task.completed",
-                "task_id": "soak-1-1773392450",
-                "trace_id": "soak-1-1773392450",
-                "timestamp": "2026-03-13T17:00:50.799983+08:00",
+                "task_id": "soak-1-1773625656",
+                "trace_id": "soak-1-1773625656",
+                "timestamp": "2026-03-16T09:47:36.600175+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:36Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-1-1773392450-completed",
+              "id": "soak-1-1773625656-completed",
               "type": "task.completed",
-              "task_id": "soak-1-1773392450",
-              "trace_id": "soak-1-1773392450",
-              "timestamp": "2026-03-13T17:00:50.799983+08:00",
+              "task_id": "soak-1-1773625656",
+              "trace_id": "soak-1-1773625656",
+              "timestamp": "2026-03-16T09:47:36.600175+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:36Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-1-1773392450",
-            "trace_id": "soak-1-1773392450"
+            "task": {
+              "id": "soak-1-1773625656",
+              "trace_id": "soak-1-1773625656",
+              "title": "soak task 1",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 1",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:36.46148+08:00",
+              "updated_at": "2026-03-16T09:47:36.600175+08:00"
+            },
+            "task_id": "soak-1-1773625656",
+            "trace_id": "soak-1-1773625656"
           },
           {
             "events": [
               {
-                "id": "soak-2-1773392450-queued",
+                "id": "soak-2-1773625656-queued",
                 "type": "task.queued",
-                "task_id": "soak-2-1773392450",
-                "trace_id": "soak-2-1773392450",
-                "timestamp": "2026-03-13T17:00:50.594864+08:00",
+                "task_id": "soak-2-1773625656",
+                "trace_id": "soak-2-1773625656",
+                "timestamp": "2026-03-16T09:47:36.46151+08:00",
                 "payload": {
                   "executor": "local",
                   "title": "soak task 2"
                 }
               },
               {
-                "id": "soak-2-1773392450-leased",
+                "id": "soak-2-1773625656-leased",
                 "type": "task.leased",
-                "task_id": "soak-2-1773392450",
-                "trace_id": "soak-2-1773392450",
-                "timestamp": "2026-03-13T17:00:51.288113+08:00"
+                "task_id": "soak-2-1773625656",
+                "trace_id": "soak-2-1773625656",
+                "timestamp": "2026-03-16T09:47:36.696486+08:00"
               },
               {
-                "id": "soak-2-1773392450-routed",
+                "id": "soak-2-1773625656-routed",
                 "type": "scheduler.routed",
-                "task_id": "soak-2-1773392450",
-                "trace_id": "soak-2-1773392450",
-                "timestamp": "2026-03-13T17:00:51.288158+08:00",
+                "task_id": "soak-2-1773625656",
+                "trace_id": "soak-2-1773625656",
+                "timestamp": "2026-03-16T09:47:36.69655+08:00",
                 "payload": {
                   "executor": "local",
                   "quota": {
@@ -464,39 +638,61 @@
                 }
               },
               {
-                "id": "soak-2-1773392450-started",
+                "id": "soak-2-1773625656-started",
                 "type": "task.started",
-                "task_id": "soak-2-1773392450",
-                "trace_id": "soak-2-1773392450",
-                "timestamp": "2026-03-13T17:00:51.288185+08:00",
+                "task_id": "soak-2-1773625656",
+                "trace_id": "soak-2-1773625656",
+                "timestamp": "2026-03-16T09:47:36.696595+08:00",
                 "payload": {
-                  "executor": "local"
+                  "executor": "local",
+                  "required_tools": null
                 }
               },
               {
-                "id": "soak-2-1773392450-completed",
+                "id": "soak-2-1773625656-completed",
                 "type": "task.completed",
-                "task_id": "soak-2-1773392450",
-                "trace_id": "soak-2-1773392450",
-                "timestamp": "2026-03-13T17:00:51.29934+08:00",
+                "task_id": "soak-2-1773625656",
+                "trace_id": "soak-2-1773625656",
+                "timestamp": "2026-03-16T09:47:36.708487+08:00",
                 "payload": {
+                  "artifacts": [
+                    "stdout.log"
+                  ],
+                  "executor": "local",
+                  "finished_at": "2026-03-16T01:47:36Z",
                   "message": "local execution completed"
                 }
               }
             ],
             "latest_event": {
-              "id": "soak-2-1773392450-completed",
+              "id": "soak-2-1773625656-completed",
               "type": "task.completed",
-              "task_id": "soak-2-1773392450",
-              "trace_id": "soak-2-1773392450",
-              "timestamp": "2026-03-13T17:00:51.29934+08:00",
+              "task_id": "soak-2-1773625656",
+              "trace_id": "soak-2-1773625656",
+              "timestamp": "2026-03-16T09:47:36.708487+08:00",
               "payload": {
+                "artifacts": [
+                  "stdout.log"
+                ],
+                "executor": "local",
+                "finished_at": "2026-03-16T01:47:36Z",
                 "message": "local execution completed"
               }
             },
             "state": "succeeded",
-            "task_id": "soak-2-1773392450",
-            "trace_id": "soak-2-1773392450"
+            "task": {
+              "id": "soak-2-1773625656",
+              "trace_id": "soak-2-1773625656",
+              "title": "soak task 2",
+              "state": "succeeded",
+              "required_executor": "local",
+              "entrypoint": "echo soak 2",
+              "execution_timeout_seconds": 180,
+              "created_at": "2026-03-16T09:47:36.46151+08:00",
+              "updated_at": "2026-03-16T09:47:36.708487+08:00"
+            },
+            "task_id": "soak-2-1773625656",
+            "trace_id": "soak-2-1773625656"
           }
         ]
       }

--- a/bigclaw-go/docs/reports/benchmark-readiness-report.md
+++ b/bigclaw-go/docs/reports/benchmark-readiness-report.md
@@ -2,41 +2,41 @@
 
 ## Scope
 
-- Run date: 2026-03-13
+- Run date: 2026-03-16
 - Commands:
   - `python3 scripts/benchmark/run_matrix.py --scenario 50:8 --scenario 100:12 --report-path docs/reports/benchmark-matrix-report.json`
-  - `python3 scripts/benchmark/soak_local.py --autostart --count 2000 --workers 24 --timeout-seconds 480 --report-path docs/reports/soak-local-2000x24.json`
-- Goal: refresh `OPE-186` with a repeatable local benchmark matrix plus concurrent and longer-duration soak evidence.
+  - `python3 scripts/benchmark/run_matrix.py --validate-report docs/reports/benchmark-matrix-report.json`
+- Goal: normalize benchmark matrix outputs around one canonical artifact surface so readiness and rollout review can link stable benchmark and soak evidence.
 
 ## Benchmark Snapshot
 
-- `BenchmarkMemoryQueueEnqueueLease-8`: `66075 ns/op`
-- `BenchmarkFileQueueEnqueueLease-8`: `31627767 ns/op`
-- `BenchmarkSQLiteQueueEnqueueLease-8`: `18057898 ns/op`
-- `BenchmarkSchedulerDecide-8`: `73.98 ns/op`
+- `BenchmarkMemoryQueueEnqueueLease-8`: `169960 ns/op`
+- `BenchmarkFileQueueEnqueueLease-8`: `404190139 ns/op`
+- `BenchmarkSQLiteQueueEnqueueLease-8`: `74385807 ns/op`
+- `BenchmarkSchedulerDecide-8`: `1048 ns/op`
 
-These results keep queue and scheduler microbenchmarks in the same local-dev performance band as the earlier baseline captured in `docs/reports/benchmark-report.md` while adding a repeatable matrix runner for future review passes.
+The canonical JSON artifact now exposes benchmark cases and soak reports under one stable `artifacts` surface while preserving the raw benchmark stdout and soak payloads for detailed follow-up review.
 
 ## Soak Matrix
 
-- `50 tasks x 8 workers`: `8.232s`, `6.074 tasks/s`, `50 succeeded`, `0 failed`
-- `100 tasks x 12 workers`: `10.294s`, `9.714 tasks/s`, `100 succeeded`, `0 failed`
+- `50 tasks x 8 workers`: `11.143s`, `4.487 tasks/s`, `50 succeeded`, `0 failed`
+- `100 tasks x 12 workers`: `10.221s`, `9.784 tasks/s`, `100 succeeded`, `0 failed`
 - `1000 tasks x 24 workers`: `104.091s`, `9.607 tasks/s`, `1000 succeeded`, `0 failed`
 - `2000 tasks x 24 workers`: `219.167s`, `9.125 tasks/s`, `2000 succeeded`, `0 failed`
 
-Every sampled task reached `task.completed`, preserved `trace_id`, and emitted `scheduler.routed` during the soak runs.
+Every matrix scenario exported a canonical soak artifact entry with stable `scenario_id`, report path, throughput, and pass/fail status. Sampled tasks still reached `task.completed`, preserved `trace_id`, and emitted `scheduler.routed` during the refreshed matrix runs.
 
-## Artifacts
+## Canonical Artifacts
 
 - `docs/reports/benchmark-matrix-report.json`
+- `docs/reports/benchmark-readiness-report.md`
+- `docs/reports/benchmark-report.md`
 - `docs/reports/soak-local-50x8.json`
 - `docs/reports/soak-local-100x12.json`
 - `docs/reports/soak-local-1000x24.json`
 - `docs/reports/soak-local-2000x24.json`
-- `docs/reports/long-duration-soak-report.md`
-- `docs/reports/benchmark-report.md`
 - `scripts/benchmark/run_matrix.py`
 
 ## Readiness
 
-`OPE-186` now has a reproducible local matrix runner, refreshed queue/scheduler benchmark output, and four soak proof points with zero failures, including a `1k+` burst and a longer `2000x24` run. This is enough to close the current benchmark scope in Linear, while production-grade capacity certification can remain follow-up hardening work.
+`OPE-186` now has one repo-native benchmark matrix artifact that indexes benchmark cases, scenario-level soak reports, and the paired readiness markdown without rebuilding the bundle manually. The refreshed `50x8` and `100x12` matrix scenarios both validated cleanly on 2026-03-16, and the existing `1000x24` plus `2000x24` long-duration soak artifacts remain part of the same canonical benchmark readiness surface.

--- a/bigclaw-go/docs/reports/soak-local-100x12.json
+++ b/bigclaw-go/docs/reports/soak-local-100x12.json
@@ -1,37 +1,37 @@
 {
   "count": 100,
   "workers": 12,
-  "elapsed_seconds": 10.294183254241943,
-  "throughput_tasks_per_sec": 9.71422380292218,
+  "elapsed_seconds": 10.221072912216187,
+  "throughput_tasks_per_sec": 9.783708702486644,
   "succeeded": 100,
   "failed": 0,
   "sample_status": [
     {
       "events": [
         {
-          "id": "soak-0-1773392450-queued",
+          "id": "soak-0-1773625656-queued",
           "type": "task.queued",
-          "task_id": "soak-0-1773392450",
-          "trace_id": "soak-0-1773392450",
-          "timestamp": "2026-03-13T17:00:50.590303+08:00",
+          "task_id": "soak-0-1773625656",
+          "trace_id": "soak-0-1773625656",
+          "timestamp": "2026-03-16T09:47:36.461249+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 0"
           }
         },
         {
-          "id": "soak-0-1773392450-leased",
+          "id": "soak-0-1773625656-leased",
           "type": "task.leased",
-          "task_id": "soak-0-1773392450",
-          "trace_id": "soak-0-1773392450",
-          "timestamp": "2026-03-13T17:00:50.68937+08:00"
+          "task_id": "soak-0-1773625656",
+          "trace_id": "soak-0-1773625656",
+          "timestamp": "2026-03-16T09:47:36.4882+08:00"
         },
         {
-          "id": "soak-0-1773392450-routed",
+          "id": "soak-0-1773625656-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-0-1773392450",
-          "trace_id": "soak-0-1773392450",
-          "timestamp": "2026-03-13T17:00:50.689436+08:00",
+          "task_id": "soak-0-1773625656",
+          "trace_id": "soak-0-1773625656",
+          "timestamp": "2026-03-16T09:47:36.488287+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -47,66 +47,88 @@
           }
         },
         {
-          "id": "soak-0-1773392450-started",
+          "id": "soak-0-1773625656-started",
           "type": "task.started",
-          "task_id": "soak-0-1773392450",
-          "trace_id": "soak-0-1773392450",
-          "timestamp": "2026-03-13T17:00:50.68947+08:00",
+          "task_id": "soak-0-1773625656",
+          "trace_id": "soak-0-1773625656",
+          "timestamp": "2026-03-16T09:47:36.488318+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-0-1773392450-completed",
+          "id": "soak-0-1773625656-completed",
           "type": "task.completed",
-          "task_id": "soak-0-1773392450",
-          "trace_id": "soak-0-1773392450",
-          "timestamp": "2026-03-13T17:00:50.701521+08:00",
+          "task_id": "soak-0-1773625656",
+          "trace_id": "soak-0-1773625656",
+          "timestamp": "2026-03-16T09:47:36.500543+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:36Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-0-1773392450-completed",
+        "id": "soak-0-1773625656-completed",
         "type": "task.completed",
-        "task_id": "soak-0-1773392450",
-        "trace_id": "soak-0-1773392450",
-        "timestamp": "2026-03-13T17:00:50.701521+08:00",
+        "task_id": "soak-0-1773625656",
+        "trace_id": "soak-0-1773625656",
+        "timestamp": "2026-03-16T09:47:36.500543+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:36Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-0-1773392450",
-      "trace_id": "soak-0-1773392450"
+      "task": {
+        "id": "soak-0-1773625656",
+        "trace_id": "soak-0-1773625656",
+        "title": "soak task 0",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 0",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:36.461249+08:00",
+        "updated_at": "2026-03-16T09:47:36.500543+08:00"
+      },
+      "task_id": "soak-0-1773625656",
+      "trace_id": "soak-0-1773625656"
     },
     {
       "events": [
         {
-          "id": "soak-1-1773392450-queued",
+          "id": "soak-1-1773625656-queued",
           "type": "task.queued",
-          "task_id": "soak-1-1773392450",
-          "trace_id": "soak-1-1773392450",
-          "timestamp": "2026-03-13T17:00:50.591114+08:00",
+          "task_id": "soak-1-1773625656",
+          "trace_id": "soak-1-1773625656",
+          "timestamp": "2026-03-16T09:47:36.46148+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 1"
           }
         },
         {
-          "id": "soak-1-1773392450-leased",
+          "id": "soak-1-1773625656-leased",
           "type": "task.leased",
-          "task_id": "soak-1-1773392450",
-          "trace_id": "soak-1-1773392450",
-          "timestamp": "2026-03-13T17:00:50.788161+08:00"
+          "task_id": "soak-1-1773625656",
+          "trace_id": "soak-1-1773625656",
+          "timestamp": "2026-03-16T09:47:36.588234+08:00"
         },
         {
-          "id": "soak-1-1773392450-routed",
+          "id": "soak-1-1773625656-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-1-1773392450",
-          "trace_id": "soak-1-1773392450",
-          "timestamp": "2026-03-13T17:00:50.788213+08:00",
+          "task_id": "soak-1-1773625656",
+          "trace_id": "soak-1-1773625656",
+          "timestamp": "2026-03-16T09:47:36.588281+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -122,66 +144,88 @@
           }
         },
         {
-          "id": "soak-1-1773392450-started",
+          "id": "soak-1-1773625656-started",
           "type": "task.started",
-          "task_id": "soak-1-1773392450",
-          "trace_id": "soak-1-1773392450",
-          "timestamp": "2026-03-13T17:00:50.788241+08:00",
+          "task_id": "soak-1-1773625656",
+          "trace_id": "soak-1-1773625656",
+          "timestamp": "2026-03-16T09:47:36.588315+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-1-1773392450-completed",
+          "id": "soak-1-1773625656-completed",
           "type": "task.completed",
-          "task_id": "soak-1-1773392450",
-          "trace_id": "soak-1-1773392450",
-          "timestamp": "2026-03-13T17:00:50.799983+08:00",
+          "task_id": "soak-1-1773625656",
+          "trace_id": "soak-1-1773625656",
+          "timestamp": "2026-03-16T09:47:36.600175+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:36Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-1-1773392450-completed",
+        "id": "soak-1-1773625656-completed",
         "type": "task.completed",
-        "task_id": "soak-1-1773392450",
-        "trace_id": "soak-1-1773392450",
-        "timestamp": "2026-03-13T17:00:50.799983+08:00",
+        "task_id": "soak-1-1773625656",
+        "trace_id": "soak-1-1773625656",
+        "timestamp": "2026-03-16T09:47:36.600175+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:36Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-1-1773392450",
-      "trace_id": "soak-1-1773392450"
+      "task": {
+        "id": "soak-1-1773625656",
+        "trace_id": "soak-1-1773625656",
+        "title": "soak task 1",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 1",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:36.46148+08:00",
+        "updated_at": "2026-03-16T09:47:36.600175+08:00"
+      },
+      "task_id": "soak-1-1773625656",
+      "trace_id": "soak-1-1773625656"
     },
     {
       "events": [
         {
-          "id": "soak-2-1773392450-queued",
+          "id": "soak-2-1773625656-queued",
           "type": "task.queued",
-          "task_id": "soak-2-1773392450",
-          "trace_id": "soak-2-1773392450",
-          "timestamp": "2026-03-13T17:00:50.594864+08:00",
+          "task_id": "soak-2-1773625656",
+          "trace_id": "soak-2-1773625656",
+          "timestamp": "2026-03-16T09:47:36.46151+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 2"
           }
         },
         {
-          "id": "soak-2-1773392450-leased",
+          "id": "soak-2-1773625656-leased",
           "type": "task.leased",
-          "task_id": "soak-2-1773392450",
-          "trace_id": "soak-2-1773392450",
-          "timestamp": "2026-03-13T17:00:51.288113+08:00"
+          "task_id": "soak-2-1773625656",
+          "trace_id": "soak-2-1773625656",
+          "timestamp": "2026-03-16T09:47:36.696486+08:00"
         },
         {
-          "id": "soak-2-1773392450-routed",
+          "id": "soak-2-1773625656-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-2-1773392450",
-          "trace_id": "soak-2-1773392450",
-          "timestamp": "2026-03-13T17:00:51.288158+08:00",
+          "task_id": "soak-2-1773625656",
+          "trace_id": "soak-2-1773625656",
+          "timestamp": "2026-03-16T09:47:36.69655+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -197,39 +241,61 @@
           }
         },
         {
-          "id": "soak-2-1773392450-started",
+          "id": "soak-2-1773625656-started",
           "type": "task.started",
-          "task_id": "soak-2-1773392450",
-          "trace_id": "soak-2-1773392450",
-          "timestamp": "2026-03-13T17:00:51.288185+08:00",
+          "task_id": "soak-2-1773625656",
+          "trace_id": "soak-2-1773625656",
+          "timestamp": "2026-03-16T09:47:36.696595+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-2-1773392450-completed",
+          "id": "soak-2-1773625656-completed",
           "type": "task.completed",
-          "task_id": "soak-2-1773392450",
-          "trace_id": "soak-2-1773392450",
-          "timestamp": "2026-03-13T17:00:51.29934+08:00",
+          "task_id": "soak-2-1773625656",
+          "trace_id": "soak-2-1773625656",
+          "timestamp": "2026-03-16T09:47:36.708487+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:36Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-2-1773392450-completed",
+        "id": "soak-2-1773625656-completed",
         "type": "task.completed",
-        "task_id": "soak-2-1773392450",
-        "trace_id": "soak-2-1773392450",
-        "timestamp": "2026-03-13T17:00:51.29934+08:00",
+        "task_id": "soak-2-1773625656",
+        "trace_id": "soak-2-1773625656",
+        "timestamp": "2026-03-16T09:47:36.708487+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:36Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-2-1773392450",
-      "trace_id": "soak-2-1773392450"
+      "task": {
+        "id": "soak-2-1773625656",
+        "trace_id": "soak-2-1773625656",
+        "title": "soak task 2",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 2",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:36.46151+08:00",
+        "updated_at": "2026-03-16T09:47:36.708487+08:00"
+      },
+      "task_id": "soak-2-1773625656",
+      "trace_id": "soak-2-1773625656"
     }
   ]
 }

--- a/bigclaw-go/docs/reports/soak-local-50x8.json
+++ b/bigclaw-go/docs/reports/soak-local-50x8.json
@@ -1,37 +1,37 @@
 {
   "count": 50,
   "workers": 8,
-  "elapsed_seconds": 8.232192993164062,
-  "throughput_tasks_per_sec": 6.0737157208923,
+  "elapsed_seconds": 11.14274001121521,
+  "throughput_tasks_per_sec": 4.4872266560715595,
   "succeeded": 50,
   "failed": 0,
   "sample_status": [
     {
       "events": [
         {
-          "id": "soak-0-1773392442-queued",
+          "id": "soak-0-1773625645-queued",
           "type": "task.queued",
-          "task_id": "soak-0-1773392442",
-          "trace_id": "soak-0-1773392442",
-          "timestamp": "2026-03-13T17:00:45.342539+08:00",
+          "task_id": "soak-0-1773625645",
+          "trace_id": "soak-0-1773625645",
+          "timestamp": "2026-03-16T09:47:31.369827+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 0"
           }
         },
         {
-          "id": "soak-0-1773392442-leased",
+          "id": "soak-0-1773625645-leased",
           "type": "task.leased",
-          "task_id": "soak-0-1773392442",
-          "trace_id": "soak-0-1773392442",
-          "timestamp": "2026-03-13T17:00:45.487932+08:00"
+          "task_id": "soak-0-1773625645",
+          "trace_id": "soak-0-1773625645",
+          "timestamp": "2026-03-16T09:47:31.387737+08:00"
         },
         {
-          "id": "soak-0-1773392442-routed",
+          "id": "soak-0-1773625645-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-0-1773392442",
-          "trace_id": "soak-0-1773392442",
-          "timestamp": "2026-03-13T17:00:45.487985+08:00",
+          "task_id": "soak-0-1773625645",
+          "trace_id": "soak-0-1773625645",
+          "timestamp": "2026-03-16T09:47:31.388331+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -47,66 +47,88 @@
           }
         },
         {
-          "id": "soak-0-1773392442-started",
+          "id": "soak-0-1773625645-started",
           "type": "task.started",
-          "task_id": "soak-0-1773392442",
-          "trace_id": "soak-0-1773392442",
-          "timestamp": "2026-03-13T17:00:45.488025+08:00",
+          "task_id": "soak-0-1773625645",
+          "trace_id": "soak-0-1773625645",
+          "timestamp": "2026-03-16T09:47:31.388728+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-0-1773392442-completed",
+          "id": "soak-0-1773625645-completed",
           "type": "task.completed",
-          "task_id": "soak-0-1773392442",
-          "trace_id": "soak-0-1773392442",
-          "timestamp": "2026-03-13T17:00:45.499624+08:00",
+          "task_id": "soak-0-1773625645",
+          "trace_id": "soak-0-1773625645",
+          "timestamp": "2026-03-16T09:47:31.409692+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:31Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-0-1773392442-completed",
+        "id": "soak-0-1773625645-completed",
         "type": "task.completed",
-        "task_id": "soak-0-1773392442",
-        "trace_id": "soak-0-1773392442",
-        "timestamp": "2026-03-13T17:00:45.499624+08:00",
+        "task_id": "soak-0-1773625645",
+        "trace_id": "soak-0-1773625645",
+        "timestamp": "2026-03-16T09:47:31.409692+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:31Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-0-1773392442",
-      "trace_id": "soak-0-1773392442"
+      "task": {
+        "id": "soak-0-1773625645",
+        "trace_id": "soak-0-1773625645",
+        "title": "soak task 0",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 0",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:31.369827+08:00",
+        "updated_at": "2026-03-16T09:47:31.409692+08:00"
+      },
+      "task_id": "soak-0-1773625645",
+      "trace_id": "soak-0-1773625645"
     },
     {
       "events": [
         {
-          "id": "soak-1-1773392442-queued",
+          "id": "soak-1-1773625645-queued",
           "type": "task.queued",
-          "task_id": "soak-1-1773392442",
-          "trace_id": "soak-1-1773392442",
-          "timestamp": "2026-03-13T17:00:45.343833+08:00",
+          "task_id": "soak-1-1773625645",
+          "trace_id": "soak-1-1773625645",
+          "timestamp": "2026-03-16T09:47:31.369962+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 1"
           }
         },
         {
-          "id": "soak-1-1773392442-leased",
+          "id": "soak-1-1773625645-leased",
           "type": "task.leased",
-          "task_id": "soak-1-1773392442",
-          "trace_id": "soak-1-1773392442",
-          "timestamp": "2026-03-13T17:00:45.587684+08:00"
+          "task_id": "soak-1-1773625645",
+          "trace_id": "soak-1-1773625645",
+          "timestamp": "2026-03-16T09:47:31.48971+08:00"
         },
         {
-          "id": "soak-1-1773392442-routed",
+          "id": "soak-1-1773625645-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-1-1773392442",
-          "trace_id": "soak-1-1773392442",
-          "timestamp": "2026-03-13T17:00:45.587746+08:00",
+          "task_id": "soak-1-1773625645",
+          "trace_id": "soak-1-1773625645",
+          "timestamp": "2026-03-16T09:47:31.49001+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -122,66 +144,88 @@
           }
         },
         {
-          "id": "soak-1-1773392442-started",
+          "id": "soak-1-1773625645-started",
           "type": "task.started",
-          "task_id": "soak-1-1773392442",
-          "trace_id": "soak-1-1773392442",
-          "timestamp": "2026-03-13T17:00:45.587906+08:00",
+          "task_id": "soak-1-1773625645",
+          "trace_id": "soak-1-1773625645",
+          "timestamp": "2026-03-16T09:47:31.490401+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-1-1773392442-completed",
+          "id": "soak-1-1773625645-completed",
           "type": "task.completed",
-          "task_id": "soak-1-1773392442",
-          "trace_id": "soak-1-1773392442",
-          "timestamp": "2026-03-13T17:00:45.600043+08:00",
+          "task_id": "soak-1-1773625645",
+          "trace_id": "soak-1-1773625645",
+          "timestamp": "2026-03-16T09:47:31.504516+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:31Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-1-1773392442-completed",
+        "id": "soak-1-1773625645-completed",
         "type": "task.completed",
-        "task_id": "soak-1-1773392442",
-        "trace_id": "soak-1-1773392442",
-        "timestamp": "2026-03-13T17:00:45.600043+08:00",
+        "task_id": "soak-1-1773625645",
+        "trace_id": "soak-1-1773625645",
+        "timestamp": "2026-03-16T09:47:31.504516+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:31Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-1-1773392442",
-      "trace_id": "soak-1-1773392442"
+      "task": {
+        "id": "soak-1-1773625645",
+        "trace_id": "soak-1-1773625645",
+        "title": "soak task 1",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 1",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:31.369962+08:00",
+        "updated_at": "2026-03-16T09:47:31.504516+08:00"
+      },
+      "task_id": "soak-1-1773625645",
+      "trace_id": "soak-1-1773625645"
     },
     {
       "events": [
         {
-          "id": "soak-2-1773392442-queued",
+          "id": "soak-2-1773625645-queued",
           "type": "task.queued",
-          "task_id": "soak-2-1773392442",
-          "trace_id": "soak-2-1773392442",
-          "timestamp": "2026-03-13T17:00:45.342365+08:00",
+          "task_id": "soak-2-1773625645",
+          "trace_id": "soak-2-1773625645",
+          "timestamp": "2026-03-16T09:47:31.370114+08:00",
           "payload": {
             "executor": "local",
             "title": "soak task 2"
           }
         },
         {
-          "id": "soak-2-1773392442-leased",
+          "id": "soak-2-1773625645-leased",
           "type": "task.leased",
-          "task_id": "soak-2-1773392442",
-          "trace_id": "soak-2-1773392442",
-          "timestamp": "2026-03-13T17:00:45.387886+08:00"
+          "task_id": "soak-2-1773625645",
+          "trace_id": "soak-2-1773625645",
+          "timestamp": "2026-03-16T09:47:31.588449+08:00"
         },
         {
-          "id": "soak-2-1773392442-routed",
+          "id": "soak-2-1773625645-routed",
           "type": "scheduler.routed",
-          "task_id": "soak-2-1773392442",
-          "trace_id": "soak-2-1773392442",
-          "timestamp": "2026-03-13T17:00:45.387974+08:00",
+          "task_id": "soak-2-1773625645",
+          "trace_id": "soak-2-1773625645",
+          "timestamp": "2026-03-16T09:47:31.588514+08:00",
           "payload": {
             "executor": "local",
             "quota": {
@@ -197,39 +241,61 @@
           }
         },
         {
-          "id": "soak-2-1773392442-started",
+          "id": "soak-2-1773625645-started",
           "type": "task.started",
-          "task_id": "soak-2-1773392442",
-          "trace_id": "soak-2-1773392442",
-          "timestamp": "2026-03-13T17:00:45.388025+08:00",
+          "task_id": "soak-2-1773625645",
+          "trace_id": "soak-2-1773625645",
+          "timestamp": "2026-03-16T09:47:31.588549+08:00",
           "payload": {
-            "executor": "local"
+            "executor": "local",
+            "required_tools": null
           }
         },
         {
-          "id": "soak-2-1773392442-completed",
+          "id": "soak-2-1773625645-completed",
           "type": "task.completed",
-          "task_id": "soak-2-1773392442",
-          "trace_id": "soak-2-1773392442",
-          "timestamp": "2026-03-13T17:00:45.39999+08:00",
+          "task_id": "soak-2-1773625645",
+          "trace_id": "soak-2-1773625645",
+          "timestamp": "2026-03-16T09:47:31.600477+08:00",
           "payload": {
+            "artifacts": [
+              "stdout.log"
+            ],
+            "executor": "local",
+            "finished_at": "2026-03-16T01:47:31Z",
             "message": "local execution completed"
           }
         }
       ],
       "latest_event": {
-        "id": "soak-2-1773392442-completed",
+        "id": "soak-2-1773625645-completed",
         "type": "task.completed",
-        "task_id": "soak-2-1773392442",
-        "trace_id": "soak-2-1773392442",
-        "timestamp": "2026-03-13T17:00:45.39999+08:00",
+        "task_id": "soak-2-1773625645",
+        "trace_id": "soak-2-1773625645",
+        "timestamp": "2026-03-16T09:47:31.600477+08:00",
         "payload": {
+          "artifacts": [
+            "stdout.log"
+          ],
+          "executor": "local",
+          "finished_at": "2026-03-16T01:47:31Z",
           "message": "local execution completed"
         }
       },
       "state": "succeeded",
-      "task_id": "soak-2-1773392442",
-      "trace_id": "soak-2-1773392442"
+      "task": {
+        "id": "soak-2-1773625645",
+        "trace_id": "soak-2-1773625645",
+        "title": "soak task 2",
+        "state": "succeeded",
+        "required_executor": "local",
+        "entrypoint": "echo soak 2",
+        "execution_timeout_seconds": 180,
+        "created_at": "2026-03-16T09:47:31.370114+08:00",
+        "updated_at": "2026-03-16T09:47:31.600477+08:00"
+      },
+      "task_id": "soak-2-1773625645",
+      "trace_id": "soak-2-1773625645"
     }
   ]
 }

--- a/bigclaw-go/scripts/benchmark/run_matrix.py
+++ b/bigclaw-go/scripts/benchmark/run_matrix.py
@@ -4,6 +4,11 @@ import json
 import pathlib
 import re
 import subprocess
+import time
+
+
+READINESS_REPORT_PATH = 'docs/reports/benchmark-readiness-report.md'
+LEGACY_BENCHMARK_REPORT_PATH = 'docs/reports/benchmark-report.md'
 
 
 def parse_benchmark_stdout(stdout):
@@ -44,15 +49,158 @@ def run_soak(go_root, count, workers, timeout_seconds, report_path):
     return json.loads((go_root / report_path).read_text(encoding='utf-8'))
 
 
+def scenario_id(count, workers):
+    return f'{count}x{workers}'
+
+
+def benchmark_cases(parsed):
+    return [
+        {
+            'name': name,
+            'ns_per_op': values['ns_per_op'],
+        }
+        for name, values in parsed.items()
+    ]
+
+
+def build_report(report_path, benchmark_result, soak_results):
+    soak_artifacts = []
+    throughput_values = []
+    all_zero_failures = True
+    all_completed = True
+    for item in soak_results:
+        result = item['result']
+        throughput = result.get('throughput_tasks_per_sec', 0)
+        throughput_values.append(throughput)
+        failed = result.get('failed', 0)
+        succeeded = result.get('succeeded', 0)
+        count = item['scenario']['count']
+        workers = item['scenario']['workers']
+        zero_failures = failed == 0
+        completed = succeeded == count
+        all_zero_failures = all_zero_failures and zero_failures
+        all_completed = all_completed and completed
+        soak_artifacts.append({
+            'artifact_type': 'soak_report',
+            'scenario_id': scenario_id(count, workers),
+            'count': count,
+            'workers': workers,
+            'report_path': item['report_path'],
+            'elapsed_seconds': result.get('elapsed_seconds'),
+            'throughput_tasks_per_sec': throughput,
+            'succeeded': succeeded,
+            'failed': failed,
+            'zero_failures': zero_failures,
+            'all_tasks_completed': completed,
+        })
+
+    readiness_status = 'ready' if all_zero_failures and all_completed else 'needs-attention'
+    readiness_highlights = [
+        f"{len(benchmark_result['parsed'])} benchmark cases captured in one canonical matrix report.",
+        f"{len(soak_artifacts)} soak scenarios exported as stable scenario artifacts.",
+    ]
+    if throughput_values:
+        readiness_highlights.append(
+            'Observed soak throughput band: '
+            f"{min(throughput_values):.3f}-{max(throughput_values):.3f} tasks/s."
+        )
+    readiness_highlights.append(
+        'All soak artifacts completed without failures.'
+        if all_zero_failures and all_completed
+        else 'One or more soak artifacts recorded failures or incomplete completion.'
+    )
+
+    return {
+        'report_version': 2,
+        'generated_at': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+        'artifacts': {
+            'canonical_report_path': report_path,
+            'readiness_report_path': READINESS_REPORT_PATH,
+            'legacy_benchmark_report_path': LEGACY_BENCHMARK_REPORT_PATH,
+            'benchmark_cases': benchmark_cases(benchmark_result['parsed']),
+            'soak_reports': soak_artifacts,
+        },
+        'readiness': {
+            'status': readiness_status,
+            'all_soak_zero_failures': all_zero_failures,
+            'all_soak_completed': all_completed,
+            'highlights': readiness_highlights,
+        },
+        'benchmark': benchmark_result,
+        'soak_matrix': soak_results,
+    }
+
+
+def validate_report(report):
+    if not isinstance(report, dict):
+        raise ValueError('report must be a JSON object')
+
+    for required_key in ('report_version', 'generated_at', 'artifacts', 'readiness', 'benchmark', 'soak_matrix'):
+        if required_key not in report:
+            raise ValueError(f'missing top-level key: {required_key}')
+
+    artifacts = report['artifacts']
+    readiness = report['readiness']
+    benchmark = report['benchmark']
+    soak_matrix = report['soak_matrix']
+    if not isinstance(artifacts, dict):
+        raise ValueError('artifacts must be an object')
+    if not isinstance(readiness, dict):
+        raise ValueError('readiness must be an object')
+    if not isinstance(benchmark, dict):
+        raise ValueError('benchmark must be an object')
+    if not isinstance(soak_matrix, list):
+        raise ValueError('soak_matrix must be a list')
+
+    if 'canonical_report_path' not in artifacts:
+        raise ValueError('artifacts.canonical_report_path is required')
+    if 'benchmark_cases' not in artifacts or not isinstance(artifacts['benchmark_cases'], list):
+        raise ValueError('artifacts.benchmark_cases must be a list')
+    if 'soak_reports' not in artifacts or not isinstance(artifacts['soak_reports'], list):
+        raise ValueError('artifacts.soak_reports must be a list')
+    if len(artifacts['soak_reports']) != len(soak_matrix):
+        raise ValueError('artifacts.soak_reports must align with soak_matrix length')
+
+    parsed = benchmark.get('parsed')
+    if not isinstance(parsed, dict):
+        raise ValueError('benchmark.parsed must be an object')
+    if len(artifacts['benchmark_cases']) != len(parsed):
+        raise ValueError('artifacts.benchmark_cases must align with benchmark.parsed')
+
+    for case in artifacts['benchmark_cases']:
+        if not isinstance(case, dict) or 'name' not in case or 'ns_per_op' not in case:
+            raise ValueError('each artifacts.benchmark_cases entry must include name and ns_per_op')
+
+    for artifact, soak in zip(artifacts['soak_reports'], soak_matrix):
+        if artifact.get('report_path') != soak.get('report_path'):
+            raise ValueError('artifact report_path must match soak_matrix report_path')
+        scenario = soak.get('scenario', {})
+        expected_id = scenario_id(scenario.get('count'), scenario.get('workers'))
+        if artifact.get('scenario_id') != expected_id:
+            raise ValueError('artifact scenario_id must match soak_matrix scenario')
+
+    if readiness.get('status') not in {'ready', 'needs-attention'}:
+        raise ValueError('readiness.status must be ready or needs-attention')
+    if not isinstance(readiness.get('highlights'), list) or not readiness['highlights']:
+        raise ValueError('readiness.highlights must be a non-empty list')
+
+
 def main():
     parser = argparse.ArgumentParser(description='Run a local benchmark/soak matrix for BigClaw Go')
     parser.add_argument('--go-root', default=str(pathlib.Path(__file__).resolve().parents[2]))
     parser.add_argument('--report-path', default='docs/reports/benchmark-matrix-report.json')
     parser.add_argument('--timeout-seconds', type=int, default=180)
     parser.add_argument('--scenario', action='append', help='count:workers; default scenarios are 50:8 and 100:12')
+    parser.add_argument('--validate-report', help='Validate an existing benchmark matrix report and exit')
     args = parser.parse_args()
 
     go_root = pathlib.Path(args.go_root)
+    if args.validate_report:
+        report = json.loads((go_root / args.validate_report).read_text(encoding='utf-8'))
+        validate_report(report)
+        print(f'validated {args.validate_report}')
+        return 0
+
     scenarios = args.scenario or ['50:8', '100:12']
     benchmark_result = run_benchmarks(go_root)
 
@@ -69,13 +217,11 @@ def main():
             'result': soak_report,
         })
 
-    report = {
-        'benchmark': benchmark_result,
-        'soak_matrix': soak_results,
-    }
+    report = build_report(args.report_path, benchmark_result, soak_results)
+    validate_report(report)
     output_path = go_root / args.report_path
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding='utf-8')
+    output_path.write_text(json.dumps(report, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
     print(json.dumps(report, ensure_ascii=False, indent=2))
     return 0
 


### PR DESCRIPTION
## Summary
- normalize benchmark matrix output around a stable artifacts/readiness surface
- add report-contract validation to the benchmark runner
- refresh canonical benchmark and soak artifacts for the 50x8 and 100x12 matrix scenarios

## Validation
- python3 scripts/benchmark/run_matrix.py --scenario 50:8 --scenario 100:12 --report-path docs/reports/benchmark-matrix-report.json
- python3 scripts/benchmark/run_matrix.py --validate-report docs/reports/benchmark-matrix-report.json
- python3 -m py_compile scripts/benchmark/run_matrix.py