### PR TITLE
OPE-263: add retention and external-store follow-up digest

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -135,6 +135,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
+- `docs/reports/retention-external-store-follow-up-digest.md` is the repo-native reviewer digest for the current SQLite-backed durability boundary, pending higher-scale external-store validation, and the replicated-backend follow-up plan.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
 

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -38,4 +38,4 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - Multi-subscriber takeover validation is planned in `docs/reports/multi-subscriber-takeover-validation-report.md`, but the underlying lease-aware subscriber-group checkpoint coordination is still pending.
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
-- Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.
+- Replay retention, compaction, aged-out checkpoint semantics, and the current SQLite-versus-replicated external-store boundary for the follow-on durability track are consolidated in `docs/reports/retention-external-store-follow-up-digest.md`, with deeper detail in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -66,6 +66,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 - `OPE-216` established the expired replay cursor semantics, `OPE-226` added the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes, and `OPE-228` extends that flow with persisted reset audit history.
 - Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
 - SQLite-backed durable logs now persist trimmed replay boundaries across restarts when a retention window is configured, giving operators a stable replay horizon even after reboot.
+- `docs/reports/retention-external-store-follow-up-digest.md` is the reviewer-facing summary for how retention semantics line up with SQLite-backed durability evidence and the remaining broker/quorum follow-up path.
 
 ## Repo evidence
 

--- a/bigclaw-go/docs/reports/retention-external-store-follow-up-digest.md
+++ b/bigclaw-go/docs/reports/retention-external-store-follow-up-digest.md
@@ -1,0 +1,55 @@
+# Retention and External-Store Follow-up Digest
+
+## Scope
+
+This digest consolidates the remaining replay-retention, external-store validation, and replicated-durability follow-up work after the latest closeout wave for `OPE-263` / `BIG-PAR-074`.
+
+It is intentionally limited to repo-native evidence and consistency checks. It does not claim new runtime behavior beyond what the linked reports and code already implement.
+
+## Current repo-backed position
+
+- Replay retention watermarks and replay horizon diagnostics are exposed through API/debug surfaces and event-log service reporting.
+- SQLite-backed event logs now persist trimmed replay boundaries across restarts when a retention window is configured, so retained replay state survives process reboot.
+- Expired durable checkpoint resumes now fail closed with explicit reset guidance, and checkpoint reset history is persisted for operator review.
+- Durable consumer dedup bootstrap exists only for SQLite-backed persistence; broader shared external-store coverage is still incomplete.
+
+## Stable evidence map
+
+- Replay retention and expired-cursor semantics: `docs/reports/replay-retention-semantics-report.md`
+- Event-bus durability shape and backend roadmap: `docs/reports/event-bus-reliability-report.md`
+- Reviewer entrypoint for current hardening caveats: `docs/reports/review-readiness.md`
+- MVP coverage and remaining honest-closeout gaps: `docs/reports/issue-coverage.md`
+- Epic-level OpenClaw comparison and remaining distributed gaps: `docs/openclaw-parallel-gap-analysis.md`
+
+## Follow-up digest
+
+### Replay retention
+
+- The retained replay window is now an explicit contract: resumability depends on the oldest retained cursor, not just whether a checkpoint payload is well formed.
+- Expired checkpoints must return diagnostics and reset guidance instead of silently resuming from a later point.
+- SQLite now preserves trimmed replay boundaries across restarts, which closes the gap for single-node durable retention evidence.
+- Memory-backed deployments remain bounded by in-process history, so replay guarantees still disappear on restart when no durable log is configured.
+
+### External-store validation
+
+- SQLite is the only concrete durable external store evidenced in this checkout for replay retention and dedup persistence.
+- Shared service or replicated backends remain planned rather than implemented, so higher-scale external-store validation is still pending beyond the SQLite-backed path.
+- Review surfaces should keep describing current evidence as SQLite-backed durability, not generic distributed durability.
+
+### Broker and quorum future work
+
+- Replicated broker or quorum-backed event-log adapters remain future work.
+- The rollout contract is documented, including publish acknowledgement, shared replay/checkpoint sequencing, retention-boundary visibility, and failover expectations.
+- No current repo evidence supports claiming cross-process replicated replay durability, partitioned topic coordination, or exactly-once delivery semantics.
+
+## Reviewer-facing conclusion
+
+- BigClaw now has explicit replay-retention diagnostics and a durable single-node SQLite path.
+- BigClaw does not yet have a validated shared or replicated external event-log backend.
+- BigClaw remains replay-safe rather than exactly-once; downstream idempotency and broader durable-store coverage are still follow-up work.
+
+## Consistency checklist
+
+- `docs/reports/replay-retention-semantics-report.md` is the canonical source for retention and expired-cursor semantics.
+- `docs/reports/event-bus-reliability-report.md` is the canonical source for backend capability, SQLite durability, and replicated-backend future work.
+- `docs/reports/review-readiness.md`, `docs/reports/issue-coverage.md`, and `docs/openclaw-parallel-gap-analysis.md` should point reviewers back to this digest instead of restating divergent caveats.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -41,4 +41,4 @@
 
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
-- Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Higher-scale external-store validation is still pending beyond the current SQLite-backed scope; the consolidated retention and durability caveats live in `docs/reports/retention-external-store-follow-up-digest.md`.

--- a/bigclaw-go/internal/reporting/retention_digest_docs_test.go
+++ b/bigclaw-go/internal/reporting/retention_digest_docs_test.go
@@ -1,0 +1,31 @@
+package reporting
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRetentionExternalStoreFollowUpDigestReferencesRequiredReports(t *testing.T) {
+	root := filepath.Join("..", "..")
+	digestPath := filepath.Join(root, "docs", "reports", "retention-external-store-follow-up-digest.md")
+	body, err := os.ReadFile(digestPath)
+	if err != nil {
+		t.Fatalf("read digest: %v", err)
+	}
+
+	requiredRefs := []string{
+		"docs/reports/replay-retention-semantics-report.md",
+		"docs/reports/event-bus-reliability-report.md",
+		"docs/reports/review-readiness.md",
+		"docs/reports/issue-coverage.md",
+		"docs/openclaw-parallel-gap-analysis.md",
+	}
+	content := string(body)
+	for _, ref := range requiredRefs {
+		if !strings.Contains(content, ref) {
+			t.Fatalf("digest missing required reference %q", ref)
+		}
+	}
+}

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -37,6 +37,7 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 - Service-style SQLite and HTTP-backed coordination improve sharing, but replicated broker or quorum-backed durability is still future work.
 - Downstream consumers still need idempotent handlers and durable dedupe stores; the system remains replay-safe, not globally exactly-once.
 - Parallel validation for Kubernetes, Ray, and shared-queue takeover should continue to be bundled as repo-native evidence.
+- `bigclaw-go/docs/reports/retention-external-store-follow-up-digest.md` consolidates the current retention and external-store boundary so reviewers can audit the SQLite-backed evidence and remaining broker/quorum work from one repo-native entrypoint.
 
 ### Current rollout gate
 


### PR DESCRIPTION
## Summary
- add a reviewer-facing digest for replay retention, SQLite-backed durability, and remaining external-store follow-up
- link the digest from the retention, event-bus, review-readiness, issue-coverage, and OpenClaw gap-analysis reports
- add a lightweight Go test that verifies the digest keeps referencing the required report surfaces

## Validation
- cd bigclaw-go && go test ./internal/reporting ./internal/events
- git rev-parse HEAD
- git rev-parse origin/dcjcloud/ope-263-big-par-074-retention-and-external-store-follow-up-digest