### PR TITLE
OPE-250 refresh v5 issue coverage and sync reports

### DIFF
--- a/bigclaw-go/docs/reports/epic-closure-readiness-report.md
+++ b/bigclaw-go/docs/reports/epic-closure-readiness-report.md
@@ -34,6 +34,14 @@ The three previously open closure items are now covered by fresh same-day eviden
 
 This does not magically turn the system into production-grade distributed infrastructure, but it does make the current rewrite epic complete enough to close in Linear. Remaining work is now follow-up hardening, not missing baseline evidence.
 
+## Follow-On Reporting Refresh
+
+- `2026-03-16` follow-on reporting work now treats this closure report as the baseline proof for `OPE-187`, not the complete project-sync surface for the newer distributed slices.
+- Recently completed refresh slices `OPE-243`, `OPE-244`, `OPE-245`, and `OPE-246` normalized mixed-workload, benchmark, shadow, and lease/takeover evidence so later closeout notes can cite stable artifact paths.
+- Active refresh slices are `OPE-247` for migration review-pack alignment and `OPE-250` for issue-coverage plus project-sync alignment.
+- The next standby slice is `OPE-251`, which will consolidate epic concurrency, queue, and event-bus closeout reporting after the active reporting work lands.
+- Project-level state and active-slice tracking now live in `docs/reports/linear-project-sync-summary.md`.
+
 ## Artifacts
 
 - `docs/reports/benchmark-readiness-report.md`

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -1,10 +1,11 @@
-# BigClaw Go MVP Issue Coverage
+# BigClaw Go Issue Coverage
 
 ## Summary
 
-This document maps the current local MVP implementation to the Linear rewrite issues `OPE-176` through `OPE-186`.
+This document maps the current repo to the closed rewrite baseline plus the
+active distributed-platform follow-on work in Linear.
 
-## Coverage
+## Rewrite Baseline Coverage
 
 - `OPE-176` / `BIG-GO-001`
   - Covered by `docs/adr/0001-go-rewrite-control-plane.md` and `docs/reports/migration-plan-review-notes.md`
@@ -29,6 +30,25 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - `OPE-186` / `BIG-GO-011`
   - Covered by `internal/queue/benchmark_test.go`, `internal/scheduler/benchmark_test.go`, `docs/benchmark-plan.md`, `docs/reports/benchmark-report.md`, `docs/reports/benchmark-readiness-report.md`, `docs/reports/benchmark-matrix-report.json`, `docs/reports/long-duration-soak-report.md`, `docs/reports/soak-local-report.json`, `docs/reports/soak-local-50x8.json`, `docs/reports/soak-local-100x12.json`, `docs/reports/soak-local-1000x24.json`, `docs/reports/soak-local-2000x24.json`, `docs/reports/live-validation-summary.json`, `scripts/benchmark/run_suite.sh`, `scripts/benchmark/run_matrix.py`, `scripts/benchmark/soak_local.py`, and `scripts/e2e/run_all.sh`
 
