### PR TITLE
OPE-260 scale validation follow-up digest

### DIFF
--- a/bigclaw-go/docs/reports/benchmark-readiness-report.md
+++ b/bigclaw-go/docs/reports/benchmark-readiness-report.md
@@ -40,3 +40,7 @@ Every sampled task reached `task.completed`, preserved `trace_id`, and emitted `
 ## Readiness
 
 `OPE-186` now has a reproducible local matrix runner, refreshed queue/scheduler benchmark output, and four soak proof points with zero failures, including a `1k+` burst and a longer `2000x24` run. This is enough to close the current benchmark scope in Linear, while production-grade capacity certification can remain follow-up hardening work.
+
+## Follow-Up Digest
+
+- `docs/reports/scale-validation-follow-up-digest.md` consolidates the remaining queue matrix expansion, capacity-certification caveat, and longer-duration soak reviewer path.

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -34,6 +34,7 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - Real `Kubernetes` API integration path is implemented and has passed live smoke validation against `kind-ray-local` using `KUBECONFIG=/Users/jxrt/.kube/ray-local-config`.
 - Real `Ray Jobs` REST integration path is implemented and has passed live smoke validation against `ray://127.0.0.1:10001` via the live dashboard Jobs API on `127.0.0.1:8265`.
 - SQLite-backed durable queue support is implemented; higher-scale external store validation is still pending.
+- `docs/reports/scale-validation-follow-up-digest.md` consolidates the remaining scale-validation caveats across the `10k` queue matrix follow-up, the local `2000x24` soak proof, and the production-grade capacity certification gap.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof captured in `docs/reports/multi-node-coordination-report.md`.
 - Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.

--- a/bigclaw-go/docs/reports/long-duration-soak-report.md
+++ b/bigclaw-go/docs/reports/long-duration-soak-report.md
@@ -20,3 +20,7 @@ This run adds a same-day longer-duration local soak to the existing benchmark pa
 ## Artifact
 
 - `docs/reports/soak-local-2000x24.json`
+
+## Follow-Up Digest
+
+- `docs/reports/scale-validation-follow-up-digest.md` consolidates this local `2000x24` soak proof with the remaining queue and capacity-certification follow-up caveats.

--- a/bigclaw-go/docs/reports/queue-reliability-report.md
+++ b/bigclaw-go/docs/reports/queue-reliability-report.md
@@ -26,3 +26,7 @@ This report summarizes the current reliability evidence for the Go queue layer a
 - Lease recovery and replay paths are directly testable and inspectable through the API.
 - The queue layer is materially closer to the original reliability target and is ready for another review pass.
 - A larger `10k` reliability matrix is still a reasonable next follow-up if stricter closure criteria are desired.
+
+## Follow-Up Digest
+
+- `docs/reports/scale-validation-follow-up-digest.md` consolidates the remaining queue scale follow-up with the benchmark and longer-duration soak caveats.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -32,13 +32,13 @@
   - Supporting report: `docs/reports/migration-readiness-report.md`.
 - `OPE-186`
   - Benchmark evidence includes a repeatable matrix runner plus `50x8`, `100x12`, `1000x24`, and `2000x24` soak runs with zero failures.
-  - Supporting reports: `docs/reports/benchmark-readiness-report.md`, `docs/reports/benchmark-matrix-report.json`, and `docs/reports/long-duration-soak-report.md`.
+  - Supporting reports: `docs/reports/benchmark-readiness-report.md`, `docs/reports/benchmark-matrix-report.json`, `docs/reports/long-duration-soak-report.md`, and `docs/reports/scale-validation-follow-up-digest.md`.
 - `OPE-175`
   - Epic-level evidence includes longer-duration soak (`2000x24`), mixed workload validation across `local` / `kubernetes` / `ray`, and a concrete two-node shared-queue coordination proof.
   - Supporting report: `docs/reports/epic-closure-readiness-report.md`.
 
 ## Follow-up Hardening
 
-- Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
+- `docs/reports/scale-validation-follow-up-digest.md` consolidates the remaining scale follow-up, including the `10k` queue matrix expansion path, the local `2000x24` soak context, and the production-grade capacity certification caveat.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.

