### PR TITLE
Refresh epic concurrency and reliability closeout pack

### DIFF
--- a/bigclaw-go/docs/reports/epic-concurrency-readiness-report.md
+++ b/bigclaw-go/docs/reports/epic-concurrency-readiness-report.md
@@ -2,21 +2,46 @@
 
 ## Scope
 
-- Run date: 2026-03-13
-- Command: `python3 scripts/benchmark/soak_local.py --autostart --count 1000 --workers 24 --timeout-seconds 300 --report-path docs/reports/soak-local-1000x24.json`
-- Goal: reduce the remaining `OPE-175` closure gap around `1k+` local concurrency evidence.
+- Refresh date: `2026-03-16`
+- Goal: summarize the latest concurrency-ready proof points from the distributed closeout slices in one reviewer-facing pack.
 
-## Result
+## Local Concurrency Evidence
 
-- `1000 tasks x 24 workers`: `104.091s` elapsed
-- Throughput: `9.607 tasks/s`
-- Terminal outcome: `1000 succeeded`, `0 failed`
-- Sample traces preserved `trace_id` and reached `task.completed` after `scheduler.routed`
+- `1000 tasks x 24 workers`: `104.091s`, `1000/1000 succeeded`, `0 failed`
+- `2000 tasks x 24 workers`: `219.167s`, `2000/2000 succeeded`, `0 failed`
+- Supporting reports: `docs/reports/epic-closure-readiness-report.md` and `docs/reports/long-duration-soak-report.md`
+
+## Mixed Executor Evidence
+
+- One control-plane instance completed a mixed workload matrix covering `local`, `kubernetes`, and `ray`.
+- Automatic routing for `browser`, `gpu`, and `high` risk requests matched the expected executor on every scenario.
+- Supporting report: `docs/reports/mixed-workload-validation-report.md`
+
+## Multi-Node Coordination Evidence
+
+- Two `bigclawd` processes shared one SQLite queue and completed `200` tasks with `0` duplicate starts and `0` duplicate completions.
+- Cross-node completions reached `99`, which shows queue concurrency evidence is not limited to one process-local worker pool.
+- Supporting reports: `docs/reports/multi-node-coordination-report.md` and `docs/reports/queue-reliability-report.md`
 
 ## Meaning
 
-This run provides a concrete local `1k+` burst proof point for the current Go control plane. It materially improves epic readiness, but it does not replace broader closure requirements such as production-like executor mixes, multi-node coordination, or longer-duration certification.
+The concurrency closeout surface is now anchored to the latest repo-native evidence instead of a single burst run. The current pack covers:
 
-## Artifact
+- local burst and longer soak capacity
+- mixed executor routing under one control plane
+- shared-queue coordination across two nodes
 
+That is enough to review the current rewrite as concurrency-ready for the implemented local and shared-SQLite topology. It is not evidence for production-scale cluster durability, broker-backed replay coordination, or long-lived multi-node control-plane leadership.
+
+## Artifacts
+
+- `docs/reports/epic-closure-readiness-report.md`
+- `docs/reports/long-duration-soak-report.md`
+- `docs/reports/mixed-workload-validation-report.md`
+- `docs/reports/multi-node-coordination-report.md`
+- `docs/reports/queue-reliability-report.md`
 - `docs/reports/soak-local-1000x24.json`
+- `docs/reports/soak-local-2000x24.json`
+- `docs/reports/mixed-workload-matrix-report.json`
+- `docs/reports/multi-node-shared-queue-report.json`
+- `docs/reports/live-validation-summary.json`

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -2,9 +2,9 @@
 
 ## Scope
 
-This report summarizes the current event bus reliability evidence and the next replicated-durability integration plan for `OPE-183` / `BIG-GO-008` and `OPE-206`.
+This report summarizes the current event-bus reliability evidence and the replicated-durability rollout posture for `OPE-183` / `BIG-GO-008` plus the follow-on distributed slices through `OPE-246`.
 
-## Implemented surfaces
+## Implemented Surfaces
 
 - In-process publish/subscribe bus with replay history
 - Recorder sink integration for audit/debug persistence
@@ -23,7 +23,23 @@ This report summarizes the current event bus reliability evidence and the next r
 - Event backend capability and config-validation contract via `internal/events/backend_contract.go`
 - Event-log backend capability probe surfaced through control/debug responses before replay-oriented dispatch
 
