### PR TITLE
OPE-258: refresh remaining hardening gap report register

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -132,11 +132,11 @@ This report summarizes the current event bus reliability evidence and the next r
 - No concrete durable external event log exists yet in this checkout; replay still depends on process-local history plus the documented integration plan.
 - Only the SQLite durable consumer dedup backend exists yet; HTTP and broker-backed dedup persistence still need concrete implementations.
 - No delivery acknowledgement protocol exists beyond sink-level best effort.
-- Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
+- Lease-aware checkpoint coordination is implemented for the current in-process event bus, but shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- Multi-subscriber takeover fault injection is defined in `docs/reports/multi-subscriber-takeover-validation-report.md`, but executable shared multi-node takeover validation remains follow-up work until lease coordination moves to a durable backend.
 
 ## Replicated rollout contract
 
@@ -152,7 +152,4 @@ This report summarizes the current event bus reliability evidence and the next r
 - `internal/events/log.go` now defines the provider-neutral event-log and checkpoint contract for future broker-backed adapters.
 - `internal/events/memory_log.go` provides the contract-compatible in-memory baseline while BigClaw remains on local fanout.
 - Broker-facing runtime knobs are reserved behind `BIGCLAW_EVENT_LOG_*` env vars so a first provider adapter can land without changing publish/replay/checkpoint callers.
-- No durable external event log yet; replay is process-local history.
-- No delivery acknowledgement protocol beyond sink-level best effort.
-- No partitioned topic model or cross-process subscriber coordination yet.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- The remaining backend work stays scoped to durable append/replay storage, acknowledgement semantics, and cross-process subscriber coordination without changing the current in-process contract.

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -33,9 +33,9 @@ This document maps the current local MVP implementation to the Linear rewrite is
 
 - Real `Kubernetes` API integration path is implemented and has passed live smoke validation against `kind-ray-local` using `KUBECONFIG=/Users/jxrt/.kube/ray-local-config`.
 - Real `Ray Jobs` REST integration path is implemented and has passed live smoke validation against `ray://127.0.0.1:10001` via the live dashboard Jobs API on `127.0.0.1:8265`.
-- SQLite-backed durable queue support is implemented; higher-scale external store validation is still pending.
+- SQLite-backed durable queue support is implemented; higher-scale external-store validation remains follow-up hardening beyond the current SQLite-backed proof.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof captured in `docs/reports/multi-node-coordination-report.md`.
-- Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
-- Benchmark output is local bootstrap evidence, not production-grade capacity certification.
+- Lease-aware subscriber-group checkpoint coordination is implemented for the current in-process event bus, but durable shared multi-node subscriber-group coordination and executable takeover validation remain follow-up work in `docs/reports/multi-subscriber-takeover-validation-report.md`.
+- Benchmark output is local bootstrap evidence; production-grade capacity certification remains follow-up hardening beyond the current rewrite closure.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
 - Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.

--- a/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
+++ b/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-This report captures the planned fault-injection and evidence contract for `OPE-217` before lease-aware subscriber-group checkpoint coordination is implemented.
+This report captures the remaining fault-injection and evidence contract for `OPE-217` after lease-aware subscriber-group checkpoint coordination landed for the in-process event bus, but before a durable shared multi-node coordination backend exists.
 
 ## Current Evidence Inputs
 
