### PR TITLE
OPE-247: refresh migration readiness review pack evidence

### DIFF
--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -45,7 +45,13 @@
 
 - `cd bigclaw-go && ./scripts/e2e/run_all.sh`
 - `cd bigclaw-go && go test ./...`
+- `cd bigclaw-go && python3 scripts/migration/check_review_pack.py`
 - `git push origin <branch> && git log -1 --stat`
+
+## Migration review-pack consumers
+
+- `docs/reports/migration-readiness-report.md` uses this index as the stable live-validation reference for migration closeout review.
+- `docs/reports/migration-plan-review-notes.md` uses this index to anchor rollout and rollback notes to the latest stored validation bundle.
 
 ## Recent bundles
 

--- a/bigclaw-go/docs/reports/migration-plan-review-notes.md
+++ b/bigclaw-go/docs/reports/migration-plan-review-notes.md
@@ -8,6 +8,7 @@ This note captures the review outcome for the Go rewrite boundary and migration 
 - `docs/migration.md`
 - `docs/migration-shadow.md`
 - `scripts/migration/shadow_compare.py`
+- `scripts/migration/check_review_pack.py`
 
 ## Boundary Decisions
 
@@ -19,19 +20,28 @@ This note captures the review outcome for the Go rewrite boundary and migration 
 
 1. Stand up the Go control plane alongside the incumbent implementation.
 2. Run shadow comparison and timeline diffing using `scripts/migration/shadow_compare.py`.
-3. Validate queue, scheduler, worker, Kubernetes, and Ray paths through local and live smoke reports.
-4. Roll traffic gradually by tenant, task type, or environment.
-5. Use rollback by redirecting submission back to the incumbent control plane and preserving Go reports for postmortem review.
+3. Confirm matrix coverage through `docs/reports/shadow-matrix-report.json`.
+4. Validate queue, scheduler, worker, Kubernetes, and Ray paths through the latest indexed bundle in `docs/reports/live-validation-index.md`.
+5. Run `python3 scripts/migration/check_review_pack.py` so the review-pack references and artifact paths stay in sync.
+6. Roll traffic gradually by tenant, task type, or environment once the repo-native evidence pack remains green.
+7. Use rollback by redirecting submission back to the incumbent control plane and preserving the stored review-pack artifacts for postmortem review.
 
 ## Rollback Notes
 
 - The Go validation path is isolated enough to be disabled without deleting existing queue or audit reports.
 - Live validation reports persist enough metadata (`base_url`, `state_dir`, `service_log`) to reconstruct a failed rollout attempt.
-- Shadow compare output provides a low-risk read-only verification step before cutover.
+- Shadow compare and shadow matrix output provide low-risk read-only verification steps before cutover.
+
+## Review-Pack Evidence
+
+- `docs/reports/migration-readiness-report.md` is the stable migration closeout entrypoint for reviewers.
+- `docs/reports/shadow-compare-report.json` records a matched sample run on `2026-03-13`.
+- `docs/reports/shadow-matrix-report.json` records `3/3` matched sample fixtures on `2026-03-13`.
+- `docs/reports/live-validation-index.md` records a succeeded latest bundle for run `20260314T164647Z` generated on `2026-03-14T16:46:57.671520+00:00`.
 
 ## Review Outcome
 
 - ADR boundary is internally consistent with the current code layout and runtime wiring.
-- Migration plan supports shadow validation before cutover.
+- Migration plan supports shadow validation and live smoke review before cutover.
 - Rollback path is documented and operationally simple.
-- This issue is considered ready for closure from a design-governance perspective.
+- Closeout claims should remain limited to the stored repo-native evidence in the migration review pack.

--- a/bigclaw-go/docs/reports/migration-readiness-report.md
+++ b/bigclaw-go/docs/reports/migration-readiness-report.md
@@ -2,30 +2,49 @@
 
 ## Scope
 
-This report summarizes the current migration-readiness evidence for `OPE-185` / `BIG-GO-010`.
+This report summarizes the current repo-native migration review pack for `OPE-185` / `BIG-GO-010`.
+It keeps the latest shadow-comparison evidence, live-validation bundle, and review notes in one stable reviewer-facing surface.
 
-## Implemented surfaces
+## Stable review pack
 