-## Validated behaviors
+## Current Evidence Pack
+
+- Automated coverage:
+  - `internal/events/bus_test.go`
+  - `internal/events/delivery_test.go`
+  - `internal/events/dedup_ledger_test.go`
+  - `internal/events/subscriber_leases_test.go`
+  - `internal/events/backend_contract_test.go`
+  - `internal/api/server_test.go`
+- Supporting closeout reports:
+  - `docs/reports/live-validation-index.md`
+  - `docs/reports/replay-retention-semantics-report.md`
+  - `docs/reports/multi-subscriber-takeover-validation-report.md`
+  - `docs/reports/replicated-event-log-durability-rollout-contract.md`
+  - `docs/reports/broker-failover-fault-injection-validation-pack.md`
+
+## Validated Behaviors
 
 - Published events are retained in replay history.
 - New subscribers can request replayed events before switching to live events.
@@ -31,128 +47,32 @@ This report summarizes the current event bus reliability evidence and the next r
 - SSE streaming can deliver live events.
 - SSE replay can filter to one trace without leaking unrelated events.
 - Replay and live deliveries preserve the original event id while exposing an explicit delivery mode and stable downstream idempotency key.
-- Subscriber-group checkpoint commits are fenced by lease token + epoch, so stale writers cannot advance ownership after takeover.
+- Subscriber-group checkpoint commits are fenced by lease token plus epoch, so stale writers cannot advance ownership after takeover.
 - Checkpoint offsets remain monotonic within a subscriber group and reject rollback writes.
 - Operators can inspect backend capability support before dispatching replay-oriented operations.
-- Operator-facing capability payloads now distinguish durable consumer dedup support from process-local replay/checkpoint support.
+- Operator-facing capability payloads distinguish durable consumer dedup support from process-local replay/checkpoint support.
 
-## Evidence
+## Rollout Posture
 
-- `internal/events/bus.go`
-- `internal/events/bus_test.go`
-- `internal/events/capabilities.go`
-- `internal/events/durability.go`
-- `internal/events/delivery.go`
-- `internal/events/delivery_test.go`
-- `internal/domain/consumer_dedup.go`
-- `internal/domain/consumer_dedup_test.go`
-- `internal/events/webhook.go`
-- `internal/events/webhook_test.go`
-- `internal/events/recorder_sink.go`
-- `internal/events/subscriber_leases.go`
-- `internal/events/subscriber_leases_test.go`
-- `internal/events/backend_contract.go`
-- `internal/events/backend_contract_test.go`
-- `internal/events/dedup_ledger.go`
-- `internal/events/dedup_ledger_test.go`
-- `internal/events/sqlite_log.go`
-- `internal/api/server.go`
-- `internal/api/server_test.go`
-- `cmd/bigclawd/main.go`
-- `internal/config/config.go`
+- Local event distribution is implemented and test-backed today.
+- Durable replay semantics, checkpoint fencing, and retention boundaries now have repo-native contracts and validation references.
+- `docs/reports/live-validation-index.md` normalizes the latest local, Kubernetes, and Ray validation bundle so event-bus review can point to one stable runtime evidence surface.
+- `docs/reports/multi-subscriber-takeover-validation-report.md` defines the next takeover-focused reliability matrix, but that plan is still ahead of a durable shared lease backend.
 
-## Current durability shape
+## Remaining Gaps
 
