### PR TITLE
OPE-252: refresh worker runtime closeout digest

### DIFF
--- a/bigclaw-go/docs/reports/state-machine-validation-report.md
+++ b/bigclaw-go/docs/reports/state-machine-validation-report.md
@@ -2,27 +2,44 @@
 
 ## Objective
 
-Validate that the unified Go task state machine accepts legal transitions and rejects illegal transitions.
+Validate the task-state transition contract summarized in `docs/reports/worker-runtime-closeout-digest.md`.
 
 ## Evidence
 
 Primary automated coverage lives in:
 
 - `internal/domain/state_machine_test.go`
+- `internal/domain/state_machine.go`
+- `internal/domain/task.go`
 - `internal/api/server_test.go`
 - `internal/worker/runtime_test.go`
 
 ## Verified Behaviors
 
 - `queued -> leased` is accepted
+- `queued -> cancelled` is accepted
 - `leased -> running` is accepted
+- `leased -> retrying` is accepted
+- `leased -> cancelled` is accepted
 - `running -> succeeded` is accepted
+- `running -> failed` is accepted
+- `running -> blocked` is accepted
+- `running -> retrying` is accepted
+- `running -> cancelled` is accepted
+- `running -> dead_letter` is accepted
+- `blocked -> retrying` is accepted
+- `blocked -> cancelled` is accepted
+- `retrying -> queued` is accepted
+- `retrying -> dead_letter` is accepted
+- `retrying -> cancelled` is accepted
+- `failed -> retrying` is accepted
+- `failed -> dead_letter` is accepted
 - illegal jumps such as `queued -> succeeded` are rejected
-- API status responses translate event types back into externally visible task states
+- API status and replay responses translate event types back into externally visible task states
 - worker runtime emits lifecycle events in queue -> lease -> start -> terminal order
 
 ## Result
 
 - The current task-state contract is stable enough for scheduler, worker, API, recorder, and executor integration.
 - Illegal transition rejection is covered by automated tests.
-- Event-driven status projection matches the internal state model.
+- Event-driven status projection matches the internal state model summarized in the closeout digest.

--- a/bigclaw-go/docs/reports/task-protocol-spec.md
+++ b/bigclaw-go/docs/reports/task-protocol-spec.md
@@ -1,5 +1,7 @@
 # Task Protocol Spec
 
+This report captures the protocol-specific slice of the canonical closeout digest in `docs/reports/worker-runtime-closeout-digest.md`.
+
 ## Core Entities
 
 ### Task
@@ -9,9 +11,10 @@ The Go control plane task model is defined in `internal/domain/task.go` and carr
 - identity: `id`, `title`
 - execution routing: `required_executor`, `command`, `args`, `entrypoint`, `container_image`, `working_dir`
 - governance: `priority`, `budget_cents`, `risk_level`
+- coordination: `idempotency_key`, `tenant_id`, `labels`, `acceptance_criteria`, `validation_plan`, `required_tools`
 - runtime controls: `execution_timeout_seconds`, `environment`, `metadata`, `runtime_env`
 - timing: `created_at`, `updated_at`
-- state: `queued`, `leased`, `running`, `retrying`, `succeeded`, `failed`, `cancelled`, `dead_letter`
+- state: `queued`, `leased`, `running`, `blocked`, `retrying`, `succeeded`, `failed`, `cancelled`, `dead_letter`
 
 ### Lease
 
@@ -40,11 +43,23 @@ The enforced task-state transitions live in `internal/domain/state_machine.go`.
 Allowed examples include:
 
 - `queued -> leased`
+- `queued -> cancelled`
 - `leased -> running`
+- `leased -> retrying`
+- `leased -> cancelled`
 - `running -> succeeded`
+- `running -> failed`
+- `running -> blocked`
 - `running -> retrying`
 - `running -> dead_letter`
 - `running -> cancelled`
+- `blocked -> retrying`
+- `blocked -> cancelled`
+- `retrying -> queued`
+- `retrying -> dead_letter`
+- `retrying -> cancelled`
+- `failed -> retrying`
+- `failed -> dead_letter`
 
 Illegal transitions are rejected by `ValidateTransition`.
 
@@ -69,5 +84,7 @@ The task protocol is observable via:
 
 - `GET /tasks/{id}` for status and event history
 - `GET /events?task_id=...` for filtered timelines
+- `GET /events?trace_id=...` for trace-scoped timelines
 - `GET /replay/{id}` for replay-oriented timelines
 - `GET /stream/events` for SSE consumers
+- `GET /debug/status` for worker snapshots, worker-pool snapshots, and event durability diagnostics

--- a/bigclaw-go/docs/reports/worker-lifecycle-validation-report.md
+++ b/bigclaw-go/docs/reports/worker-lifecycle-validation-report.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This report captures the current worker runtime lifecycle evidence for the Go control plane.
+This report captures the worker-lifecycle-specific slice of the canonical closeout digest in `docs/reports/worker-runtime-closeout-digest.md`.
 
 ## Automated Evidence
 