-- Shadow comparison for one task via `scripts/migration/shadow_compare.py`
-- Shadow comparison matrix across multiple task fixtures via `scripts/migration/shadow_matrix.py`
-- Shared `trace_id` correlation across primary/shadow runs
-- JSON reports for single-run and matrix outcomes
+- Shadow comparison sample generated via `scripts/migration/shadow_compare.py` and persisted in `docs/reports/shadow-compare-report.json`
+- Shadow comparison matrix generated via `scripts/migration/shadow_matrix.py` and persisted in `docs/reports/shadow-matrix-report.json`
+- Latest live-validation bundle indexed in `docs/reports/live-validation-index.md`
+- Migration closeout notes captured in `docs/reports/migration-plan-review-notes.md`
 
-## Evidence
+## Current evidence snapshot
 
-- `docs/migration.md`
-- `docs/migration-shadow.md`
-- `scripts/migration/shadow_compare.py`
-- `scripts/migration/shadow_matrix.py`
-- `docs/reports/shadow-compare-report.json`
-- `docs/reports/shadow-matrix-report.json`
+- Shadow compare sample: `docs/reports/shadow-compare-report.json`
+  - Sample trace: `shadow-compare-sample`
+  - Terminal states: primary `succeeded`, shadow `succeeded`
+  - Event-type sequence match: `true`
+  - Sample event window: `2026-03-13T15:53:21.384193+08:00` to `2026-03-13T15:53:21.403765+08:00`
+- Shadow matrix bundle: `docs/reports/shadow-matrix-report.json`
+  - Matrix size: `3` sample task fixtures
+  - Matched results: `3`
+  - Mismatched results: `0`
+  - Latest matrix event date: `2026-03-13`
+- Live validation index: `docs/reports/live-validation-index.md`
+  - Latest run id: `20260314T164647Z`
+  - Generated at: `2026-03-14T16:46:57.671520+00:00`
+  - Latest bundle: `docs/reports/live-validation-runs/20260314T164647Z`
+  - Status: `succeeded`
 
-## Validation target
+## Review-pack links
 
-- Matrix should report matched terminal states and matched event-type sequences for all sample tasks before a wider cutover.
+- Migration plan: `docs/migration.md`
+- Shadow-comparison instructions: `docs/migration-shadow.md`
+- Migration review notes: `docs/reports/migration-plan-review-notes.md`
+- Review readiness matrix entry: `docs/reports/review-readiness.md`
 
-## Remaining gaps
+## Validation posture
 
-- Still no live legacy-vs-Go production traffic comparison.
-- No tenant-scoped automated rollback trigger yet.
-- Matrix currently uses local fixture tasks rather than a production issue/task corpus.
+- Shadow evidence currently demonstrates matched terminal states and matched event-type sequences across the stored sample fixtures.
+- Live validation currently demonstrates succeeded local, Kubernetes, and Ray smoke runs in the latest indexed bundle.
+- The review pack is suitable for migration closeout review because it links concrete repo-native artifacts rather than relying on ad-hoc rollout prose.
+
+## Remaining rollout limits
+
+- The shadow reports compare controlled sample tasks, not mirrored production traffic.
+- The current evidence pack does not prove tenant-scoped automatic rollback behavior.
+- Rollout approval should remain gated on the stored shadow and live-validation artifacts above rather than on aspirational cutover claims.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -28,8 +28,8 @@
   - Audit and debug surfaces include trace summary endpoints, trace timeline lookup, worker lifecycle snapshots, and `trace_count` metrics visibility.
   - Supporting report: `docs/reports/go-control-plane-observability-report.md`.
 - `OPE-185`
-  - Migration evidence includes a shadow matrix across multiple sample tasks with matched terminal states and matched event sequences.
-  - Supporting report: `docs/reports/migration-readiness-report.md`.
+  - Migration evidence includes a stable review pack that links matched shadow sample output, a `3/3` matched shadow matrix, current migration review notes, and the latest live-validation bundle index.
+  - Supporting reports: `docs/reports/migration-readiness-report.md`, `docs/reports/migration-plan-review-notes.md`, and `docs/reports/live-validation-index.md`.
 - `OPE-186`
   - Benchmark evidence includes a repeatable matrix runner plus `50x8`, `100x12`, `1000x24`, and `2000x24` soak runs with zero failures.
   - Supporting reports: `docs/reports/benchmark-readiness-report.md`, `docs/reports/benchmark-matrix-report.json`, and `docs/reports/long-duration-soak-report.md`.