-- Runtime publish/subscribe remains in-process.
-- Audit/debug persistence is recorder-backed, with optional JSONL sinking.
-- The `events.DurabilityPlan` surface makes the active backend and the next replicated target explicit in bootstrap and `GET /debug/status`, including broker bootstrap readiness when a replicated target is configured.
-- Default plan is `memory -> broker_replicated` with replication factor `3`, and env overrides exist for:
-  - `BIGCLAW_EVENT_LOG_BACKEND`
-  - `BIGCLAW_EVENT_LOG_TARGET_BACKEND`
-  - `BIGCLAW_EVENT_LOG_REPLICATION_FACTOR`
-
-## Next backend targets
-
-- `sqlite`: durable single-node append log with monotonic checkpoints but no replica quorum.
-- `http`: shared service-backed append log with single-writer ordering and shared subscriber state.
-- `broker_replicated`: quorum or partition-backed log with shared replay, replicated durability, and publisher ack requirements.
-
-## Repo-native integration points
-
-- `cmd/bigclawd/main.go`: bootstrap backend selection, capability validation, dedup ledger contract exposure, and future broker client wiring.
-- `internal/events/bus.go`: publish path remains the place to insert append/ack behavior ahead of live fanout.
-- `internal/api/server.go`: operational reporting for current and target durability mode plus runtime capability probes.
-- Subscriber checkpoint persistence, replay endpoints, and dedup ledger surfaces preserve resume and idempotency semantics while moving state out of process-local memory.
-- `internal/events/durability.go`: rollout-facing contract for replicated durability phases, failure domains, and required verification evidence.
-
-## Migration and compatibility constraints
-
-- Preserve append-only replay semantics across backend cutover.
-- Keep subscriber checkpoints monotonic during dual-write or backfill.
-- Keep `task_id`, `trace_id`, and `event_type` stable so partitioning and replay filters remain compatible.
-- Decouple SSE live fanout from broker consumer lag so replay catch-up does not stall live delivery.
-
-## Implementation-ready follow-up plan
-
-1. Add a concrete event-log interface alongside the in-process bus sink contract so append, replay, and checkpoint operations can be backed by SQLite, HTTP, or broker implementations.
-2. Introduce a dual-write migration phase from the current publish path into the new event-log backend while keeping recorder/audit output unchanged.
-3. Add checkpoint-backed replay endpoints that read from the shared event log instead of recorder-only history.
-4. Add a broker-backed implementation with partition-key rules for `trace_id` and explicit publisher ack / durability error handling.
-5. Validate cutover with replay, checkpoint monotonicity, SSE handoff, capability-matrix regression coverage, dedup-ledger persistence coverage, backend-capability probe validation, and multi-subscriber takeover fault-injection evidence under shared multi-node conditions.
-
-## Durability capability matrix
-
-| Backend | Implemented in bootstrap | Durable history | Publish | Replay | Checkpoint | Filtering | Required config |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `memory` | yes | no | native | native | unsupported | native | none |
-| `sqlite` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-| `http` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-| `broker` | no | yes | native | native | native | derived | `BIGCLAW_EVENT_LOG_DSN`, `BIGCLAW_EVENT_CHECKPOINT_DSN`, `BIGCLAW_EVENT_RETENTION` |
-
-## Validation contract
-
-- Startup validates `BIGCLAW_EVENT_BACKEND` against the backend catalog before queue/bootstrap wiring begins.
-- Durable backends must provide explicit event-log DSN, checkpoint DSN, and positive retention.
-- `BIGCLAW_EVENT_REQUIRE_REPLAY`, `BIGCLAW_EVENT_REQUIRE_CHECKPOINT`, and `BIGCLAW_EVENT_REQUIRE_FILTERING` express the runtime features operators expect from the selected backend.
-- Unsupported combinations fail fast with field-specific errors instead of silently downgrading runtime behavior.
-- Backends declared in the matrix but not yet wired into the bootstrap runtime are rejected explicitly so planning assumptions cannot masquerade as implemented support.
-
-## Consumer dedup ledger contract
-
-- Stable storage keys use `v1/<consumer_id>/<event_id>` so durable backends can share one persistence layout while still rejecting conflicting event metadata for the same consumer/event tuple.
-- Collision protection uses a fingerprint over `consumer_id`, `event_id`, `event_type`, `task_id`, `trace_id`, and `run_id`; the same storage key cannot be reused for a different event payload shape.
-- Reservation semantics distinguish first-writer `reserved`, repeated in-flight `duplicate`, and terminal `already_applied` outcomes.
-- Applied side effects persist `handler`, `applied_at`, `effect_id`, `effect_sequence`, `effect_fingerprint`, `summary`, and stable metadata so duplicate deliveries can return the prior applied result instead of replaying the side effect.
-- Once a record reaches `applied`, backends must treat a different result fingerprint as a conflict instead of silently overwriting the prior side effect evidence.
-- The first durable bootstrap is SQLite-backed, stores the full normalized dedup record as durable JSON, and indexes state/update timestamps so lifecycle cleanup can evolve without changing caller contracts.
-- Control-plane capability payloads expose `dedup` separately so operators can see whether replay-safe consumers are backed by durable dedup state or process memory only.
-
-## Remaining gaps
-
-- No concrete durable external event log exists yet in this checkout; replay still depends on process-local history plus the documented integration plan.
-- Only the SQLite durable consumer dedup backend exists yet; HTTP and broker-backed dedup persistence still need concrete implementations.
-- No delivery acknowledgement protocol exists beyond sink-level best effort.
-- Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
+- No concrete broker-backed external event log exists yet in this checkout; replay still depends on in-process or local durable history plus the documented adapter plan.
+- Only the SQLite durable consumer dedup backend exists today; HTTP and broker-backed dedup persistence are still future work.
+- Lease coordination is still single-process and not yet backed by a shared durable store.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
-- Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
-- Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- Multi-subscriber takeover fault injection remains a planned validation pack rather than an implemented executable suite.
 
