### PR TITLE
OPE-256: refresh scheduler policy closeout report

### DIFF
--- a/bigclaw-go/docs/reports/scheduler-policy-report.md
+++ b/bigclaw-go/docs/reports/scheduler-policy-report.md
@@ -2,32 +2,60 @@
 
 ## Scope
 
-This report summarizes the current Go scheduler policy surface for `OPE-179` / `BIG-GO-004`.
+- Run date: 2026-03-16
+- Goal: refresh `OPE-179` scheduler closeout evidence so policy guardrails, fairness behavior, preemption, and executor routing can be reviewed from one current repo-native summary.
 
-## Implemented policies
+## Admission And Fairness Policy
 
-- Budget guardrail rejects tasks whose `budget_cents` exceed remaining budget.
-- Concurrency quota rejects new work when tenant concurrency is exhausted.
-- Multi-tenant fairness windows can throttle dominant tenant low-priority work when peer tenants are also active, with optional shared SQLite-backed coordination or a remote HTTP fairness service across scheduler processes.
-- Preemptible capacity now supports live preemption: urgent tasks can cancel a lower-priority leased/running task to reclaim capacity when `preemptible_executions` is available.
-- Backpressure rejects low-priority tasks when queue depth exceeds `max_queue_depth`.
-- High-risk tasks default to `kubernetes`.
-- GPU-tagged tasks default to `ray`.
-- Browser-tagged tasks default to `kubernetes`.
-- Explicit `required_executor` still overrides policy routing.
+- Budget guardrail rejects a task when `budget_cents` exceeds `BudgetRemaining`.
+- Queue backpressure rejects non-exempt work when `QueueDepth >= MaxQueueDepth`.
+- Tenant concurrency rejects new work when `CurrentRunning >= ConcurrentLimit`.
+- Urgent work can reclaim preemptible capacity when `PreemptibleExecutions > 0`, returning a decision with `Preemption.Required=true`.
+- Fairness windows only throttle non-urgent, non-high-risk work and only when another tenant is active inside the configured window.
+- Fairness state can run in process memory, shared SQLite, or through a remote HTTP fairness service.
 
-## Evidence
+## Routing Order
 
-- Policy implementation: `internal/scheduler/scheduler.go` and `internal/scheduler/policy_store.go`
-- Unit coverage: `internal/scheduler/scheduler_test.go` and `internal/worker/runtime_test.go`
-- Runtime emission of `scheduler.routed`, `task.preempted`, and in-flight cancellation enforcement: `internal/worker/runtime.go`
-- File-backed scheduler policy inspection and reload now optionally replicate through a shared SQLite-backed policy store for multi-process convergence: `GET /v2/control-center/policy` and `POST /v2/control-center/policy/reload`
-- Local benchmark: `docs/reports/benchmark-report.md`
+The scheduler applies executor routing in this order:
 
-## Fresh benchmark snapshot
+1. `required_executor` hard override
+2. tool-aware routing from `tool_executors`
+3. computed high-risk routing to `high_risk_executor`
+4. fallback routing to `default_executor`
 
-- `BenchmarkSchedulerDecide-8 = 51.08 ns/op`
+Current default routing evidence from `DefaultRoutingRules()`:
 
-## Remaining gaps
+- `gpu -> ray`
+- `browser -> kubernetes`
+- high-risk tasks -> `kubernetes`
+- low/medium-risk fallback -> `local`
 
-- No open fairness-distribution gaps remain in the current scheduler policy scope; fairness can now coordinate through memory, shared SQLite, or a remote HTTP service backend.
+## Runtime Evidence
+
+- Core routing and admission logic: `internal/scheduler/scheduler.go`
+- Policy loading, reload, and shared SQLite policy replication: `internal/scheduler/policy_store.go`
+- Fairness backends: `internal/scheduler/fairness.go`, `internal/scheduler/sqlite_fairness.go`, and `internal/scheduler/http_fairness.go`
+- Scheduler policy API snapshot: `GET /v2/control-center/policy`
+- Scheduler policy reload API: `POST /v2/control-center/policy/reload`
+- Remote fairness service surface: `/internal/scheduler/fairness/{throttle,record,snapshot}`
+- Unit coverage: `internal/scheduler/scheduler_test.go`
+- Policy endpoint coverage: `internal/api/server_test.go`
+- Runtime routing/preemption events: `internal/worker/runtime.go`
+
+## Benchmark Reference
+
+- Baseline microbenchmark reference: `docs/reports/benchmark-report.md`
+- Current scheduler microbenchmark label: `BenchmarkSchedulerDecide-8`
+
+The scheduler closeout report intentionally links the stable benchmark reference instead of copying a stale performance narrative into policy docs.
+
+## Closeout Summary
+
+The current scheduler surface now has repo-native evidence for:
+
+- budget rejection and queue backpressure
+- tenant fairness with memory, SQLite, and HTTP coordination modes
+- live urgent-task preemption when reclaimable capacity exists
+- deterministic executor routing precedence across explicit pins, tool requirements, computed risk, and default fallback
+
+That is sufficient to review the current scheduler policy scope without reconstructing behavior from scattered code paths or older benchmark notes.

--- a/bigclaw-go/internal/scheduler/report_consistency_test.go
+++ b/bigclaw-go/internal/scheduler/report_consistency_test.go
@@ -1,0 +1,60 @@
+package scheduler
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSchedulerPolicyReportReferencesCurrentSurfaces(t *testing.T) {
+	report := readRepoFile(t, filepath.Join("..", "..", "docs", "reports", "scheduler-policy-report.md"))
+	server := readRepoFile(t, filepath.Join("..", "api", "server.go"))
+	policyRuntime := readRepoFile(t, filepath.Join("..", "api", "policy_runtime.go"))
+	benchmarkReport := readRepoFile(t, filepath.Join("..", "..", "docs", "reports", "benchmark-report.md"))
+
+	for _, want := range []string{
+		"/v2/control-center/policy",
+		"/v2/control-center/policy/reload",
+		"/internal/scheduler/fairness/{throttle,record,snapshot}",
+		"docs/reports/benchmark-report.md",
+		"BenchmarkSchedulerDecide-8",
+		"required_executor",
+		"tool_executors",
+		"high_risk_executor",
+		"default_executor",
+		"memory",
+		"SQLite",
+		"HTTP",
+	} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("scheduler policy report missing %q", want)
+		}
+	}
+
+	for _, endpoint := range []string{
+		"/v2/control-center/policy",
+		"/v2/control-center/policy/reload",
+		"/internal/scheduler/fairness",
+	} {
+		if !strings.Contains(server, endpoint) {
+			t.Fatalf("server routing missing %q", endpoint)
+		}
+	}
+
+	if !strings.Contains(policyRuntime, `"/v2/control-center/policy/reload"`) {
+		t.Fatal("policy runtime metadata missing reload_url reference")
+	}
+	if !strings.Contains(benchmarkReport, "BenchmarkSchedulerDecide-8") {
+		t.Fatal("benchmark report missing scheduler benchmark label")
+	}
+}
+
+func readRepoFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}


### PR DESCRIPTION
## Summary
- refresh the scheduler policy closeout report around current guardrails, routing precedence, fairness backends, and policy runtime surfaces
- add a lightweight scheduler report consistency test that checks the report against the registered policy endpoints and benchmark reference

## Validation
- go test ./internal/scheduler ./internal/api