--- a/bigclaw-go/docs/reports/scale-validation-follow-up-digest.md
+++ b/bigclaw-go/docs/reports/scale-validation-follow-up-digest.md
@@ -1,0 +1,31 @@
+# Scale Validation Follow-Up Digest
+
+## Scope
+
+This digest consolidates the remaining scale-validation follow-up after the latest closeout wave so reviewers can inspect the queue reliability expansion path, benchmark caveats, and longer-duration soak evidence from one stable repo-native entrypoint.
+
+## Current Evidence Bundle
+
+- Queue reliability evidence is summarized in `docs/reports/queue-reliability-report.md`, including dead-letter replay, lease recovery, and the current `1k` no-duplicate-consumption proof for SQLite-backed local validation.
+- Local benchmark readiness is summarized in `docs/reports/benchmark-readiness-report.md`, including the repeatable matrix runner and the `50x8`, `100x12`, `1000x24`, and `2000x24` soak checkpoints.
+- The longer-duration local soak proof is summarized in `docs/reports/long-duration-soak-report.md` and anchored by `docs/reports/soak-local-2000x24.json`.
+
+## Remaining Scale Follow-Up
+
+- A larger `10k` queue reliability matrix remains the next queue-specific follow-up if reviewers want stricter closure criteria than the current `1k` local proof.
+- The existing benchmark and soak package is local evidence, not production-grade capacity certification.
+- The current longer-duration proof is the local `2000x24` soak run; it reduces closure risk, but it does not replace external-store validation or production rollout certification.
+
+## Reviewer Path
+
+- Start with `docs/reports/review-readiness.md` for the cross-epic review matrix.
+- Use this digest to inspect the remaining scale hardening caveats in one place.
+- Cross-check implementation and scope coverage in `docs/reports/issue-coverage.md`.
+
+## Referenced Reports
+
+- `docs/reports/queue-reliability-report.md`
+- `docs/reports/benchmark-readiness-report.md`
+- `docs/reports/long-duration-soak-report.md`
+- `docs/reports/review-readiness.md`
+- `docs/reports/issue-coverage.md`