+## Distributed Platform Coverage Snapshot
+
+- `OPE-187` / `BIG-EPIC-21`
+  - Covered by `docs/reports/epic-closure-readiness-report.md`, `docs/reports/review-readiness.md`, and `docs/reports/linear-project-sync-summary.md`
+- `Control Plane & Worker Pool` milestone
+  - Closed milestone coverage for `OPE-188`, `OPE-191`, `OPE-192`, and `OPE-242` is grounded in `internal/api/distributed.go`, `internal/api/metrics.go`, `internal/control/controller.go`, `internal/scheduler/scheduler.go`, `internal/executor/kubernetes.go`, `internal/executor/ray.go`, `docs/reports/go-control-plane-observability-report.md`, and `docs/reports/review-readiness.md`
+- `Shared Queue & Coordination` milestone
+  - Closed milestone coverage for `OPE-189`, `OPE-203` through `OPE-205`, `OPE-210`, `OPE-217`, `OPE-228` through `OPE-231`, `OPE-235`, and `OPE-246` is grounded in `internal/queue/sqlite_queue.go`, `internal/queue/sqlite_queue_test.go`, `internal/events/checkpoints.go`, `internal/events/subscriber_leases.go`, `internal/events/subscriber_leases_test.go`, `docs/reports/queue-reliability-report.md`, `docs/reports/lease-recovery-report.md`, `docs/reports/multi-node-coordination-report.md`, and `docs/reports/multi-subscriber-takeover-validation-report.md`
+- `Parallel Validation Matrix` milestone
+  - Closed milestone coverage for `OPE-190`, `OPE-211`, `OPE-237`, `OPE-239`, and `OPE-243` is grounded in `docs/e2e-validation.md`, `scripts/e2e/run_all.sh`, `scripts/e2e/export_validation_bundle.py`, `scripts/e2e/mixed_workload_matrix.py`, `docs/reports/live-validation-index.md`, `docs/reports/live-validation-summary.json`, `docs/reports/broker-failover-fault-injection-validation-pack.md`, and `docs/reports/mixed-workload-validation-report.md`
+- `Distributed Diagnostics & Rollout` milestone
+  - Completed slice coverage for `OPE-233`, `OPE-234`, `OPE-236`, `OPE-238` through `OPE-245`, and `OPE-246` is grounded in `docs/reports/review-readiness.md`, `docs/reports/replicated-event-log-durability-rollout-contract.md`, `docs/reports/benchmark-readiness-report.md`, `docs/reports/epic-closure-readiness-report.md`, `docs/reports/migration-readiness-report.md`, `docs/reports/shadow-compare-report.json`, and `docs/reports/shadow-matrix-report.json`
+- `OPE-247` / `BIG-PAR-060`
+  - Active follow-on migration review work is anchored to `docs/reports/migration-readiness-report.md`, `docs/reports/live-validation-index.md`, `docs/reports/live-validation-summary.json`, `docs/reports/shadow-compare-report.json`, and `docs/reports/shadow-matrix-report.json`
+- `OPE-250` / `BIG-PAR-061`
+  - Active issue-coverage and project-sync refresh work is anchored to `docs/reports/issue-coverage.md`, `docs/reports/linear-project-sync-summary.md`, and `docs/reports/epic-closure-readiness-report.md`
+- `OPE-251` / `BIG-PAR-062`
+  - Next standby closeout refresh remains queued behind the active reporting slices and will draw from `docs/reports/epic-concurrency-readiness-report.md`, `docs/reports/queue-reliability-report.md`, `docs/reports/event-bus-reliability-report.md`, and `docs/reports/review-readiness.md`
+
 ## Remaining Gaps Before Honest Closure
 
 - Real `Kubernetes` API integration path is implemented and has passed live smoke validation against `kind-ray-local` using `KUBECONFIG=/Users/jxrt/.kube/ray-local-config`.
@@ -38,4 +58,4 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
-- Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.
+- Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `../../../docs/openclaw-parallel-gap-analysis.md`.

--- a/bigclaw-go/docs/reports/linear-project-sync-summary.md
+++ b/bigclaw-go/docs/reports/linear-project-sync-summary.md
@@ -1,5 +1,40 @@
 # Linear Project Sync Summary
 
+## BigClaw v5.0 Parallel Distributed Platform
+
+- Project status: `Planned`
+- Start date: `2026-03-14`
+- Project target date: `2026-04-11`
+- Linear project id: `20b45595-d6ac-47c3-8896-7f6fe77ccf88`
+- Parent epic: `OPE-187`
+- Scope summary: the distributed-platform implementation baseline is landed, three milestones are fully closed, and the remaining open work is concentrated in rollout/report refresh slices for the final milestone.
+
+### Milestones
+
+- `Control Plane & Worker Pool`: `100%`, target `2026-03-21`
+- `Parallel Validation Matrix`: `100%`, target `2026-04-04`
+- `Shared Queue & Coordination`: `100%`, target `2026-03-28`
+- `Distributed Diagnostics & Rollout`: `81%`, target `2026-04-11`
+
+### Current slices
+
+- `In Progress`: `OPE-247` / `BIG-PAR-060` migration readiness review pack refresh
+- `In Progress`: `OPE-250` / `BIG-PAR-061` issue coverage and project sync evidence refresh
+- `Backlog`: `OPE-251` / `BIG-PAR-062` epic concurrency and reliability closeout refresh
+
+### Recent completed slices
+
+- `OPE-243` normalized mixed-workload validation drilldowns around `docs/reports/mixed-workload-validation-report.md`
+- `OPE-244` normalized benchmark matrix and soak evidence around `docs/reports/benchmark-readiness-report.md`
+- `OPE-245` normalized shadow comparison artifacts around `docs/reports/shadow-compare-report.json` and `docs/reports/shadow-matrix-report.json`
+- `OPE-246` refreshed lease/takeover readiness evidence around `docs/reports/lease-recovery-report.md`, `docs/reports/multi-node-coordination-report.md`, and `docs/reports/multi-subscriber-takeover-validation-report.md`
+
+### Notes
+
+- `OPE-187` is closed in Linear, but the v5.0 project remains open because milestone-level follow-on reporting slices are still active.
+- The repo-side refill order is tracked in `../../../docs/parallel-refill-queue.json` and `../../../docs/parallel-refill-queue.md`; it now matches the current active pair plus the next standby slice.
+- `docs/reports/issue-coverage.md` is the repo-native coverage map for the rewrite baseline plus the current distributed follow-on pack.
+
 ## BigClaw v4.0 Execution Pack
 
 - Project status: `Completed`
