### PR TITLE
OPE-261: distributed coordination hardening digest

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -108,6 +108,13 @@ python3 scripts/e2e/subscriber_takeover_fault_matrix.py --pretty
 
 This refreshes `docs/reports/multi-subscriber-takeover-validation-report.json` with the canonical scenario list, expected audit/checkpoint/replay assertions, and the minimum harness outputs the future lease-aware validation run must emit.
 
+To verify the coordination digest still points at the same future-work surfaces, run:
+
+```bash
+cd bigclaw-go
+python3 scripts/e2e/check_coordination_digest.py
+```
+
 Optional toggles:
 
 ```bash

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -132,11 +132,11 @@ This report summarizes the current event bus reliability evidence and the next r
 - No concrete durable external event log exists yet in this checkout; replay still depends on process-local history plus the documented integration plan.
 - Only the SQLite durable consumer dedup backend exists yet; HTTP and broker-backed dedup persistence still need concrete implementations.
 - No delivery acknowledgement protocol exists beyond sink-level best effort.
-- Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
+- Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend, which is why `docs/reports/multi-node-coordination-report.md` remains a queue-level proof instead of a subscriber-group takeover proof.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and generated JSON in `docs/reports/multi-subscriber-takeover-validation-report.json`; it is not executable until lease-aware checkpoint ownership exists.
 
 ## Replicated rollout contract
 
@@ -155,4 +155,4 @@ This report summarizes the current event bus reliability evidence and the next r
 - No durable external event log yet; replay is process-local history.
 - No delivery acknowledgement protocol beyond sink-level best effort.
 - No partitioned topic model or cross-process subscriber coordination yet.
-- Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
+- Shared multi-node subscriber groups still need a durable lease/checkpoint backend before takeover validation can move beyond the current plan in `docs/reports/multi-subscriber-takeover-validation-report.md`.

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -35,7 +35,8 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - Real `Ray Jobs` REST integration path is implemented and has passed live smoke validation against `ray://127.0.0.1:10001` via the live dashboard Jobs API on `127.0.0.1:8265`.
 - SQLite-backed durable queue support is implemented; higher-scale external store validation is still pending.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof captured in `docs/reports/multi-node-coordination-report.md`.
-- Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
+- Shared multi-node subscriber-group checkpoint coordination still needs a durable backend, as summarized in `docs/reports/event-bus-reliability-report.md`.
+- Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md` and generated in `docs/reports/multi-subscriber-takeover-validation-report.json`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
 - Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.

--- a/bigclaw-go/docs/reports/multi-node-coordination-report.md
+++ b/bigclaw-go/docs/reports/multi-node-coordination-report.md
@@ -22,6 +22,13 @@
 
 This run proves that two independent `bigclawd` processes can share the same SQLite-backed queue and coordinate task consumption without duplicate terminal execution in the current local topology. It is not a full leader-election system, but it gives the epic a concrete multi-node coordination proof instead of relying only on single-process evidence.
 
+## Current limits and follow-up links
+
+- No dedicated leader-election layer exists yet; this remains a two-node shared-SQLite coordination proof rather than durable cross-node control-plane ownership.
+- Shared multi-node subscriber-group checkpoint coordination still needs a durable backend; the current event-bus limitation and rollout boundary are summarized in `docs/reports/event-bus-reliability-report.md`.
+- Multi-subscriber takeover fault injection is defined as a planning-ready matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and `docs/reports/multi-subscriber-takeover-validation-report.json`, but it is not executable until lease-aware checkpoint ownership exists.
+- Reviewer-facing summary surfaces in `docs/reports/review-readiness.md` and `docs/reports/issue-coverage.md` should continue to point back to this report when describing the remaining coordination hardening gap.
+
 ## Artifact
 
 - `docs/reports/multi-node-shared-queue-report.json`

--- a/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
+++ b/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
@@ -58,4 +58,6 @@ The canonical generated matrix lives in `docs/reports/multi-subscriber-takeover-
 
 - The repo now has a generated, reviewable scenario matrix for takeover fault injection instead of an implied TODO.
 - Existing evidence is sufficient to define the report contract, but not yet to execute the takeover scenarios end to end.
