### PR TITLE
OPE-243 Normalize mixed workload drilldown bundle

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -74,6 +74,8 @@ python3 scripts/e2e/mixed_workload_matrix.py \
 
 This validates one control-plane instance against a more production-like mix of `local`, tool-routed `kubernetes`, tool-routed `ray`, and high-risk isolation scenarios.
 
+The command refreshes the latest summary at `docs/reports/mixed-workload-matrix-report.json` and writes a timestamped evidence bundle under `docs/reports/mixed-workload-runs/<run-id>/` with per-scenario drilldowns, a bundle README, and copied service or audit artifacts when autostart is used.
+
 ## Multi-node shared queue proof
 
 ```bash

--- a/bigclaw-go/docs/reports/mixed-workload-validation-report.md
+++ b/bigclaw-go/docs/reports/mixed-workload-validation-report.md
@@ -5,6 +5,7 @@
 - Run date: 2026-03-13
 - Command: `python3 scripts/e2e/mixed_workload_matrix.py --report-path docs/reports/mixed-workload-matrix-report.json`
 - Goal: validate more production-like routing and executor behavior inside one BigClaw Go control-plane instance.
+- Artifact contract: keep one stable latest summary plus one timestamped per-run evidence bundle with scenario drilldowns.
 
 ## Matrix
 
@@ -14,7 +15,7 @@
 - `high-risk-auto` -> expected `kubernetes`, routed `kubernetes`, final state `succeeded`
 - `required-ray` -> expected `ray`, routed `ray`, final state `succeeded`
 
-Each scenario emitted `scheduler.routed`, preserved `trace_id`, and reached `task.completed` on the expected executor path.
+Each scenario emitted `scheduler.routed`, preserved `trace_id`, and reached `task.completed` on the expected executor path. The latest JSON summary now stores normalized expectation labels and links each scenario to its own drilldown artifact instead of embedding all raw events inline.
 
 ## Meaning
 
@@ -23,3 +24,6 @@ This matrix gives the epic a same-day mixed-workload proof point rather than iso
 ## Artifact
 
 - `docs/reports/mixed-workload-matrix-report.json`
+- `docs/reports/mixed-workload-runs/<run-id>/summary.json`
+- `docs/reports/mixed-workload-runs/<run-id>/tasks/<scenario>.json`
+- `docs/reports/mixed-workload-runs/<run-id>/README.md`

--- a/bigclaw-go/scripts/e2e/mixed_workload_matrix.py
+++ b/bigclaw-go/scripts/e2e/mixed_workload_matrix.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import os
 import pathlib
+import shutil
 import socket
 import subprocess
 import sys
@@ -87,6 +88,8 @@ def default_tasks(timestamp):
         {
             'name': 'local-default',
             'expected_executor': 'local',
+            'expectation_label': 'default low/medium risk route',
+            'expectation_rule': 'unscoped low-risk tasks stay on the local executor',
             'task': {
                 'id': f'mixed-local-{timestamp}',
                 'trace_id': f'mixed-local-{timestamp}',
@@ -98,6 +101,8 @@ def default_tasks(timestamp):
         {
             'name': 'browser-auto',
             'expected_executor': 'kubernetes',
+            'expectation_label': 'browser tool route',
+            'expectation_rule': 'browser-required workloads should route to kubernetes',
             'task': {
                 'id': f'mixed-browser-{timestamp}',
                 'trace_id': f'mixed-browser-{timestamp}',
@@ -111,6 +116,8 @@ def default_tasks(timestamp):
         {
             'name': 'gpu-auto',
             'expected_executor': 'ray',
+            'expectation_label': 'gpu tool route',
+            'expectation_rule': 'gpu-required workloads should route to ray',
             'task': {
                 'id': f'mixed-gpu-{timestamp}',
                 'trace_id': f'mixed-gpu-{timestamp}',
@@ -123,6 +130,8 @@ def default_tasks(timestamp):
         {
             'name': 'high-risk-auto',
             'expected_executor': 'kubernetes',
+            'expectation_label': 'high-risk isolation route',
+            'expectation_rule': 'high-risk workloads should route to the isolated kubernetes executor',
             'task': {
                 'id': f'mixed-risk-{timestamp}',
                 'trace_id': f'mixed-risk-{timestamp}',
@@ -136,6 +145,8 @@ def default_tasks(timestamp):
         {
             'name': 'required-ray',
             'expected_executor': 'ray',
+            'expectation_label': 'explicit required executor route',
+            'expectation_rule': 'required_executor=ray must override automatic routing',
             'task': {
                 'id': f'mixed-required-ray-{timestamp}',
                 'trace_id': f'mixed-required-ray-{timestamp}',
@@ -154,10 +165,154 @@ def write_report(go_root, report_path, payload):
     output_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + '\n', encoding='utf-8')
 
 
+def copy_artifact(source, destination):
+    source_path = pathlib.Path(source)
+    if not source_path.exists():
+        return ''
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source_path, destination)
+    return str(destination)
+
+
+def relpath(path, go_root):
+    try:
+        return str(pathlib.Path(path).resolve().relative_to(pathlib.Path(go_root).resolve()))
+    except ValueError:
+        return str(path)
+
+
+def event_summary(event):
+    payload = event.get('payload') if isinstance(event.get('payload'), dict) else {}
+    return {
+        'id': event.get('id', ''),
+        'type': event.get('type', ''),
+        'timestamp': event.get('timestamp', ''),
+        'executor': payload.get('executor', ''),
+        'reason': payload.get('reason', ''),
+        'message': payload.get('message', ''),
+    }
+
+
+def build_task_result(spec, status, events):
+    routed = routed_event(events)
+    routed_executor = None
+    routed_reason = None
+    if routed and isinstance(routed.get('payload'), dict):
+        routed_executor = routed['payload'].get('executor')
+        routed_reason = routed['payload'].get('reason')
+    latest_event_type = status['latest_event']['type'] if status.get('latest_event') else ''
+    return {
+        'name': spec['name'],
+        'task_id': spec['task']['id'],
+        'trace_id': spec['task']['trace_id'],
+        'expectation': {
+            'executor': spec['expected_executor'],
+            'label': spec['expectation_label'],
+            'rule': spec['expectation_rule'],
+        },
+        'observed': {
+            'routed_executor': routed_executor,
+            'routed_reason': routed_reason,
+            'final_state': status['state'],
+            'latest_event_type': latest_event_type,
+        },
+        'event_highlights': [event_summary(event) for event in events],
+        'event_types': [event.get('type', '') for event in events],
+        'event_count': len(events),
+        'ok': status['state'] == 'succeeded' and routed_executor == spec['expected_executor'],
+        'task': spec['task'],
+        'events': events,
+    }
+
+
+def render_bundle_readme(report):
+    lines = [
+        '# Mixed Workload Validation Bundle',
+        '',
+        f"- Run ID: `{report['run_id']}`",
+        f"- Generated at: `{report['generated_at']}`",
+        f"- Status: `{'succeeded' if report['all_ok'] else 'failed'}`",
+        f"- Latest summary: `{report['latest_report_path']}`",
+        '',
+        '## Scenario drilldowns',
+        '',
+    ]
+    for task in report['tasks']:
+        lines.append(f"### {task['name']}")
+        lines.append(f"- Expectation: `{task['expectation']['label']}`")
+        lines.append(f"- Expected executor: `{task['expectation']['executor']}`")
+        lines.append(f"- Routed executor: `{task['observed']['routed_executor']}`")
+        lines.append(f"- Final state: `{task['observed']['final_state']}`")
+        lines.append(f"- Drilldown JSON: `{task['drilldown']['json_path']}`")
+        lines.append('')
+    lines.extend(
+        [
+            '## Shared artifacts',
+            '',
+            f"- Bundle summary: `{report['bundle']['summary_path']}`",
+            f"- Canonical report: `{report['latest_report_path']}`",
+        ]
+    )
+    if report['bundle'].get('audit_log_path'):
+        lines.append(f"- Audit log copy: `{report['bundle']['audit_log_path']}`")
+    if report['bundle'].get('service_log_path'):
+        lines.append(f"- Service log copy: `{report['bundle']['service_log_path']}`")
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def materialize_bundle(go_root, bundle_root, run_id, report, state_dir, log_path):
+    root = pathlib.Path(go_root)
+    bundle_dir = root / bundle_root / run_id
+    drilldown_dir = bundle_dir / 'tasks'
+    drilldown_dir.mkdir(parents=True, exist_ok=True)
+
+    for task in report['tasks']:
+        drilldown_payload = {
+            'generated_at': report['generated_at'],
+            'run_id': report['run_id'],
+            'name': task['name'],
+            'task_id': task['task_id'],
+            'trace_id': task['trace_id'],
+            'expectation': task['expectation'],
+            'observed': task['observed'],
+            'event_types': task['event_types'],
+            'task': task['task'],
+            'events': task['events'],
+            'ok': task['ok'],
+        }
+        drilldown_path = drilldown_dir / f"{task['name']}.json"
+        write_report(go_root, relpath(drilldown_path, go_root), drilldown_payload)
+        task['drilldown'] = {'json_path': relpath(drilldown_path, go_root)}
+        task.pop('task', None)
+        task.pop('events', None)
+
+    summary_path = bundle_dir / 'summary.json'
+    readme_path = bundle_dir / 'README.md'
+    report['bundle'] = {
+        'path': relpath(bundle_dir, go_root),
+        'summary_path': relpath(summary_path, go_root),
+        'readme_path': relpath(readme_path, go_root),
+    }
+    if state_dir:
+        copied_audit = copy_artifact(pathlib.Path(state_dir) / 'audit.jsonl', bundle_dir / 'audit.jsonl')
+        if copied_audit:
+            report['bundle']['audit_log_path'] = relpath(copied_audit, go_root)
+    if log_path:
+        copied_service_log = copy_artifact(log_path, bundle_dir / 'service.log')
+        if copied_service_log:
+            report['bundle']['service_log_path'] = relpath(copied_service_log, go_root)
+
+    write_report(go_root, relpath(summary_path, go_root), report)
+    readme_path.write_text(render_bundle_readme(report) + '\n', encoding='utf-8')
+    return report
+
+
 def main():
     parser = argparse.ArgumentParser(description='Run a mixed workload matrix against one BigClaw Go control plane')
     parser.add_argument('--go-root', default=str(pathlib.Path(__file__).resolve().parents[2]))
     parser.add_argument('--report-path', default='docs/reports/mixed-workload-matrix-report.json')
+    parser.add_argument('--bundle-root', default='docs/reports/mixed-workload-runs')
     parser.add_argument('--timeout-seconds', type=int, default=240)
     parser.add_argument('--autostart', action='store_true', default=True)
     args = parser.parse_args()
@@ -180,32 +335,19 @@ def main():
             http_json(base_url + '/tasks', method='POST', payload=task)
             status = wait_task(base_url, task['id'], args.timeout_seconds)
             events = fetch_events(base_url, task['id'])
-            routed = routed_event(events)
-            routed_executor = None
-            routed_reason = None
-            if routed and isinstance(routed.get('payload'), dict):
-                routed_executor = routed['payload'].get('executor')
-                routed_reason = routed['payload'].get('reason')
-            results.append({
-                'name': spec['name'],
-                'task_id': task['id'],
-                'trace_id': task['trace_id'],
-                'expected_executor': spec['expected_executor'],
-                'routed_executor': routed_executor,
-                'routed_reason': routed_reason,
-                'final_state': status['state'],
-                'latest_event_type': status['latest_event']['type'] if status.get('latest_event') else '',
-                'events': events,
-                'ok': status['state'] == 'succeeded' and routed_executor == spec['expected_executor'],
-            })
+            results.append(build_task_result(spec, status, events))
+        run_id = time.strftime('%Y%m%dT%H%M%SZ', time.gmtime())
         report = {
             'generated_at': time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+            'run_id': run_id,
             'base_url': base_url,
             'state_dir': str(state_dir) if state_dir else '',
             'service_log': str(log_path) if log_path else '',
             'all_ok': all(item['ok'] for item in results),
             'tasks': results,
         }
+        report['latest_report_path'] = args.report_path
+        report = materialize_bundle(args.go_root, args.bundle_root, run_id, report, state_dir, log_path)
         write_report(args.go_root, args.report_path, report)
         print(json.dumps(report, ensure_ascii=False, indent=2))
         return 0 if report['all_ok'] else 1

--- a/bigclaw-go/scripts/e2e/mixed_workload_matrix_test.py
+++ b/bigclaw-go/scripts/e2e/mixed_workload_matrix_test.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+import tempfile
+import unittest
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import mixed_workload_matrix
+
+
+class MixedWorkloadMatrixBundleTest(unittest.TestCase):
+    def test_materialize_bundle_writes_summary_and_task_drilldowns(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = pathlib.Path(tmpdir)
+            state_dir = root / 'state'
+            state_dir.mkdir()
+            (state_dir / 'audit.jsonl').write_text('{"event":"audit"}\n', encoding='utf-8')
+            service_log = root / 'service.log'
+            service_log.write_text('service log\n', encoding='utf-8')
+
+            report = {
+                'generated_at': '2026-03-16T02:00:00Z',
+                'run_id': '20260316T020000Z',
+                'latest_report_path': 'docs/reports/mixed-workload-matrix-report.json',
+                'all_ok': True,
+                'tasks': [
+                    {
+                        'name': 'browser-auto',
+                        'task_id': 'task-1',
+                        'trace_id': 'trace-1',
+                        'expectation': {
+                            'executor': 'kubernetes',
+                            'label': 'browser tool route',
+                            'rule': 'browser-required workloads should route to kubernetes',
+                        },
+                        'observed': {
+                            'routed_executor': 'kubernetes',
+                            'routed_reason': 'browser workloads default to kubernetes executor',
+                            'final_state': 'succeeded',
+                            'latest_event_type': 'task.completed',
+                        },
+                        'event_types': ['task.queued', 'scheduler.routed', 'task.completed'],
+                        'event_count': 3,
+                        'ok': True,
+                        'task': {'id': 'task-1', 'trace_id': 'trace-1'},
+                        'events': [{'type': 'task.completed'}],
+                    }
+                ],
+            }
+
+            materialized = mixed_workload_matrix.materialize_bundle(
+                str(root),
+                'docs/reports/mixed-workload-runs',
+                report['run_id'],
+                report,
+                str(state_dir),
+                str(service_log),
+            )
+
+            summary_path = root / 'docs/reports/mixed-workload-runs/20260316T020000Z/summary.json'
+            task_path = root / 'docs/reports/mixed-workload-runs/20260316T020000Z/tasks/browser-auto.json'
+            readme_path = root / 'docs/reports/mixed-workload-runs/20260316T020000Z/README.md'
+            self.assertTrue(summary_path.exists())
+            self.assertTrue(task_path.exists())
+            self.assertTrue(readme_path.exists())
+            self.assertEqual(
+                materialized['tasks'][0]['drilldown']['json_path'],
+                'docs/reports/mixed-workload-runs/20260316T020000Z/tasks/browser-auto.json',
+            )
+            self.assertNotIn('task', materialized['tasks'][0])
+            self.assertNotIn('events', materialized['tasks'][0])
+            self.assertEqual(
+                materialized['bundle']['audit_log_path'],
+                'docs/reports/mixed-workload-runs/20260316T020000Z/audit.jsonl',
+            )
+            self.assertEqual(
+                materialized['bundle']['service_log_path'],
+                'docs/reports/mixed-workload-runs/20260316T020000Z/service.log',
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- normalize mixed-workload validation output into a stable latest summary plus timestamped bundle layout
- emit per-scenario drilldown JSON artifacts and copy shared audit/service logs into the bundle
- document the new artifact surface and add unit coverage for bundle materialization

## Validation
- python3 -m py_compile scripts/e2e/mixed_workload_matrix.py scripts/e2e/mixed_workload_matrix_test.py
- python3 -m unittest scripts/e2e/mixed_workload_matrix_test.py
- python3 scripts/e2e/mixed_workload_matrix.py --report-path docs/reports/mixed-workload-matrix-report.json  # timed out on mixed-gpu-* waiting for Ray