--- a/bigclaw-go/scripts/migration/check_review_pack.py
+++ b/bigclaw-go/scripts/migration/check_review_pack.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+import json
+import pathlib
+import sys
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def require(condition, message, errors):
+    if not condition:
+        errors.append(message)
+
+
+def read_text(path):
+    return path.read_text(encoding="utf-8")
+
+
+def main():
+    errors = []
+
+    readiness_report = ROOT / "docs/reports/migration-readiness-report.md"
+    review_notes = ROOT / "docs/reports/migration-plan-review-notes.md"
+    readiness_matrix = ROOT / "docs/reports/review-readiness.md"
+    live_index = ROOT / "docs/reports/live-validation-index.md"
+    live_manifest = ROOT / "docs/reports/live-validation-index.json"
+    shadow_compare = ROOT / "docs/reports/shadow-compare-report.json"
+    shadow_matrix = ROOT / "docs/reports/shadow-matrix-report.json"
+
+    for path in [
+        readiness_report,
+        review_notes,
+        readiness_matrix,
+        live_index,
+        live_manifest,
+        shadow_compare,
+        shadow_matrix,
+    ]:
+        require(path.exists(), f"missing required artifact: {path.relative_to(ROOT)}", errors)
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    readiness_text = read_text(readiness_report)
+    review_notes_text = read_text(review_notes)
+    readiness_matrix_text = read_text(readiness_matrix)
+    live_index_text = read_text(live_index)
+    live_manifest_payload = json.loads(read_text(live_manifest))
+    shadow_compare_payload = json.loads(read_text(shadow_compare))
+    shadow_matrix_payload = json.loads(read_text(shadow_matrix))
+
+    require("docs/reports/shadow-compare-report.json" in readiness_text, "migration readiness report must reference shadow compare report", errors)
+    require("docs/reports/shadow-matrix-report.json" in readiness_text, "migration readiness report must reference shadow matrix report", errors)
+    require("docs/reports/live-validation-index.md" in readiness_text, "migration readiness report must reference live validation index", errors)
+    require("docs/reports/migration-plan-review-notes.md" in readiness_text, "migration readiness report must reference migration review notes", errors)
+
+    require("docs/reports/migration-readiness-report.md" in review_notes_text, "migration review notes must reference migration readiness report", errors)
+    require("docs/reports/live-validation-index.md" in review_notes_text, "migration review notes must reference live validation index", errors)
+    require("docs/reports/shadow-matrix-report.json" in review_notes_text, "migration review notes must reference shadow matrix report", errors)
+
+    require("docs/reports/migration-plan-review-notes.md" in readiness_matrix_text, "review readiness matrix must reference migration plan review notes", errors)
+    require("docs/reports/live-validation-index.md" in readiness_matrix_text, "review readiness matrix must reference live validation index", errors)
+    require("docs/reports/migration-readiness-report.md" in readiness_matrix_text, "review readiness matrix must reference migration readiness report", errors)
+    require("docs/reports/migration-readiness-report.md" in live_index_text, "live validation index must link back to migration readiness report", errors)
+
+    require(shadow_compare_payload.get("diff", {}).get("state_equal") is True, "shadow compare report must show equal terminal state", errors)
+    require(shadow_compare_payload.get("diff", {}).get("event_types_equal") is True, "shadow compare report must show equal event type sequence", errors)
+    require(shadow_matrix_payload.get("matched") == shadow_matrix_payload.get("total"), "shadow matrix report must be fully matched", errors)
+
+    latest = live_manifest_payload.get("latest", {})
+    require(latest.get("status") == "succeeded", "live validation manifest latest status must be succeeded", errors)
+    bundle_path = latest.get("bundle_path")
+    require(bool(bundle_path), "live validation manifest must include latest bundle path", errors)
+    if bundle_path:
+        require((ROOT / bundle_path).exists(), f"live validation bundle path missing on disk: {bundle_path}", errors)
+
+    for error in errors:
+        print(error, file=sys.stderr)
+    if errors:
+        return 1
+
+    print("migration review pack references and evidence are consistent")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- refresh the migration readiness report to point at the current shadow and live-validation artifacts with explicit evidence dates
- tighten migration review notes and readiness matrix wording around repo-native review-pack evidence
- add a lightweight migration review-pack consistency check script and wire it into the workflow closeout commands

## Validation
- cd bigclaw-go && python3 scripts/migration/check_review_pack.py
- git rev-parse HEAD
- git ls-remote origin refs/heads/dcjcloud/ope-247-big-par-060-migration-readiness-review-pack-refresh
- git log -1 --stat