### PR TITLE
OPE-257: refresh review matrix and closeout navigation

### DIFF
--- a/bigclaw-go/docs/reports/epic-closure-readiness-report.md
+++ b/bigclaw-go/docs/reports/epic-closure-readiness-report.md
@@ -4,6 +4,14 @@
 
 - Run date: 2026-03-13
 - Goal: close the three remaining epic hardening items with same-day evidence for sustained soak, production-like workload mix, and multi-node coordination.
+- Current review entrypoint: `docs/reports/review-readiness.md`
+
+## Current Closeout Navigation
+
+- `OPE-254` benchmark closeout: `docs/reports/benchmark-readiness-report.md` and `docs/reports/long-duration-soak-report.md`
+- `OPE-255` operations foundation alignment: `docs/reports/v2-phase1-operations-foundation-report.md`
+- `OPE-256` scheduler policy and routing closeout: `docs/reports/scheduler-policy-report.md`
+- `OPE-257` review matrix and project sync navigation: `docs/reports/review-readiness.md` and `docs/reports/linear-project-sync-summary.md`
 
 ## Long-Duration Soak
 
@@ -33,6 +41,13 @@ The three previously open closure items are now covered by fresh same-day eviden
 - concrete two-node shared-queue coordination proof
 
 This does not magically turn the system into production-grade distributed infrastructure, but it does make the current rewrite epic complete enough to close in Linear. Remaining work is now follow-up hardening, not missing baseline evidence.
+
+The latest distributed-platform refresh slices add reviewer-friendly navigation on top of that baseline:
+
+- benchmark and soak evidence remain anchored here and in `docs/reports/benchmark-readiness-report.md`
+- operations foundation evidence is consolidated in `docs/reports/v2-phase1-operations-foundation-report.md`
+- scheduler policy closeout stays anchored in `docs/reports/scheduler-policy-report.md`
+- Linear issue and project crosswalks stay anchored in `docs/reports/linear-project-sync-summary.md`
 
 ## Artifacts
 

--- a/bigclaw-go/docs/reports/linear-project-sync-summary.md
+++ b/bigclaw-go/docs/reports/linear-project-sync-summary.md
@@ -1,5 +1,24 @@
 # Linear Project Sync Summary
 
+## BigClaw v5.0 Parallel Distributed Platform
+
+- Project status: `In Progress`
+- Linear project id: `20b45595-d6ac-47c3-8896-7f6fe77ccf88`
+- Scope summary: distributed-platform closeout is being kept reviewable through repo-native reports that map directly to the active and most recently completed parallel slices.
+
+### Active / latest slices
+
+- `OPE-254` / `BIG-PAR-065`: benchmark and soak closeout refreshed in `docs/reports/benchmark-readiness-report.md` and `docs/reports/long-duration-soak-report.md`
+- `OPE-255` / `BIG-PAR-066`: operations foundation evidence aligned in `docs/reports/v2-phase1-operations-foundation-report.md`
+- `OPE-256` / `BIG-PAR-067`: scheduler policy and routing closeout anchored in `docs/reports/scheduler-policy-report.md`
+- `OPE-257` / `BIG-PAR-068`: review matrix and closeout navigation refreshed through `docs/reports/review-readiness.md` and `docs/reports/epic-closure-readiness-report.md`
+
+### Notes
+
+- Reviewer navigation starts from `docs/reports/review-readiness.md`.
+- Epic-closeout navigation stays centered on `docs/reports/epic-closure-readiness-report.md`.
+- The parallel refill queue currently targets `2` active issues and records the next standby slice in `docs/parallel-refill-queue.json`.
+
 ## BigClaw v4.0 Execution Pack
 
 - Project status: `Completed`
@@ -82,4 +101,3 @@
 
 - All v1.0 issues remain `Done` after milestone backfill.
 - A project update has been posted in Linear to capture the completed historical structure.
-

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -1,5 +1,20 @@
 # Review Readiness Matrix
 
