### PR TITLE
[OPE-246] BIG-PAR-059 lease recovery and takeover readiness digest refresh

### DIFF
--- a/bigclaw-go/docs/reports/lease-takeover-readiness-digest.md
+++ b/bigclaw-go/docs/reports/lease-takeover-readiness-digest.md
@@ -1,0 +1,124 @@
+# Lease And Takeover Readiness Digest
+
+## Scope
+
+This digest consolidates the current lease recovery, shared-queue coordination, and takeover-readiness evidence for `OPE-246` into one reviewer-facing report.
+
+## Current Evidence Snapshot
+
+- Lease recovery report: `docs/reports/lease-recovery-report.md`
+- Multi-node coordination report: `docs/reports/multi-node-coordination-report.md`
+- Coordination artifact: `docs/reports/multi-node-shared-queue-report.json`
+- Takeover validation contract: `docs/reports/multi-subscriber-takeover-validation-report.md`
+- Takeover validation matrix: `docs/reports/multi-subscriber-takeover-validation-report.json`
+
+## Lease Recovery Evidence
+
+- Worker leases carry explicit owner, attempt, acquisition time, and expiry metadata.
+- Worker runtime renews leases on a heartbeat interval while execution is active.
+- Expired SQLite leases become available for reacquisition by a different worker.
+- Replay and dead-letter operations clear lease ownership and return the task to an actionable state.
+- A `1k` task concurrent processing scenario now completes without duplicate consumption.
+
+## Shared-Queue Coordination Evidence
+
+- Run date: `2026-03-13`
+- Command: ``python3 scripts/e2e/multi_node_shared_queue.py --count 200 --submit-workers 8 --timeout-seconds 180 --report-path docs/reports/multi-node-shared-queue-report.json``
+- Total tasks: `200`
+- Submitted by `node-a`: `100`
+- Submitted by `node-b`: `100`
+- Completed by `node-a`: `73`
+- Completed by `node-b`: `127`
+- Cross-node completions: `99`
+- Duplicate `task.started`: `0`
+- Duplicate `task.completed`: `0`
+- Missing terminal completions: `0`
+- Overall result: `pass`
+
+## Takeover Readiness Contract
+
+- Current status: `planning-ready`
+- Source ticket: `OPE-217`
+- Generated matrix timestamp: `2026-03-15T09:19:19Z`
+- Required report sections: `scenario metadata`, `fault injection steps`, `audit assertions`, `checkpoint assertions`, `replay assertions`, `per-node audit artifacts`, `final owner and replay cursor summary`, `duplicate delivery accounting`, `open blockers and follow-up implementation hooks`
+
+The takeover matrix is planning-ready evidence. It defines the assertions and report shape reviewers should expect once shared multi-node subscriber-group takeover automation exists, but it does not claim the end-to-end fault injection is implemented today.
+
+## Scenario Assertions
+
+### `takeover-after-primary-crash`
+
+- Title: Primary subscriber crashes after processing but before checkpoint flush
+- Target gap: prove takeover replays the uncheckpointed tail without losing or double-committing progress
+- Audit assertions:
+  - Audit log shows one ownership handoff from primary to standby.
+  - Audit log records the primary interruption reason before standby completion.
+  - Audit log links takeover to the same task or trace identifier across both subscribers.
+- Checkpoint assertions:
+  - Checkpoint after takeover is greater than or equal to the last durable checkpoint from the primary.
+  - Standby checkpoint commit is attributed to the new lease owner.
+  - No checkpoint update is accepted from the crashed primary after takeover.
+- Replay assertions:
+  - Replay resumes from the last durable checkpoint, not from the last in-memory event processed by the crashed primary.
+  - At most one duplicate delivery is tolerated for the uncheckpointed tail and it is visible in the report.
+  - Replay window closes once the standby checkpoint advances past the tail.
+- Current blockers:
+  - Subscriber-group checkpoint leases are not implemented yet.
+  - No audit event schema currently records subscriber-group ownership transfers.
+
+### `lease-expiry-stale-writer-rejected`
+
+- Title: Lease expires and the former owner attempts a stale checkpoint write
+- Target gap: prove stale writers cannot move a subscriber-group checkpoint backwards after takeover
+- Audit assertions:
+  - Audit log records lease expiry for the former owner and acquisition by the standby.
+  - Audit log records the stale write rejection with both attempted and accepted owners.
+  - Audit log keeps the rejection and accepted takeover in the same ordered timeline.
+- Checkpoint assertions:
+  - Checkpoint sequence never decreases after the standby acquires ownership.
+  - Late primary acknowledgement is rejected or ignored without mutating durable checkpoint state.
+  - Accepted checkpoint owner always matches the active lease holder.
+- Replay assertions:
+  - Replay after stale write rejection starts from the accepted durable checkpoint only.
+  - No event acknowledged only by the stale writer disappears from the replay timeline.
+  - Replay report exposes any duplicate event IDs caused by the overlap window.
+- Current blockers:
+  - Checkpoint ownership is not fenced by lease metadata yet.
+  - No current API/report payload exposes stale checkpoint rejection counts.
+
+### `split-brain-dual-replay-window`
+
+- Title: Two subscribers briefly believe they can replay the same tail
+- Target gap: prove audit evidence is strong enough to diagnose duplicate replay attempts and the winning lease owner
+- Audit assertions:
+  - Combined audit timeline shows overlapping replay attempts and identifies the surviving owner.
+  - Audit evidence includes per-node file paths and normalized subscriber identities.
+  - The final report highlights whether duplicate replay attempts were observed or only simulated.
+- Checkpoint assertions:
+  - Only the winning owner can advance the durable checkpoint.
+  - Losing owner leaves durable checkpoint unchanged once fencing is applied.
+  - Report includes the exact checkpoint sequence where overlap began and ended.
+- Replay assertions:
+  - Replay output groups duplicate candidate deliveries by event ID.
+  - Final replay cursor belongs to the winning owner only.
+  - Validation reports whether overlapping replay created observable duplicate deliveries.
+- Current blockers:
+  - No subscriber-group membership or lease coordinator exists yet.
+  - Replay reports do not currently aggregate duplicate candidates by event ID across nodes.
+
+## Review Guidance
+
+- Lease recovery is directly covered by automated tests instead of only being implied by implementation.
+- The SQLite queue no longer surfaces the previous `database is locked` failure under the added concurrent reliability test.
+- The system supports the core recovery loop expected for worker interruption scenarios.
+- The repo now has a generated, reviewable scenario matrix for takeover fault injection instead of an implied TODO.
+- Existing evidence is sufficient to define the report contract, but not yet to execute the takeover scenarios end to end.
+- The next implementation slice should add lease-aware checkpoint ownership metadata and normalized audit events so the shared multi-node harness can execute this matrix directly.
+- Current shared-queue evidence proves lease expiry recovery and two-node coordination, but not durable cross-node subscriber-group takeover fencing.
+- `docs/reports/event-bus-reliability-report.md` documents subscriber-group lease concepts and current API/reporting boundaries; reviewers should treat the takeover matrix here as the stricter cross-node readiness contract.
+
+## Validation
+
+- Regenerate with `python3 scripts/e2e/lease_takeover_readiness_digest.py --write`.
+- Verify consistency with `python3 scripts/e2e/lease_takeover_readiness_digest.py --check`.
+

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -10,7 +10,7 @@
   - Supporting reports exist in `docs/reports/task-protocol-spec.md` and `docs/reports/state-machine-validation-report.md`.
 - `OPE-178`
   - Queue reliability evidence includes dead-letter replay, lease expiry recovery, API replay endpoints, and a `1k` no-duplicate-consumption test.