@@ -82,4 +117,3 @@
 
 - All v1.0 issues remain `Done` after milestone backfill.
 - A project update has been posted in Linear to capture the completed historical structure.
-

--- a/bigclaw-go/scripts/docs/validate_report_links.py
+++ b/bigclaw-go/scripts/docs/validate_report_links.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Validate that repo-relative file references in selected report docs exist."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REFERENCE_RE = re.compile(
+    r"`((?:(?:(?:\.\./)+)?(?:cmd|docs|examples|internal|scripts)/[^`\n*]+?\.(?:go|json|md|py|sh|txt|yaml|yml)))`"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate repo-relative file references in markdown reports."
+    )
+    parser.add_argument(
+        "documents",
+        nargs="*",
+        default=[
+            "docs/reports/issue-coverage.md",
+            "docs/reports/linear-project-sync-summary.md",
+            "docs/reports/epic-closure-readiness-report.md",
+        ],
+        help="Markdown documents relative to the bigclaw-go repo root.",
+    )
+    return parser.parse_args()
+
+
+def collect_references(document: Path) -> list[str]:
+    text = document.read_text(encoding="utf-8")
+    return sorted(set(REFERENCE_RE.findall(text)))
+
+
+def resolve_reference(repo_root: Path, document: Path, reference: str) -> Path:
+    if reference.startswith("../"):
+        return (document.parent / reference).resolve()
+    return repo_root / reference
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = Path(__file__).resolve().parents[2]
+    failures: list[str] = []
+
+    for relative_document in args.documents:
+        document = repo_root / relative_document
+        if not document.is_file():
+            failures.append(f"{relative_document}: document not found")
+            continue
+
+        references = collect_references(document)
+        missing = [
+            reference
+            for reference in references
+            if not resolve_reference(repo_root, document, reference).exists()
+        ]
+        if missing:
+            failures.extend(f"{relative_document}: missing {reference}" for reference in missing)
+            continue
+
+        print(f"{relative_document}: {len(references)} references OK")
+
+    if failures:
+        for failure in failures:
+            print(failure, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/parallel-refill-queue.json
+++ b/docs/parallel-refill-queue.json
@@ -17,69 +17,41 @@
   },
   "recent_batches": {
     "completed": [
-      "OPE-212",
-      "OPE-213",
-      "OPE-214",
-      "OPE-215",
-      "OPE-216",
-      "OPE-217",
-      "OPE-219",
-      "OPE-220",
-      "OPE-221",
-      "OPE-222",
-      "OPE-223",
-      "OPE-224",
-      "OPE-225",
-      "OPE-226",
-      "OPE-227",
-      "OPE-228",
-      "OPE-229",
-      "OPE-230",
-      "OPE-231",
-      "OPE-232",
-      "OPE-233",
-      "OPE-234",
-      "OPE-235",
-      "OPE-236",
-      "OPE-237",
-      "OPE-238",
-      "OPE-239",
-      "OPE-240",
-      "OPE-241",
-      "OPE-242",
       "OPE-243",
-      "OPE-244"
-    ],
-    "active": [
+      "OPE-244",
       "OPE-245",
       "OPE-246"
     ],
+    "active": [
+      "OPE-247",
+      "OPE-250"
+    ],
     "standby": [
-      "OPE-247"
+      "OPE-251"
     ]
   },
   "issue_order": [
-    "OPE-245",
-    "OPE-246",
-    "OPE-247"
+    "OPE-247",
+    "OPE-250",
+    "OPE-251"
   ],
   "issues": [
-    {
-      "identifier": "OPE-245",
-      "title": "BIG-PAR-058 shadow comparison artifact bundle normalization",
-      "track": "Shadow Artifact Bundle",
-      "status": "In Progress"
-    },
-    {
-      "identifier": "OPE-246",
-      "title": "BIG-PAR-059 lease recovery and takeover readiness digest refresh",
-      "track": "Lease Recovery Digest",
-      "status": "In Progress"
-    },
     {
       "identifier": "OPE-247",
       "title": "BIG-PAR-060 migration readiness review pack refresh",
       "track": "Migration Review Pack",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-250",
+      "title": "BIG-PAR-061 issue coverage and project sync evidence refresh",
+      "track": "Coverage And Sync Refresh",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-251",
+      "title": "BIG-PAR-062 epic concurrency and reliability closeout refresh",
+      "track": "Epic Closeout Refresh",
       "status": "Backlog"
     }
   ]