@@ -57,5 +57,5 @@ The canonical generated matrix lives in `docs/reports/multi-subscriber-takeover-
 ## Current Result
 
 - The repo now has a generated, reviewable scenario matrix for takeover fault injection instead of an implied TODO.
-- Existing evidence is sufficient to define the report contract, but not yet to execute the takeover scenarios end to end.
-- The next implementation slice should add lease-aware checkpoint ownership metadata and normalized audit events so the shared multi-node harness can execute this matrix directly.
+- Existing evidence is sufficient to define the report contract, but not yet to execute the takeover scenarios end to end under shared multi-node conditions.
+- The next implementation slice should carry the existing lease ownership and normalized audit semantics into a durable shared multi-node backend so the harness can execute this matrix directly.

--- a/bigclaw-go/docs/reports/queue-reliability-report.md
+++ b/bigclaw-go/docs/reports/queue-reliability-report.md
@@ -25,4 +25,8 @@ This report summarizes the current reliability evidence for the Go queue layer a
 - Queue implementations now support dead-letter retrieval and replay instead of only marking terminal failure.
 - Lease recovery and replay paths are directly testable and inspectable through the API.
 - The queue layer is materially closer to the original reliability target and is ready for another review pass.
-- A larger `10k` reliability matrix is still a reasonable next follow-up if stricter closure criteria are desired.
+
+## Follow-up hardening register
+
+- A larger `10k` reliability matrix remains a reasonable next follow-up if stricter closure criteria are desired.
+- Higher-scale external-store validation remains follow-up hardening beyond the current SQLite-backed proof.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -39,6 +39,7 @@
 
 ## Follow-up Hardening
 
-- Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
+- Production-grade capacity certification remains follow-up hardening beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
-- Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Higher-scale external-store validation remains follow-up hardening beyond the current SQLite-backed proof.
+- Lease-aware checkpoint coordination is implemented for the current in-process event bus, but durable shared multi-node subscriber-group coordination and executable takeover fault injection remain follow-up work.

--- a/tests/test_bigclaw_go_reports.py
+++ b/tests/test_bigclaw_go_reports.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import re
+from collections import Counter
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET_REPORTS = [
+    ROOT / "bigclaw-go" / "docs" / "reports" / "issue-coverage.md",
+    ROOT / "bigclaw-go" / "docs" / "reports" / "queue-reliability-report.md",
+    ROOT / "bigclaw-go" / "docs" / "reports" / "event-bus-reliability-report.md",
+    ROOT / "bigclaw-go" / "docs" / "reports" / "multi-subscriber-takeover-validation-report.md",
+    ROOT / "bigclaw-go" / "docs" / "reports" / "review-readiness.md",
+]
+REPORT_PATH_PATTERN = re.compile(r"`(docs/[^`*]+\.(?:md|json))`")
+
+
+def _resolve_repo_path(report_path: str) -> Path:
+    for candidate in (ROOT / report_path, ROOT / "bigclaw-go" / report_path):
+        if candidate.exists():
+            return candidate
+    raise AssertionError(f"missing referenced report path: {report_path}")
+
+
+def test_target_reports_reference_existing_repo_paths() -> None:
+    for report in TARGET_REPORTS:
+        content = report.read_text()
+        references = REPORT_PATH_PATTERN.findall(content)
+        assert references, f"{report} should reference at least one repo-native report path"
+        for reference in references:
+            resolved = _resolve_repo_path(reference)
+            assert resolved.exists(), f"{report} references missing path {reference}"
+
+
+def test_target_reports_do_not_repeat_bullets_verbatim() -> None:
+    for report in TARGET_REPORTS:
+        bullets = [
+            line.strip()
+            for line in report.read_text().splitlines()
+            if line.lstrip().startswith("- ")
+        ]
+        duplicates = sorted(line for line, count in Counter(bullets).items() if count > 1)
+        assert not duplicates, f"{report} repeats bullet lines: {duplicates}"


### PR DESCRIPTION
## Summary
- normalize remaining hardening wording across the issue coverage, queue reliability, event bus reliability, takeover validation, and review readiness reports
- update the takeover and event-bus docs to distinguish implemented in-process lease coordination from still-pending durable shared multi-node takeover validation
- add a repo-native guardrail test that verifies referenced report paths resolve and that these target reports do not repeat bullet lines verbatim

## Validation
- `python3 - <<'PY' ... validated target report refs and duplicate-bullet guardrail ... PY`
- `python3 -m py_compile tests/test_bigclaw_go_reports.py`
- `git diff --check`

## Notes
- `python3 -m pytest -q tests/test_bigclaw_go_reports.py` exits with status `139` in this workspace before producing test output, so equivalent guardrail assertions were run through a plain Python validation script instead.