-  - Supporting reports exist in `docs/reports/queue-reliability-report.md` and `docs/reports/lease-recovery-report.md`.
+  - Supporting reports exist in `docs/reports/queue-reliability-report.md`, `docs/reports/lease-recovery-report.md`, and `docs/reports/lease-takeover-readiness-digest.md`.
 - `OPE-179`
   - Scheduler policy coverage includes budget guardrails, backpressure, preemptible concurrency, and tool-aware routing for GPU/browser workloads.
   - Supporting report: `docs/reports/scheduler-policy-report.md`.

--- a/bigclaw-go/scripts/e2e/lease_takeover_readiness_digest.py
+++ b/bigclaw-go/scripts/e2e/lease_takeover_readiness_digest.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import sys
+from typing import Iterable
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+LEASE_REPORT = REPO_ROOT / "docs/reports/lease-recovery-report.md"
+COORDINATION_REPORT = REPO_ROOT / "docs/reports/multi-node-coordination-report.md"
+COORDINATION_JSON = REPO_ROOT / "docs/reports/multi-node-shared-queue-report.json"
+TAKEOVER_REPORT = REPO_ROOT / "docs/reports/multi-subscriber-takeover-validation-report.md"
+TAKEOVER_JSON = REPO_ROOT / "docs/reports/multi-subscriber-takeover-validation-report.json"
+OUTPUT_PATH = REPO_ROOT / "docs/reports/lease-takeover-readiness-digest.md"
+
+
+def read_text(path: pathlib.Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def read_json(path: pathlib.Path) -> dict:
+    return json.loads(read_text(path))
+
+
+def section_lines(markdown: str, heading: str) -> list[str]:
+    lines = markdown.splitlines()
+    capture = False
+    collected: list[str] = []
+    target = f"## {heading}"
+    for line in lines:
+        if line.startswith("## "):
+            if capture:
+                break
+            capture = line.strip() == target
+            continue
+        if capture:
+            collected.append(line)
+    return collected
+
+
+def section_bullets(markdown: str, heading: str) -> list[str]:
+    bullets: list[str] = []
+    for line in section_lines(markdown, heading):
+        stripped = line.strip()
+        if stripped.startswith("- "):
+            bullets.append(stripped[2:])
+    return bullets
+
+
+def first_value(markdown: str, heading: str, label: str) -> str:
+    prefix = f"- {label}: "
+    for line in section_lines(markdown, heading):
+        stripped = line.strip()
+        if stripped.startswith(prefix):
+            return stripped[len(prefix) :].strip()
+    raise ValueError(f"missing {label!r} under {heading!r}")
+
+
+def render_bullets(items: Iterable[str]) -> list[str]:
+    return [f"- {item}" for item in items]
+
+
+def build_digest() -> str:
+    lease_markdown = read_text(LEASE_REPORT)
+    coordination_markdown = read_text(COORDINATION_REPORT)
+    coordination = read_json(COORDINATION_JSON)
+    takeover_markdown = read_text(TAKEOVER_REPORT)
+    takeover = read_json(TAKEOVER_JSON)
+
+    lease_behaviors = section_bullets(lease_markdown, "Verified Behaviors")
+    lease_result = section_bullets(lease_markdown, "Current Result")
+    takeover_result = section_bullets(takeover_markdown, "Current Result")
+    run_date = first_value(coordination_markdown, "Scope", "Run date")
+    command = first_value(coordination_markdown, "Scope", "Command")
+    required_sections = [f"`{section}`" for section in takeover["required_report_sections"]]
+
+    duplicate_started = len(coordination.get("duplicate_started_tasks", []))
+    duplicate_completed = len(coordination.get("duplicate_completed_tasks", []))
+    missing_completed = len(coordination.get("missing_completed_tasks", []))
+
+    lines: list[str] = [
+        "# Lease And Takeover Readiness Digest",
+        "",
+        "## Scope",
+        "",
+        "This digest consolidates the current lease recovery, shared-queue coordination, and takeover-readiness evidence for `OPE-246` into one reviewer-facing report.",
+        "",
+        "## Current Evidence Snapshot",
+        "",
+        f"- Lease recovery report: `docs/reports/lease-recovery-report.md`",
+        f"- Multi-node coordination report: `docs/reports/multi-node-coordination-report.md`",
+        f"- Coordination artifact: `docs/reports/multi-node-shared-queue-report.json`",
+        f"- Takeover validation contract: `docs/reports/multi-subscriber-takeover-validation-report.md`",
+        f"- Takeover validation matrix: `docs/reports/multi-subscriber-takeover-validation-report.json`",
+        "",
+        "## Lease Recovery Evidence",
+        "",
+        *render_bullets(lease_behaviors),
+        "",
+        "## Shared-Queue Coordination Evidence",
+        "",
+        f"- Run date: `{run_date}`",
+        f"- Command: `{command}`",
+        f"- Total tasks: `{coordination['count']}`",
+        f"- Submitted by `node-a`: `{coordination['submitted_by_node']['node-a']}`",
+        f"- Submitted by `node-b`: `{coordination['submitted_by_node']['node-b']}`",
+        f"- Completed by `node-a`: `{coordination['completed_by_node']['node-a']}`",
+        f"- Completed by `node-b`: `{coordination['completed_by_node']['node-b']}`",
+        f"- Cross-node completions: `{coordination['cross_node_completions']}`",
+        f"- Duplicate `task.started`: `{duplicate_started}`",
+        f"- Duplicate `task.completed`: `{duplicate_completed}`",
+        f"- Missing terminal completions: `{missing_completed}`",
+        f"- Overall result: `{'pass' if coordination.get('all_ok') else 'fail'}`",
+        "",
+        "## Takeover Readiness Contract",
+        "",
+        f"- Current status: `{takeover['status']}`",
+        f"- Source ticket: `{takeover['ticket']}`",
+        f"- Generated matrix timestamp: `{takeover['generated_at']}`",
+        f"- Required report sections: {', '.join(required_sections)}",
+        "",
+        "The takeover matrix is planning-ready evidence. It defines the assertions and report shape reviewers should expect once shared multi-node subscriber-group takeover automation exists, but it does not claim the end-to-end fault injection is implemented today.",
+        "",
+        "## Scenario Assertions",
+        "",
+    ]
+
+    for scenario in takeover["scenarios"]:
+        lines.extend(
+            [
+                f"### `{scenario['id']}`",
+                "",
+                f"- Title: {scenario['title']}",
+                f"- Target gap: {scenario['fault']['target_gap']}",
+                "- Audit assertions:",
+                *[f"  - {item}" for item in scenario["audit_assertions"]],
+                "- Checkpoint assertions:",
+                *[f"  - {item}" for item in scenario["checkpoint_assertions"]],
+                "- Replay assertions:",
+                *[f"  - {item}" for item in scenario["replay_assertions"]],
+                "- Current blockers:",
+                *[f"  - {item}" for item in scenario["implementation_blockers"]],
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## Review Guidance",
+            "",
+            *render_bullets(lease_result),
+            *render_bullets(takeover_result),
+            "- Current shared-queue evidence proves lease expiry recovery and two-node coordination, but not durable cross-node subscriber-group takeover fencing.",
+            "- `docs/reports/event-bus-reliability-report.md` documents subscriber-group lease concepts and current API/reporting boundaries; reviewers should treat the takeover matrix here as the stricter cross-node readiness contract.",
+            "",
+            "## Validation",
+            "",
+            "- Regenerate with `python3 scripts/e2e/lease_takeover_readiness_digest.py --write`.",
+            "- Verify consistency with `python3 scripts/e2e/lease_takeover_readiness_digest.py --check`.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def check_digest(expected: str) -> int:
+    current = read_text(OUTPUT_PATH).rstrip("\n")
+    expected = expected.rstrip("\n")
+    if current == expected:
+        print(f"ok: {OUTPUT_PATH.relative_to(REPO_ROOT)}")
+        return 0
+    print(
+        f"mismatch: regenerate {OUTPUT_PATH.relative_to(REPO_ROOT)} with "
+        "python3 scripts/e2e/lease_takeover_readiness_digest.py --write",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate or validate the lease/takeover readiness digest for OPE-246."
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write the generated digest to docs/reports/lease-takeover-readiness-digest.md",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Fail if the on-disk digest does not match the generated output",
+    )
+    parser.add_argument(
+        "--print",
+        dest="print_output",
+        action="store_true",
+        help="Print the generated digest to stdout",
+    )
+    args = parser.parse_args()
+
+    if not args.write and not args.check and not args.print_output:
+        parser.error("choose at least one of --write, --check, or --print")
+
+    digest = build_digest()
+    if args.write:
+        OUTPUT_PATH.write_text(digest + "\n", encoding="utf-8")
+    if args.print_output:
+        print(digest)
+    if args.check:
+        return check_digest(digest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/parallel-refill-queue.json
+++ b/docs/parallel-refill-queue.json
@@ -49,27 +49,34 @@
       "OPE-242"
     ],
     "active": [
-      "OPE-243",
-      "OPE-244"
+      "OPE-245",
+      "OPE-246"
     ],
     "standby": []
   },
   "issue_order": [
-    "OPE-243",
-    "OPE-244"
+    "OPE-245",
+    "OPE-246",
+    "OPE-247"
   ],
   "issues": [
     {
-      "identifier": "OPE-243",
-      "title": "BIG-PAR-056 mixed workload validation drilldown normalization",
-      "track": "Mixed Workload Drilldown",
+      "identifier": "OPE-245",
+      "title": "BIG-PAR-058 shadow comparison artifact bundle normalization",
+      "track": "Migration Artifact Bundle",
       "status": "In Progress"
     },
     {
-      "identifier": "OPE-244",
-      "title": "BIG-PAR-057 benchmark matrix artifact normalization",
-      "track": "Benchmark Artifact Flow",
+      "identifier": "OPE-246",
+      "title": "BIG-PAR-059 lease recovery and takeover readiness digest refresh",
+      "track": "Lease And Takeover Readiness",
       "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-247",
+      "title": "BIG-PAR-060 migration readiness review pack refresh",
+      "track": "Migration Review Pack",
+      "status": "Backlog"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a generated lease/takeover readiness digest that consolidates lease recovery, shared-queue coordination, and takeover matrix evidence
- add a deterministic script to regenerate and validate the digest against canonical report inputs
- refresh review-readiness and parallel refill queue metadata to point at the new digest and current active slices

## Validation
- python3 scripts/e2e/lease_takeover_readiness_digest.py --write
- python3 scripts/e2e/lease_takeover_readiness_digest.py --check
- python3 -m json.tool /Users/jxrt/code/symphony-workspaces/OPE-246/docs/parallel-refill-queue.json >/dev/null