### PR TITLE
OPE-262: add event delivery semantics follow-up digest

### DIFF
--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -127,15 +127,22 @@ This report summarizes the current event bus reliability evidence and the next r
 - The first durable bootstrap is SQLite-backed, stores the full normalized dedup record as durable JSON, and indexes state/update timestamps so lifecycle cleanup can evolve without changing caller contracts.
 - Control-plane capability payloads expose `dedup` separately so operators can see whether replay-safe consumers are backed by durable dedup state or process memory only.
 
+## Event delivery follow-up digest
+
+- `docs/reports/event-delivery-semantics-follow-up-digest.md` is the canonical reviewer-facing summary for durable dedupe, delivery acknowledgement boundaries, and the current exactly-once limitations.
+- Replay-safe consumers still need a durable dedupe store keyed by `delivery.idempotency_key` before distributed retries or takeovers can avoid reapplying side effects.
+- No end-to-end delivery acknowledgement protocol exists beyond sink-level best-effort delivery.
+- BigClaw remains replay-safe, not globally exactly-once.
+
 ## Remaining gaps
 
 - No concrete durable external event log exists yet in this checkout; replay still depends on process-local history plus the documented integration plan.
 - Only the SQLite durable consumer dedup backend exists yet; HTTP and broker-backed dedup persistence still need concrete implementations.
-- No delivery acknowledgement protocol exists beyond sink-level best effort.
+- No end-to-end delivery acknowledgement protocol exists beyond sink-level best-effort delivery.
 - Lease coordination is currently in-memory and single-process; shared multi-node subscriber groups still need a durable backend.
 - No partitioned topic model or broker-backed cross-process subscriber coordination exists yet.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
-- Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
+- Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; BigClaw remains replay-safe, not globally exactly-once.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.
 
 ## Replicated rollout contract
@@ -153,6 +160,6 @@ This report summarizes the current event bus reliability evidence and the next r
 - `internal/events/memory_log.go` provides the contract-compatible in-memory baseline while BigClaw remains on local fanout.
 - Broker-facing runtime knobs are reserved behind `BIGCLAW_EVENT_LOG_*` env vars so a first provider adapter can land without changing publish/replay/checkpoint callers.
 - No durable external event log yet; replay is process-local history.
-- No delivery acknowledgement protocol beyond sink-level best effort.
+- See `docs/reports/event-delivery-semantics-follow-up-digest.md` for the canonical dedupe, acknowledgement, and exactly-once caveats that still constrain the next adapter.
 - No partitioned topic model or cross-process subscriber coordination yet.
 - Multi-subscriber takeover fault injection is defined only as a planned validation matrix in `docs/reports/multi-subscriber-takeover-validation-report.md` and is not executable until lease-aware checkpoint ownership exists.

