### PR TITLE
OPE-253: refresh control-plane observability evidence

### DIFF
--- a/bigclaw-go/docs/reports/go-control-plane-observability-report.md
+++ b/bigclaw-go/docs/reports/go-control-plane-observability-report.md
@@ -6,20 +6,22 @@ This report summarizes the current observability/debug evidence for `OPE-184` / 
 
 ## Implemented surfaces
 
-- Event counters and queue-size metrics via `GET /metrics` JSON plus Prometheus-style text exposition via `GET /metrics?format=prometheus`
+- Metrics snapshot via `GET /metrics` with concrete JSON fields for `queue_size`, `events`, `trace_count`, `registered_executors`, `event_durability`, `event_log`, and `retention_watermark`
+- Prometheus-style text exposition via `GET /metrics?format=prometheus` for queue, trace, event-type, registered-executor, worker-pool, per-worker, and control-plane gauges/counters
 - Task timeline lookup via `GET /events?task_id=...`
 - Trace timeline lookup via `GET /events?trace_id=...`
 - Trace summary listing via `GET /debug/traces`
 - Trace detail timeline via `GET /debug/traces/{trace_id}`
-- Worker lifecycle snapshot via `GET /debug/status`
+- Worker and control-plane snapshot via `GET /debug/status`
+- Replay/checkpoint diagnostics via `/events`, `/stream/events`, `/stream/events/checkpoints/{subscriber_id}`, and `/debug/status` retention/reset summaries
 - Audit persistence via `internal/observability/JSONLAuditSink`
 
 ## Validated behaviors
 
 - Task and trace timelines are queryable from the recorder.
 - Recent traces can be summarized with first/last timestamps, duration, event counts, and task ids.
-- Debug status exposes the current worker snapshot and aggregate counters.
-- Metrics surface keeps `trace_count` JSON visibility and now exposes scrape-friendly queue, event, executor, worker-pool, and control-plane gauges.
+- Debug status exposes worker snapshots, worker-pool totals, event-log capability data, retention watermark details, and recent checkpoint reset summaries.
+- Metrics surface keeps `trace_count` JSON visibility and now exposes concrete JSON fields plus Prometheus gauges/counters for queue size, recorded event types, registered executors, worker-pool totals, per-worker activity, and control-plane pause/takeover state.
 - Audit sink writes JSONL event records for later inspection.
 
 ## Evidence
@@ -28,6 +30,7 @@ This report summarizes the current observability/debug evidence for `OPE-184` / 
 - `internal/observability/recorder_test.go`
 - `internal/observability/audit.go`
 - `internal/observability/audit_test.go`
+- `internal/api/metrics.go`
 - `internal/api/server.go`
 - `internal/api/server_test.go`
 - `internal/worker/runtime.go`

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -737,6 +737,31 @@ func TestMetricsSupportsPrometheusFormat(t *testing.T) {
 	}
 }
 
+func TestObservabilityReportMentionsCurrentSurfaces(t *testing.T) {
+	reportPath := filepath.Join("..", "..", "docs", "reports", "go-control-plane-observability-report.md")
+	content, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatalf("read observability report: %v", err)
+	}
+	report := string(content)
+	checks := []string{
+		"GET /metrics",
+		"GET /metrics?format=prometheus",
+		"`retention_watermark`",
+		"`GET /debug/status`",
+		"`GET /debug/traces`",
+		"`GET /debug/traces/{trace_id}`",
+		"`/stream/events/checkpoints/{subscriber_id}`",
+		"checkpoint reset summaries",
+		"`internal/api/metrics.go`",
+	}
+	for _, check := range checks {
+		if !strings.Contains(report, check) {
+			t.Fatalf("expected %q in observability report, got %s", check, report)
+		}
+	}
+}
+
 type dashboardResponse struct {
 	Summary struct {
 		TotalTasks        int            `json:"total_tasks"`


### PR DESCRIPTION
## Summary
- refresh the Go control-plane observability report to match current metrics, trace, debug, retention, and checkpoint-reset surfaces
- add a targeted test that fails if the report stops naming the current endpoint and evidence references

## Validation
- go test ./internal/api ./internal/observability