--- a/docs/parallel-refill-queue.md
+++ b/docs/parallel-refill-queue.md
@@ -24,46 +24,18 @@ manual operator can refill the next parallel-safe issues in a stable order.
 ## Recent batches
 
 - Completed:
-  - `OPE-212` — replay checkpoint compaction / retention semantics
-  - `OPE-213` — durability capability matrix / backend config validation
-  - `OPE-214` — event-log backend capability probe / control-center exposure
-  - `OPE-215` — consumer dedup ledger backend contract
-  - `OPE-216` — replay cursor expiry / truncated history fallback semantics
-  - `OPE-217` — multi-subscriber takeover fault injection / audit evidence
-  - `OPE-219` — auto-sync failure telemetry / PR freshness audit
-  - `OPE-220` — retention watermark / replay horizon surface
-  - `OPE-221` — durable consumer dedup store bootstrap
-  - `OPE-222` — replicated event-log durability rollout contract
-  - `OPE-223` — durable replay retention backend bootstrap
-  - `OPE-224` — broker-backed event-log adapter bootstrap
-  - `OPE-225` — Kubernetes / Ray / shared-queue validation bundle refresh
-  - `OPE-226` — expired replay checkpoint diagnostics / reset surface
-  - `OPE-227` — broker adapter dry-run capability probe
-  - `OPE-228` — checkpoint reset audit trail and operator history
-  - `OPE-229` — checkpoint reset review surface in debug / control-plane payloads
-  - `OPE-230` — checkpoint reset validation bundle refresh
-  - `OPE-231` — checkpoint reset distributed report / export integration
-  - `OPE-232` — checkpoint reset rollout evidence / review-pack refresh
-  - `OPE-233` — Ray executor live readiness rollup in distributed diagnostics
-  - `OPE-234` — replicated event-log rollout readiness summary
-  - `OPE-235` — shared-queue takeover evidence bundle refresh
-  - `OPE-236` — kubernetes executor live readiness rollup in distributed diagnostics
-  - `OPE-237` — normalize live-validation evidence bundle index
-  - `OPE-238` — distributed rollout review-pack refresh
-  - `OPE-239` — broker failover evidence bundle export normalization
-  - `OPE-240` — durability backend comparison readiness report refresh
-  - `OPE-241` — distributed closure readiness scorecard refresh
-  - `OPE-242` — control-center takeover history digest
   - `OPE-243` — mixed workload validation drilldown normalization
   - `OPE-244` — benchmark matrix artifact normalization
-- Active:
   - `OPE-245` — shadow comparison artifact bundle normalization
   - `OPE-246` — lease recovery and takeover readiness digest refresh
-- Standby:
+- Active:
   - `OPE-247` — migration readiness review pack refresh
+  - `OPE-250` — issue coverage and project sync evidence refresh
+- Standby:
+  - `OPE-251` — epic concurrency and reliability closeout refresh
 
 ## Canonical refill order
 
-1. `OPE-245`
-2. `OPE-246`
-3. `OPE-247`
+1. `OPE-247`
+2. `OPE-250`
+3. `OPE-251`


### PR DESCRIPTION
## Summary
- refresh the BigClaw Go issue coverage report with the v5 distributed-platform coverage snapshot
- refresh the Linear project sync summary and epic closure report with current active, completed, and standby slices
- update the canonical refill queue docs and add a deterministic report-link validator

## Validation
- python3 bigclaw-go/scripts/docs/validate_report_links.py