@@ -15,13 +15,17 @@ This report captures the current worker runtime lifecycle evidence for the Go co
 
 - A runnable task is leased, started, and completed through the worker runtime.
 - Long-running execution renews its lease while work is in progress.
-- Timeout and cancellation paths requeue the task instead of silently dropping it.
+- Timeout paths requeue the task instead of silently dropping it.
+- In-flight cancellation completes the task as `cancelled` and updates worker snapshot counters.
 - Missing executor registrations move tasks into dead-letter state with a terminal event.
-- Lifecycle events are emitted in a form consumable by the recorder and API surfaces.
-- Runtime maintains an in-memory worker snapshot with the latest task, transition, lease-renewal count, and success/retry/dead-letter/cancellation counters.
-- `GET /debug/status` now exposes the worker snapshot for runtime debugging.
+- Control-plane pause leaves the task queued and exposes a `paused` worker snapshot.
+- Human takeover defers automation, requeues the task, and stores the task as `blocked` with an audit event.
+- Urgent work can preempt a lower-priority run and surfaces both preemption and cancellation evidence.
+- Lifecycle events are emitted in a form consumable by recorder, replay, and debug API surfaces.
+- Runtime maintains an in-memory worker snapshot with the latest task, transition, lease renewal count, executor, trace ID, and success/retry/dead-letter/cancellation/preemption counters.
+- `GET /debug/status` exposes worker and worker-pool snapshots for runtime debugging.
 
 ## Current Result
 
-- Worker lifecycle evidence is materially stronger than the original MVP and now covers timeout, retry, heartbeat, and dead-letter paths.
-- Explicit worker registration/offline coordination is still lightweight, but lifecycle evidence now includes debug-surface introspection and cancellation-aware snapshotting.
+- Worker lifecycle evidence now covers success, retry, cancellation, dead-letter, pause, takeover, and preemption paths.
+- The stable review surface for closeout is `docs/reports/worker-runtime-closeout-digest.md`, with this report retained as the lifecycle-focused companion.

--- a/bigclaw-go/docs/reports/worker-runtime-closeout-digest.md
+++ b/bigclaw-go/docs/reports/worker-runtime-closeout-digest.md
@@ -1,0 +1,131 @@
+# Worker Runtime Closeout Digest
+
+## Purpose
+
+This digest is the canonical closeout surface for the Go control-plane worker lifecycle, task state machine, and task protocol contract.
+
+It replaces scattered closeout claims with one repo-native review point backed by current code and automated tests.
+
+## Automated Evidence
+
+- `internal/worker/runtime.go`
+- `internal/worker/runtime_test.go`
+- `internal/domain/task.go`
+- `internal/domain/state_machine.go`
+- `internal/domain/state_machine_test.go`
+- `internal/api/server.go`
+- `internal/api/server_test.go`
+
+## Runtime Contract
+
+### Task States
+
+The runtime contract currently uses these task states from `internal/domain/task.go`:
+
+- `queued`
+- `leased`
+- `running`
+- `blocked`
+- `retrying`
+- `succeeded`
+- `failed`
+- `cancelled`
+- `dead_letter`
+
+### Allowed State Transitions
+
+The enforced transition map in `internal/domain/state_machine.go` currently allows:
+
+- `queued -> leased`
+- `queued -> cancelled`
+- `leased -> running`
+- `leased -> retrying`
+- `leased -> cancelled`
+- `running -> succeeded`
+- `running -> failed`
+- `running -> blocked`
+- `running -> retrying`
+- `running -> cancelled`
+- `running -> dead_letter`
+- `blocked -> retrying`
+- `blocked -> cancelled`
+- `retrying -> queued`
+- `retrying -> dead_letter`
+- `retrying -> cancelled`
+- `failed -> retrying`
+- `failed -> dead_letter`
+
+Illegal transitions are rejected by `ValidateTransition`.
+
+### Event To State Projection
+
+The externally visible task state projection in `TaskStateFromEventType` currently maps:
+
+- `task.queued -> queued`
+- `task.leased -> leased`
+- `scheduler.routed -> leased`
+- `task.started -> running`
+- `task.retried -> retrying`
+- `task.completed -> succeeded`
+- `task.preempted -> cancelled`
+- `task.cancelled -> cancelled`
+- `task.dead_lettered -> dead_letter`
+
+## Verified Lifecycle Behaviors
+
+Automated coverage in `internal/worker/runtime_test.go` and `internal/api/server_test.go` verifies that:
+
+- runnable work progresses through `queued -> leased -> running -> succeeded`
+- long-running work renews queue leases while executing
+- missing trace IDs default to the task ID for event correlation
+- timeouts requeue work with a retry event instead of dropping it
+- in-flight cancellation completes as `cancelled` and updates worker counters
+- missing executor registrations move work to `dead_letter`
+- control-plane pause leaves work queued and exposes a `paused` worker snapshot
+- active human takeover requeues work, records a takeover audit event, and stores the task as `blocked`
+- urgent work can preempt a lower-priority run and surfaces both preemption and cancellation evidence
+- runtime events include executor selection, required tools, completion messages, and artifact references
+
+## Stable Review Surfaces
+
+The current repo-native review surfaces for this contract are:
+
+- `GET /tasks/{id}` for projected task status and task metadata
+- `GET /events?task_id=...` for filtered task timelines
+- `GET /events?trace_id=...` for trace-scoped timelines
+- `GET /replay/{id}` for replay-oriented task history with delivery metadata
+- `GET /stream/events` for SSE consumers
+- `GET /debug/status` for worker snapshot, worker-pool snapshot, control snapshot, event durability, event-log backend capabilities, retention watermark, and checkpoint reset diagnostics
+
+The worker snapshot returned through `GET /debug/status` is currently expected to expose:
+
+- `worker_id`
+- `state`
+- `current_task_id`
+- `current_trace_id`
+- `current_executor`
+- `last_heartbeat_at`
+- `last_started_at`
+- `last_finished_at`
+- `last_result`
+- `lease_renewals`
+- `successful_runs`
+- `retried_runs`
+- `dead_letter_runs`
+- `cancelled_runs`
+- `preemption_active`
+- `current_preemption_task_id`
+- `current_preemption_worker_id`
+- `last_preempted_task_id`
+- `last_preemption_at`
+- `last_preemption_reason`
+- `preemptions_issued`
+- `last_transition`
+
+## Focused Companion Reports
+
+These focused reports remain in place, but this digest is the canonical closeout reference:
+
+- `docs/reports/worker-lifecycle-validation-report.md`
+- `docs/reports/state-machine-validation-report.md`
+- `docs/reports/task-protocol-spec.md`