--- a/bigclaw-go/scripts/reports/check_scale_followup_digest.py
+++ b/bigclaw-go/scripts/reports/check_scale_followup_digest.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REQUIRED_REPORTS = {
+    "docs/reports/scale-validation-follow-up-digest.md": [
+        "`10k` queue reliability matrix",
+        "production-grade capacity certification",
+        "local `2000x24` soak run",
+    ],
+    "docs/reports/queue-reliability-report.md": [
+        "docs/reports/scale-validation-follow-up-digest.md",
+    ],
+    "docs/reports/benchmark-readiness-report.md": [
+        "docs/reports/scale-validation-follow-up-digest.md",
+    ],
+    "docs/reports/long-duration-soak-report.md": [
+        "docs/reports/scale-validation-follow-up-digest.md",
+    ],
+    "docs/reports/review-readiness.md": [
+        "docs/reports/scale-validation-follow-up-digest.md",
+    ],
+    "docs/reports/issue-coverage.md": [
+        "docs/reports/scale-validation-follow-up-digest.md",
+    ],
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate the scale follow-up digest links and caveat wording.")
+    parser.add_argument(
+        "--go-root",
+        default=Path(__file__).resolve().parents[2],
+        type=Path,
+        help="Path to the bigclaw-go repository root.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    go_root = args.go_root.resolve()
+    failures: list[str] = []
+
+    for relative_path, required_snippets in REQUIRED_REPORTS.items():
+        report_path = go_root / relative_path
+        if not report_path.exists():
+            failures.append(f"missing report: {relative_path}")
+            continue
+        content = report_path.read_text(encoding="utf-8")
+        for snippet in required_snippets:
+            if snippet not in content:
+                failures.append(f"missing snippet in {relative_path}: {snippet}")
+
+    digest_path = go_root / "docs/reports/scale-validation-follow-up-digest.md"
+    if digest_path.exists():
+        digest = digest_path.read_text(encoding="utf-8")
+        referenced_paths = sorted(set(re.findall(r"`(docs/reports/[^`]+)`", digest)))
+        for reference in referenced_paths:
+            if not (go_root / reference).exists():
+                failures.append(f"digest references missing path: {reference}")
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+
+    print("scale follow-up digest check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scale_followup_digest_check.py
+++ b/tests/test_scale_followup_digest_check.py
@@ -1,0 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_scale_followup_digest_check_passes_with_aligned_reports(tmp_path: Path):
+    root = tmp_path / "bigclaw-go"
+    reports = root / "docs" / "reports"
+    reports.mkdir(parents=True)
+
+    files = {
+        "scale-validation-follow-up-digest.md": """# Scale Validation Follow-Up Digest
+
+- `docs/reports/queue-reliability-report.md`
+- `docs/reports/benchmark-readiness-report.md`
+- `docs/reports/long-duration-soak-report.md`
+- `docs/reports/soak-local-2000x24.json`
+- `docs/reports/review-readiness.md`
+- `docs/reports/issue-coverage.md`
+- A larger `10k` queue reliability matrix remains open.
+- This remains below production-grade capacity certification.
+- The current local `2000x24` soak run is the longest local proof.
+""",
+        "queue-reliability-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.\n",
+        "benchmark-readiness-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.\n",
+        "long-duration-soak-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.\n",
+        "review-readiness.md": "See `docs/reports/scale-validation-follow-up-digest.md`.\n",
+        "issue-coverage.md": "See `docs/reports/scale-validation-follow-up-digest.md`.\n",
+        "soak-local-2000x24.json": "{}\n",
+    }
+
+    for name, content in files.items():
+        (reports / name).write_text(content, encoding="utf-8")
+
+    script = Path(__file__).resolve().parents[1] / "bigclaw-go" / "scripts" / "reports" / "check_scale_followup_digest.py"
+    result = subprocess.run(
+        [sys.executable, str(script), "--go-root", str(root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "scale follow-up digest check passed" in result.stdout


### PR DESCRIPTION
## Summary
- add a dedicated scale-validation follow-up digest that consolidates the queue, benchmark, and soak caveats
- link the queue, benchmark, soak, review-readiness, and issue-coverage reports back to the digest
- add a lightweight validator plus regression coverage for digest references and canonical caveat wording

## Validation
- python3 bigclaw-go/scripts/reports/check_scale_followup_digest.py --go-root bigclaw-go
- python3 - <<'PY'
  import subprocess
  import sys
  import tempfile
  from pathlib import Path

  repo = Path.cwd()
  script = repo / "bigclaw-go" / "scripts" / "reports" / "check_scale_followup_digest.py"
  with tempfile.TemporaryDirectory() as tmp:
      root = Path(tmp) / "bigclaw-go"
      reports = root / "docs" / "reports"
      reports.mkdir(parents=True)
      files = {
          "scale-validation-follow-up-digest.md": "# Scale Validation Follow-Up Digest

- `docs/reports/queue-reliability-report.md`
- `docs/reports/benchmark-readiness-report.md`
- `docs/reports/long-duration-soak-report.md`
- `docs/reports/soak-local-2000x24.json`
- `docs/reports/review-readiness.md`
- `docs/reports/issue-coverage.md`
- A larger `10k` queue reliability matrix remains open.
- This remains below production-grade capacity certification.
- The current local `2000x24` soak run is the longest local proof.
",
          "queue-reliability-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.
",
          "benchmark-readiness-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.
",
          "long-duration-soak-report.md": "See `docs/reports/scale-validation-follow-up-digest.md`.
",
          "review-readiness.md": "See `docs/reports/scale-validation-follow-up-digest.md`.
",
          "issue-coverage.md": "See `docs/reports/scale-validation-follow-up-digest.md`.
",
          "soak-local-2000x24.json": "{}
",
      }
      for name, content in files.items():
          (reports / name).write_text(content, encoding="utf-8")
      result = subprocess.run([sys.executable, str(script), "--go-root", str(root)], capture_output=True, text=True, check=False)
      print(result.stdout.strip())
      if result.returncode != 0:
          print(result.stderr, file=sys.stderr)
          raise SystemExit(result.returncode)
  PY