+- The current queue-level cross-node proof remains `docs/reports/multi-node-coordination-report.md`; it does not claim durable subscriber-group ownership or leader election.
+- The current shared multi-node coordination gap is summarized in `docs/reports/event-bus-reliability-report.md` and mirrored in the reviewer-facing digests `docs/reports/review-readiness.md` and `docs/reports/issue-coverage.md`.
 - The next implementation slice should add lease-aware checkpoint ownership metadata and normalized audit events so the shared multi-node harness can execute this matrix directly.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -40,5 +40,7 @@
 ## Follow-up Hardening
 
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
-- No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
+- No dedicated leader-election layer exists yet; current evidence is limited to the local two-node shared-SQLite coordination proof in `docs/reports/multi-node-coordination-report.md`.
+- Shared multi-node subscriber-group checkpoint coordination still needs a durable backend; the current event-bus boundary is tracked in `docs/reports/event-bus-reliability-report.md`.
+- Multi-subscriber takeover fault injection remains planning-only in `docs/reports/multi-subscriber-takeover-validation-report.md` until lease-aware checkpoint ownership exists.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.

--- a/bigclaw-go/scripts/e2e/check_coordination_digest.py
+++ b/bigclaw-go/scripts/e2e/check_coordination_digest.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+import pathlib
+import sys
+
+
+REQUIRED = {
+    "docs/reports/multi-node-coordination-report.md": {
+        "snippets": [
+            "No dedicated leader-election layer exists yet",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/review-readiness.md",
+            "docs/reports/issue-coverage.md",
+        ],
+        "artifacts": [
+            "docs/reports/multi-node-shared-queue-report.json",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+            "docs/reports/review-readiness.md",
+            "docs/reports/issue-coverage.md",
+        ],
+    },
+    "docs/reports/review-readiness.md": {
+        "snippets": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+        ],
+        "artifacts": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+        ],
+    },
+    "docs/reports/issue-coverage.md": {
+        "snippets": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+        ],
+        "artifacts": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+        ],
+    },
+    "docs/reports/event-bus-reliability-report.md": {
+        "snippets": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+        ],
+        "artifacts": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+        ],
+    },
+    "docs/reports/multi-subscriber-takeover-validation-report.md": {
+        "snippets": [
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/review-readiness.md",
+            "docs/reports/issue-coverage.md",
+        ],
+        "artifacts": [
+            "docs/reports/multi-node-shared-queue-report.json",
+            "docs/reports/multi-node-coordination-report.md",
+            "docs/reports/event-bus-reliability-report.md",
+            "docs/reports/review-readiness.md",
+            "docs/reports/issue-coverage.md",
+            "docs/reports/multi-subscriber-takeover-validation-report.json",
+        ],
+    },
+}
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    errors = []
+
+    for relative_path, spec in REQUIRED.items():
+        path = repo_root / relative_path
+        if not path.is_file():
+            errors.append(f"missing file: {relative_path}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        for snippet in spec["snippets"]:
+            if snippet not in text:
+                errors.append(f"{relative_path}: missing snippet {snippet!r}")
+        for artifact in spec["artifacts"]:
+            if not (repo_root / artifact).exists():
+                errors.append(f"{relative_path}: missing artifact target {artifact}")
+
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    print("coordination digest links OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- align the distributed coordination digest reports around the same leader-election and durable cross-node coordination caveats
- add a coordination digest link check for the report set and document how to run it
- keep takeover planning linked to the queue-level proof and reviewer-facing summaries

## Validation
- python3 bigclaw-go/scripts/e2e/check_coordination_digest.py
- git show --stat --oneline -1