+## Current Distributed Platform Refresh Pack
+
+- `OPE-254`
+  - Long-duration soak and benchmark closeout has been refreshed around the canonical benchmark pack.
+  - Primary reports: `docs/reports/benchmark-readiness-report.md`, `docs/reports/long-duration-soak-report.md`, and `docs/reports/epic-closure-readiness-report.md`.
+- `OPE-255`
+  - Operations foundation evidence now rolls up control-center, run-detail, policy, and collaboration surfaces through one repo-native summary.
+  - Primary reports: `docs/reports/v2-phase1-operations-foundation-report.md` and `docs/reports/linear-project-sync-summary.md`.
+- `OPE-256`
+  - Scheduler policy closeout references now live with the latest routing, fairness, and preemption evidence instead of older review notes.
+  - Primary reports: `docs/reports/scheduler-policy-report.md` and `docs/reports/epic-closure-readiness-report.md`.
+- `OPE-257`
+  - Review and closeout navigation now links the latest distributed-platform refresh set from this matrix and the epic closure report.
+  - Primary reports: `docs/reports/review-readiness.md`, `docs/reports/epic-closure-readiness-report.md`, and `docs/reports/linear-project-sync-summary.md`.
+
 ## Done
 
 - `OPE-176`
@@ -36,6 +51,14 @@
 - `OPE-175`
   - Epic-level evidence includes longer-duration soak (`2000x24`), mixed workload validation across `local` / `kubernetes` / `ray`, and a concrete two-node shared-queue coordination proof.
   - Supporting report: `docs/reports/epic-closure-readiness-report.md`.
+
+## Reviewer Navigation
+
+- Start with `docs/reports/review-readiness.md` for the current refresh matrix.
+- Use `docs/reports/epic-closure-readiness-report.md` for the benchmark, mixed-workload, and multi-node closeout spine.
+- Use `docs/reports/v2-phase1-operations-foundation-report.md` for operations foundation and control-center evidence.
+- Use `docs/reports/scheduler-policy-report.md` for scheduler fairness, routing, and preemption evidence.
+- Use `docs/reports/linear-project-sync-summary.md` for the Linear project and issue crosswalk.
 
 ## Follow-up Hardening
 

--- a/tests/test_bigclaw_report_navigation.py
+++ b/tests/test_bigclaw_report_navigation.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BIGCLAW_GO = REPO_ROOT / "bigclaw-go"
+
+
+def test_review_navigation_reports_and_issue_ids_are_current() -> None:
+    review = (BIGCLAW_GO / "docs/reports/review-readiness.md").read_text()
+    closeout = (BIGCLAW_GO / "docs/reports/epic-closure-readiness-report.md").read_text()
+    project_sync = (BIGCLAW_GO / "docs/reports/linear-project-sync-summary.md").read_text()
+
+    for issue_id in ("OPE-254", "OPE-255", "OPE-256", "OPE-257"):
+        assert issue_id in review
+        assert issue_id in closeout
+        assert issue_id in project_sync
+
+    for report_path in (
+        "docs/reports/review-readiness.md",
+        "docs/reports/epic-closure-readiness-report.md",
+        "docs/reports/benchmark-readiness-report.md",
+        "docs/reports/long-duration-soak-report.md",
+        "docs/reports/v2-phase1-operations-foundation-report.md",
+        "docs/reports/scheduler-policy-report.md",
+        "docs/reports/linear-project-sync-summary.md",
+    ):
+        assert report_path in review or report_path in closeout or report_path in project_sync
+        assert (BIGCLAW_GO / report_path).exists(), report_path


### PR DESCRIPTION
## Summary
- refresh the review-readiness matrix with the current distributed-platform closeout pack
- add epic-closeout and project-sync cross-links for OPE-254 through OPE-257
- add a direct validation test for report paths and issue identifiers

## Validation
- python3 - <<'PY'
  from pathlib import Path
  repo = Path("/Users/jxrt/code/symphony-workspaces/OPE-257")
  bigclaw_go = repo / "bigclaw-go"
  review = (bigclaw_go / "docs/reports/review-readiness.md").read_text()
  closeout = (bigclaw_go / "docs/reports/epic-closure-readiness-report.md").read_text()
  project_sync = (bigclaw_go / "docs/reports/linear-project-sync-summary.md").read_text()
  for issue_id in ("OPE-254", "OPE-255", "OPE-256", "OPE-257"):
      assert issue_id in review
      assert issue_id in closeout
      assert issue_id in project_sync
  for report_path in (
      "docs/reports/review-readiness.md",
      "docs/reports/epic-closure-readiness-report.md",
      "docs/reports/benchmark-readiness-report.md",
      "docs/reports/long-duration-soak-report.md",
      "docs/reports/v2-phase1-operations-foundation-report.md",
      "docs/reports/scheduler-policy-report.md",
      "docs/reports/linear-project-sync-summary.md",
  ):
      assert report_path in review or report_path in closeout or report_path in project_sync
      assert (bigclaw_go / report_path).exists(), report_path
  print("report navigation validation: ok")
  PY
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_bigclaw_report_navigation.py -q  # segfaulted in this workspace (exit 139)