-## Replicated rollout contract
+## Artifacts
 
-- `docs/reports/replicated-event-log-durability-rollout-contract.md` now captures the minimum rollout gates for a broker-backed or quorum-backed adapter, and `event_durability` now includes broker bootstrap readiness for those targets:
-  - replicated publish acknowledgements must distinguish committed, rejected, and ambiguous outcomes;
-  - replay and checkpoint state must share the same durable sequence domain across failover;
-  - retention boundaries must be operator-visible before resumable recovery is claimed;
-  - live fanout must remain isolated from broker catch-up lag.
-- The same contract is surfaced in `events.DurabilityPlan`, so debug/control-plane payloads can show rollout checks, failure domains, and supporting evidence links before a live adapter exists.
-
-## Next adapter boundary
-
-- `internal/events/log.go` now defines the provider-neutral event-log and checkpoint contract for future broker-backed adapters.
-- `internal/events/memory_log.go` provides the contract-compatible in-memory baseline while BigClaw remains on local fanout.
-- Broker-facing runtime knobs are reserved behind `BIGCLAW_EVENT_LOG_*` env vars so a first provider adapter can land without changing publish/replay/checkpoint callers.
-- No durable external event log yet; replay is process-local history.
-- No delivery acknowledgement protocol beyond sink-level best effort.
-- No partitioned topic model or cross-process subscriber coordination yet.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- `docs/reports/live-validation-index.md`
+- `docs/reports/live-validation-index.json`
+- `docs/reports/replay-retention-semantics-report.md`
+- `docs/reports/multi-subscriber-takeover-validation-report.md`
+- `docs/reports/replicated-event-log-durability-rollout-contract.md`
+- `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- `docs/reports/event-bus-reliability-report.md`

--- a/bigclaw-go/docs/reports/queue-reliability-report.md
+++ b/bigclaw-go/docs/reports/queue-reliability-report.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This report summarizes the current reliability evidence for the Go queue layer across memory, file, and SQLite backends.
+This report summarizes the current queue reliability evidence for the Go control plane across memory, file, and SQLite backends, plus the latest shared-queue coordination proof used for distributed closeout.
 
 ## Automated Evidence
 
@@ -10,19 +10,36 @@ This report summarizes the current reliability evidence for the Go queue layer a
 - `internal/queue/file_queue_test.go`
 - `internal/queue/sqlite_queue_test.go`
 - `internal/api/server_test.go`
+- `docs/reports/lease-recovery-report.md`
+- `docs/reports/multi-node-coordination-report.md`
 - `docs/reports/live-validation-summary.json`
 
 ## Verified Behaviors
 
 - Priority ordering works for the in-memory queue.
-- File-backed queue persists tasks across reload and persists dead-letter replay behavior across reload.
-- SQLite-backed queue persists tasks across reopen, supports dead-letter listing, supports replay back into the runnable queue, and now passes a `1k` task no-duplicate-consumption test.
+- File-backed queue persists tasks across reload and preserves dead-letter replay behavior across reload.
+- SQLite-backed queue persists tasks across reopen, supports dead-letter listing, and supports replay back into the runnable queue.
+- SQLite queue coverage includes a `1k` task no-duplicate-consumption test plus lease-expiry reacquisition coverage.
 - API-level dead-letter listing and replay are available through `GET /deadletters` and `POST /deadletters/{id}/replay`.
-- SQLite local reliability has been hardened by constraining the local connection pool to a single open/idle connection, removing the `database is locked` failure that appeared during concurrent queue validation.
+- Two `bigclawd` processes can coordinate against one SQLite queue with `0` duplicate terminal executions in the latest shared-queue report.
+- SQLite local reliability has been hardened by constraining the local connection pool to a single open and idle connection, removing the `database is locked` failure from concurrent queue validation.
 
 ## Current Result
 
 - Queue implementations now support dead-letter retrieval and replay instead of only marking terminal failure.
 - Lease recovery and replay paths are directly testable and inspectable through the API.
-- The queue layer is materially closer to the original reliability target and is ready for another review pass.
+- Shared-queue coordination evidence now complements the single-process reliability tests, so the closeout pack no longer relies on one-node queue proofs only.
+- The queue layer is review-ready for the implemented local and shared-SQLite topology.
+
+## Remaining Gaps
+
 - A larger `10k` reliability matrix is still a reasonable next follow-up if stricter closure criteria are desired.
+- Queue coordination is proven for shared SQLite, not for a broker-backed or quorum-backed distributed queue.
+- Local SQLite evidence does not replace leader election, durable lease fencing across independent stores, or multi-region queue validation.
+
+## Artifacts
+
+- `docs/reports/lease-recovery-report.md`
+- `docs/reports/multi-node-coordination-report.md`
+- `docs/reports/multi-node-shared-queue-report.json`
+- `docs/reports/live-validation-summary.json`

--- a/bigclaw-go/internal/reports/closeout_reports_test.go
+++ b/bigclaw-go/internal/reports/closeout_reports_test.go
@@ -1,0 +1,82 @@
+package reports
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const moduleRoot = "../.."
+
+func TestCloseoutReportsReferenceExpectedEvidence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		report string
+		want   []string
+	}{
+		{
+			report: "docs/reports/epic-concurrency-readiness-report.md",
+			want: []string{
+				"docs/reports/epic-closure-readiness-report.md",
+				"docs/reports/long-duration-soak-report.md",
+				"docs/reports/mixed-workload-validation-report.md",
+				"docs/reports/multi-node-coordination-report.md",
+				"docs/reports/queue-reliability-report.md",
+				"docs/reports/soak-local-1000x24.json",
+				"docs/reports/soak-local-2000x24.json",
+				"docs/reports/mixed-workload-matrix-report.json",
+				"docs/reports/multi-node-shared-queue-report.json",
+				"docs/reports/live-validation-summary.json",
+			},
+		},
+		{
+			report: "docs/reports/event-bus-reliability-report.md",
+			want: []string{
+				"docs/reports/live-validation-index.md",
+				"docs/reports/live-validation-index.json",
+				"docs/reports/replay-retention-semantics-report.md",
+				"docs/reports/multi-subscriber-takeover-validation-report.md",
+				"docs/reports/replicated-event-log-durability-rollout-contract.md",
+				"docs/reports/broker-failover-fault-injection-validation-pack.md",
+			},
+		},
+		{
+			report: "docs/reports/queue-reliability-report.md",
+			want: []string{
+				"docs/reports/lease-recovery-report.md",
+				"docs/reports/multi-node-coordination-report.md",
+				"docs/reports/multi-node-shared-queue-report.json",
+				"docs/reports/live-validation-summary.json",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.report, func(t *testing.T) {
+			t.Parallel()
+
+			content := mustReadReport(t, tc.report)
+			for _, needle := range tc.want {
+				if !strings.Contains(content, needle) {
+					t.Fatalf("%s does not reference %s", tc.report, needle)
+				}
+				if _, err := os.Stat(filepath.Join(moduleRoot, filepath.FromSlash(needle))); err != nil {
+					t.Fatalf("referenced artifact %s is missing: %v", needle, err)
+				}
+			}
+		})
+	}
+}
+
+func mustReadReport(t *testing.T, path string) string {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join(moduleRoot, filepath.FromSlash(path)))
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- refresh the epic concurrency, queue reliability, and event bus closeout reports around the latest distributed evidence pack
- cross-link the closeout surfaces to shared queue, mixed workload, soak, retention, and takeover references
- add a targeted Go test that verifies the refreshed reports keep referencing required artifacts that exist in-repo

## Validation
- go test ./internal/reports