--- a/bigclaw-go/docs/reports/event-delivery-semantics-follow-up-digest.md
+++ b/bigclaw-go/docs/reports/event-delivery-semantics-follow-up-digest.md
@@ -1,0 +1,28 @@
+# Event Delivery Semantics Follow-up Digest
+
+## Scope
+
+This digest consolidates the remaining event-delivery semantics for `OPE-262` so reviewers can verify the current durable dedupe, acknowledgement, and exactly-once posture from one repo-native source.
+
+## Canonical delivery contract
+
+| Topic | Current contract | Current evidence | Remaining follow-up |
+| --- | --- | --- | --- |
+| Durable dedupe | Replay-safe consumers still need a durable dedupe store keyed by `delivery.idempotency_key` before side effects can survive retries or takeover without reapplication. | `internal/events/delivery.go`, `internal/domain/consumer_dedup.go`, `internal/events/dedup_ledger.go`, `docs/reports/event-bus-reliability-report.md` | Only the SQLite durable dedupe backend exists in this checkout; HTTP and broker-backed dedupe persistence are still future work. |
+| Delivery acknowledgement | Publish and checkpoint acknowledgements currently prove transport or replay-progress boundaries only. No end-to-end delivery acknowledgement protocol exists beyond sink-level best-effort delivery. | `docs/reports/event-bus-reliability-report.md`, `docs/reports/replicated-event-log-durability-rollout-contract.md`, `docs/reports/multi-subscriber-takeover-validation-report.md` | Replicated adapters still need committed/rejected/ambiguous acknowledgement handling plus takeover-safe checkpoint ownership across nodes. |
+| Exactly-once posture | BigClaw remains replay-safe, not globally exactly-once. Durable replay, checkpointing, and dedupe reduce duplicate side effects, but they do not prove one-and-only-once business execution across distributed sinks. | `docs/openclaw-parallel-gap-analysis.md`, `docs/reports/event-bus-reliability-report.md`, `docs/reports/review-readiness.md` | Broker/quorum durability, cross-node coordination, and durable downstream dedupe need to land before a stronger exactly-once claim is even reviewable. |
+
+## Reviewer guidance
+
+- Treat `delivery.idempotency_key` as the downstream dedupe boundary, not as proof that the platform has already enforced exactly-once side effects.
+- Treat checkpoint acknowledgement as proof of replay progress for the active consumer boundary, not proof that downstream business work completed successfully.
+- Treat publish acknowledgement as a transport-level outcome that still needs replicated committed/rejected/ambiguous handling before a broker-backed adapter can be called rollout-ready.
+- Use `docs/reports/replicated-event-log-durability-rollout-contract.md` for the replicated publish/replay gate and `docs/reports/multi-subscriber-takeover-validation-report.md` for the cross-node takeover validation shape.
+
+## Linked report surfaces
+
+- `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/issue-coverage.md`
+- `docs/reports/review-readiness.md`
+- `docs/reports/multi-subscriber-takeover-validation-report.md`
+- `docs/openclaw-parallel-gap-analysis.md`

--- a/bigclaw-go/docs/reports/issue-coverage.md
+++ b/bigclaw-go/docs/reports/issue-coverage.md
@@ -39,3 +39,4 @@ This document maps the current local MVP implementation to the Linear rewrite is
 - Benchmark output is local bootstrap evidence, not production-grade capacity certification.
 - When running multiple local smoke processes with the SQLite backend, use separate `BIGCLAW_QUEUE_SQLITE_PATH` and `BIGCLAW_AUDIT_LOG_PATH` values to avoid local file-lock contention.
 - Replay retention, compaction, and aged-out checkpoint semantics for the follow-on parallel durability track are documented in `docs/reports/replay-retention-semantics-report.md` and `docs/openclaw-parallel-gap-analysis.md`.
+- Event-delivery semantics follow-up for durable dedupe, acknowledgement boundaries, and exactly-once caveats is consolidated in `docs/reports/event-delivery-semantics-follow-up-digest.md`.

--- a/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
+++ b/bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md
@@ -9,6 +9,7 @@ This report captures the planned fault-injection and evidence contract for `OPE-
 - `internal/events/bus.go`
 - `internal/events/bus_test.go`
 - `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/event-delivery-semantics-follow-up-digest.md`
 - `docs/reports/lease-recovery-report.md`
 - `scripts/e2e/multi_node_shared_queue.py`
 - `docs/reports/multi-node-shared-queue-report.json`
@@ -57,5 +58,6 @@ The canonical generated matrix lives in `docs/reports/multi-subscriber-takeover-
 ## Current Result
 
 - The repo now has a generated, reviewable scenario matrix for takeover fault injection instead of an implied TODO.
+- The delivery acknowledgement and exactly-once caveats that constrain takeover interpretation are summarized in `docs/reports/event-delivery-semantics-follow-up-digest.md`.
 - Existing evidence is sufficient to define the report contract, but not yet to execute the takeover scenarios end to end.
 - The next implementation slice should add lease-aware checkpoint ownership metadata and normalized audit events so the shared multi-node harness can execute this matrix directly.

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -42,3 +42,4 @@
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
 - Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Event-delivery semantics follow-up for durable dedupe, acknowledgement boundaries, and exactly-once caveats is consolidated in `docs/reports/event-delivery-semantics-follow-up-digest.md`.