--- a/bigclaw-go/internal/domain/closeout_digest_test.go
+++ b/bigclaw-go/internal/domain/closeout_digest_test.go
@@ -1,0 +1,98 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func readReport(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "docs", "reports", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func TestWorkerRuntimeCloseoutDigestCoversTaskContract(t *testing.T) {
+	digest := readReport(t, "worker-runtime-closeout-digest.md")
+	taskProtocol := readReport(t, "task-protocol-spec.md")
+	stateReport := readReport(t, "state-machine-validation-report.md")
+	lifecycleReport := readReport(t, "worker-lifecycle-validation-report.md")
+
+	for _, state := range []TaskState{
+		TaskQueued,
+		TaskLeased,
+		TaskRunning,
+		TaskBlocked,
+		TaskRetrying,
+		TaskSucceeded,
+		TaskFailed,
+		TaskCancelled,
+		TaskDeadLetter,
+	} {
+		quoted := "`" + string(state) + "`"
+		if !strings.Contains(digest, quoted) {
+			t.Fatalf("expected digest to mention state %s", state)
+		}
+		if !strings.Contains(taskProtocol, quoted) {
+			t.Fatalf("expected task protocol report to mention state %s", state)
+		}
+	}
+
+	for _, transition := range []string{
+		"`queued -> leased`",
+		"`queued -> cancelled`",
+		"`leased -> running`",
+		"`leased -> retrying`",
+		"`leased -> cancelled`",
+		"`running -> blocked`",
+		"`running -> dead_letter`",
+		"`blocked -> retrying`",
+		"`retrying -> queued`",
+		"`failed -> dead_letter`",
+	} {
+		if !strings.Contains(digest, transition) {
+			t.Fatalf("expected digest to mention transition %s", transition)
+		}
+		if !strings.Contains(stateReport, transition) {
+			t.Fatalf("expected state-machine report to mention transition %s", transition)
+		}
+	}
+
+	for _, surface := range []string{
+		"`GET /tasks/{id}`",
+		"`GET /events?task_id=...`",
+		"`GET /events?trace_id=...`",
+		"`GET /replay/{id}`",
+		"`GET /stream/events`",
+		"`GET /debug/status`",
+	} {
+		if !strings.Contains(digest, surface) {
+			t.Fatalf("expected digest to mention surface %s", surface)
+		}
+	}
+
+	for _, field := range []string{
+		"`current_task_id`",
+		"`current_trace_id`",
+		"`lease_renewals`",
+		"`successful_runs`",
+		"`cancelled_runs`",
+		"`preemption_active`",
+		"`last_transition`",
+	} {
+		if !strings.Contains(digest, field) {
+			t.Fatalf("expected digest to mention debug field %s", field)
+		}
+	}
+
+	for _, report := range []string{taskProtocol, stateReport, lifecycleReport} {
+		if !strings.Contains(report, "worker-runtime-closeout-digest.md") {
+			t.Fatal("expected focused report to point back to canonical closeout digest")
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a canonical worker runtime closeout digest covering lifecycle, state-machine, and task-protocol review points
- refresh the focused lifecycle, state-machine, and task-protocol reports to point back to the digest and align with current runtime behavior
- add a Go consistency test that locks the digest and companion reports to the current task states, transitions, and debug/API review surfaces

## Validation
- cd bigclaw-go && go test ./internal/domain ./internal/worker ./internal/api