--- a/docs/openclaw-parallel-gap-analysis.md
+++ b/docs/openclaw-parallel-gap-analysis.md
@@ -35,6 +35,7 @@ The current BigClaw Go event plane now has replay-capable APIs, subscriber-group
 
 - Replay retention watermarks are now visible in runtime payloads, SQLite-backed logs now persist trimmed replay boundaries across restarts, expired durable checkpoints now fail closed with reset guidance, and checkpoint resets now leave a persisted operator history trail; memory-only deployments are still bounded by in-process history and broker/quorum retention remains future work.
 - Service-style SQLite and HTTP-backed coordination improve sharing, but replicated broker or quorum-backed durability is still future work.
+- `bigclaw-go/docs/reports/event-delivery-semantics-follow-up-digest.md` is the canonical reviewer-facing digest for durable dedupe, acknowledgement boundaries, and the exactly-once caveat.
 - Downstream consumers still need idempotent handlers and durable dedupe stores; the system remains replay-safe, not globally exactly-once.
 - Parallel validation for Kubernetes, Ray, and shared-queue takeover should continue to be bundled as repo-native evidence.
 

--- a/tests/test_event_delivery_docs.py
+++ b/tests/test_event_delivery_docs.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DIGEST = REPO_ROOT / "bigclaw-go/docs/reports/event-delivery-semantics-follow-up-digest.md"
+LINKED_DOCS = [
+    REPO_ROOT / "bigclaw-go/docs/reports/event-bus-reliability-report.md",
+    REPO_ROOT / "bigclaw-go/docs/reports/issue-coverage.md",
+    REPO_ROOT / "bigclaw-go/docs/reports/review-readiness.md",
+    REPO_ROOT / "bigclaw-go/docs/reports/multi-subscriber-takeover-validation-report.md",
+    REPO_ROOT / "docs/openclaw-parallel-gap-analysis.md",
+]
+CANONICAL_SNIPPETS = [
+    "durable dedupe store keyed by `delivery.idempotency_key`",
+    "No end-to-end delivery acknowledgement protocol exists beyond sink-level best-effort delivery.",
+    "BigClaw remains replay-safe, not globally exactly-once.",
+]
+
+
+def test_event_delivery_digest_exists_and_links_point_to_it() -> None:
+    assert DIGEST.exists()
+    digest_rel = "docs/reports/event-delivery-semantics-follow-up-digest.md"
+    root_rel = "bigclaw-go/docs/reports/event-delivery-semantics-follow-up-digest.md"
+
+    for path in LINKED_DOCS:
+        content = path.read_text()
+        assert digest_rel in content or root_rel in content
+
+
+def test_event_delivery_digest_captures_canonical_semantics() -> None:
+    content = DIGEST.read_text()
+
+    for snippet in CANONICAL_SNIPPETS:
+        assert snippet in content
+
+
+def test_event_bus_and_gap_analysis_use_canonical_exactly_once_wording() -> None:
+    event_bus = (REPO_ROOT / "bigclaw-go/docs/reports/event-bus-reliability-report.md").read_text()
+    gap_analysis = (REPO_ROOT / "docs/openclaw-parallel-gap-analysis.md").read_text()
+
+    assert "BigClaw remains replay-safe, not globally exactly-once." in event_bus
+    assert "the system remains replay-safe, not globally exactly-once." in gap_analysis


### PR DESCRIPTION
## Summary
- add a repo-native event delivery semantics follow-up digest for dedupe, acknowledgement, and exactly-once caveats
- link the digest from the event bus, gap analysis, issue coverage, review readiness, and takeover validation reports
- add a lightweight docs contract test for the digest links and canonical wording

## Validation
- PYTHONPATH=src python3 - <<'PY' ... tests/test_event_delivery_docs.py ... PY