### PR TITLE
OPE-268: expand continuation refill queue batch

### DIFF
--- a/docs/parallel-refill-queue.json
+++ b/docs/parallel-refill-queue.json
@@ -7,7 +7,7 @@
     "epic": "OPE-187"
   },
   "policy": {
-    "target_in_progress": 2,
+    "target_in_progress": 4,
     "activate_state_name": "In Progress",
     "activate_state_id": "bd8aafe7-4d8b-41aa-a85b-13e76d49ead7",
     "refill_states": [
@@ -63,78 +63,95 @@
       "OPE-258",
       "OPE-259",
       "OPE-260",
-      "OPE-261"
+      "OPE-261",
+      "OPE-262",
+      "OPE-263",
+      "OPE-264",
+      "OPE-265",
+      "OPE-266",
+      "OPE-267",
+      "OPE-275"
     ],
     "active": [
-      "OPE-262",
-      "OPE-263"
+      "OPE-271",
+      "OPE-270",
+      "OPE-269",
+      "OPE-268"
     ],
     "standby": []
   },
   "issue_order": [
-    "OPE-262",
-    "OPE-263"
+    "OPE-271",
+    "OPE-270",
+    "OPE-269",
+    "OPE-268"
   ],
   "issues": [
-    {
-      "identifier": "OPE-254",
-      "title": "BIG-PAR-065 long-duration soak and benchmark closeout refresh",
-      "track": "Soak & Benchmark Closeout",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-255",
-      "title": "BIG-PAR-066 operations foundation evidence alignment refresh",
-      "track": "Operations Foundation",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-256",
-      "title": "BIG-PAR-067 scheduler policy and routing closeout refresh",
-      "track": "Scheduler Policy Closeout",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-257",
-      "title": "BIG-PAR-068 review matrix and closeout navigation refresh",
-      "track": "Review & Closeout Navigation",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-258",
-      "title": "BIG-PAR-069 remaining hardening gap register refresh",
-      "track": "Hardening Gap Register",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-259",
-      "title": "BIG-PAR-070 follow-up roadmap and gap-analysis refresh",
-      "track": "Roadmap & Gap Analysis",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-260",
-      "title": "BIG-PAR-071 scale validation follow-up digest",
-      "track": "Scale Validation Follow-up",
-      "status": "Done"
-    },
-    {
-      "identifier": "OPE-261",
-      "title": "BIG-PAR-072 distributed coordination hardening digest",
-      "track": "Coordination Hardening",
-      "status": "Done"
-    },
     {
       "identifier": "OPE-262",
       "title": "BIG-PAR-073 event delivery semantics follow-up digest",
       "track": "Delivery Semantics Follow-up",
-      "status": "In Progress"
+      "status": "Done"
     },
     {
       "identifier": "OPE-263",
       "title": "BIG-PAR-074 retention and external-store follow-up digest",
       "track": "Retention & External Store",
+      "status": "Done"
+    },
+    {
+      "identifier": "OPE-264",
+      "title": "BIG-PAR-075 observability tracing backend follow-up digest",
+      "track": "Tracing Backend Follow-up",
+      "status": "Done"
+    },
+    {
+      "identifier": "OPE-265",
+      "title": "BIG-PAR-076 telemetry pipeline controls follow-up digest",
+      "track": "Telemetry Pipeline Follow-up",
+      "status": "Done"
+    },
+    {
+      "identifier": "OPE-266",
+      "title": "BIG-PAR-077 live shadow traffic comparison follow-up digest",
+      "track": "Live Shadow Comparison Follow-up",
+      "status": "Done"
+    },
+    {
+      "identifier": "OPE-267",
+      "title": "BIG-PAR-078 rollback safeguard follow-up digest",
+      "track": "Rollback Safeguards Follow-up",
+      "status": "Done"
+    },
+    {
+      "identifier": "OPE-268",
+      "title": "BIG-PAR-091 Symphony refill queue expansion for parallel continuation slices",
+      "track": "Parallel Refill Queue Expansion",
       "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-269",
+      "title": "BIG-PAR-090 continuation history window and stale-bundle policy controls",
+      "track": "Continuation History Window",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-270",
+      "title": "BIG-PAR-089 shared-queue companion summary in validation bundles",
+      "track": "Shared Queue Companion Summary",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-271",
+      "title": "BIG-PAR-088 workflow-enforced continuation gate for closeout",
+      "track": "Continuation Gate Closeout",
+      "status": "In Progress"
+    },
+    {
+      "identifier": "OPE-275",
+      "title": "BIG-PAR-083 production corpus replay pack and migration coverage scorecard",
+      "track": "Production Corpus Migration Coverage",
+      "status": "Done"
     }
   ]
 }

--- a/docs/parallel-refill-queue.md
+++ b/docs/parallel-refill-queue.md
@@ -15,11 +15,12 @@ manual operator can refill the next parallel-safe issues in a stable order.
 
 ## Policy
 
-- Keep at least `2` issues in `In Progress`.
+- Keep at least `4` issues in `In Progress` for the current continuation batch.
 - Promote only issues currently in `Backlog` or `Todo`.
 - Use the queue order below as the single source of truth for refill priority.
 - Every substantive code-bearing update must be committed and pushed to GitHub immediately, with local/remote SHA equality verification after each push.
 - Use `Backlog` for future standby slices; Symphony actively tracks `Todo` as runnable work.
+- Shared mirror / seed bootstrap remains mandatory for Symphony workspace creation so continuation slices reuse one local clone cache instead of re-downloading the repository per issue.
 
 ## Recent batches
 
@@ -71,13 +72,24 @@ manual operator can refill the next parallel-safe issues in a stable order.
   - `OPE-259` — follow-up roadmap and gap-analysis refresh
   - `OPE-260` — scale validation follow-up digest
   - `OPE-261` — distributed coordination hardening digest
-- Active:
   - `OPE-262` — event delivery semantics follow-up digest
   - `OPE-263` — retention and external-store follow-up digest
+  - `OPE-264` — observability tracing backend follow-up digest
+  - `OPE-265` — telemetry pipeline controls follow-up digest
+  - `OPE-266` — live shadow traffic comparison follow-up digest
+  - `OPE-267` — rollback safeguard follow-up digest
+  - `OPE-275` — production corpus replay pack and migration coverage scorecard
+- Active:
+  - `OPE-271` — workflow-enforced continuation gate for closeout
+  - `OPE-270` — shared-queue companion summary in validation bundles
+  - `OPE-269` — continuation history window and stale-bundle policy controls
+  - `OPE-268` — Symphony refill queue expansion for parallel continuation slices
 - Standby:
   - None currently; create the next standby slice after one active item closes.
 
 ## Canonical refill order
 
-1. `OPE-262`
-2. `OPE-263`
+1. `OPE-271`
+2. `OPE-270`
+3. `OPE-269`
+4. `OPE-268`

--- a/tests/test_parallel_refill.py
+++ b/tests/test_parallel_refill.py
@@ -7,21 +7,22 @@ def test_parallel_refill_queue_records_unique_identifiers() -> None:
     identifiers = queue.issue_identifiers()
 
     assert queue.project_slug() == "8a198fec793e"
-    assert queue.target_in_progress() == 2
+    assert queue.target_in_progress() == 4
     assert len(identifiers) == len(set(identifiers))
-    assert queue.issue_order()[:3] == ["OPE-233", "OPE-234", "OPE-235"]
+    assert queue.issue_order() == ["OPE-271", "OPE-270", "OPE-269", "OPE-268"]
 
 
-def test_parallel_refill_queue_selects_next_backlog_issue() -> None:
+def test_parallel_refill_queue_selects_next_continuation_slices_in_order() -> None:
     queue = ParallelIssueQueue("docs/parallel-refill-queue.json")
     issue_states = issue_state_map(
         [
-            {"identifier": "OPE-233", "state": {"name": "In Progress"}},
-            {"identifier": "OPE-234", "state": {"name": "Todo"}},
-            {"identifier": "OPE-235", "state": {"name": "Backlog"}},
+            {"identifier": "OPE-271", "state": {"name": "In Progress"}},
+            {"identifier": "OPE-270", "state": {"name": "In Progress"}},
+            {"identifier": "OPE-269", "state": {"name": "Todo"}},
+            {"identifier": "OPE-268", "state": {"name": "Backlog"}},
         ]
     )
 
-    candidates = queue.select_candidates({"OPE-233"}, issue_states)
+    candidates = queue.select_candidates({"OPE-271", "OPE-270"}, issue_states)
 
-    assert candidates == ["OPE-234"]
+    assert candidates == ["OPE-269", "OPE-268"]

--- a/workflow.md
+++ b/workflow.md
@@ -63,12 +63,14 @@ Primary operating mode:
 - Keep each parallel slice small, code-backed, and independently verifiable.
 - Use `docs/parallel-refill-queue.json` as the canonical refill order and `scripts/ops/bigclaw_refill_queue.py` as the reusable manual/automated refill entrypoint.
 - Mirror `elixir/WORKFLOW.md`'s unattended posture: keep ticket state current, keep GitHub current throughout execution, and avoid leaving active work without a synced branch state.
+- Treat the shared mirror / seed bootstrap path as mandatory for Symphony workspaces so continuation slices reuse one local clone cache instead of fetching the repository repeatedly.
 
 Hook-backed GitHub sync:
-- Workspace `after_create` installs repository Git hooks immediately after clone.
+- Workspace `after_create` uses the repo-agnostic `scripts/ops/symphony_workspace_bootstrap.py` template, with repo URL, branch, and cache location supplied through `SYMPHONY_BOOTSTRAP_*` env vars.
 - Workspace `before_run` re-applies `core.hooksPath=.githooks` and auto-pushes any clean unsynced branch head at the start of every turn.
 - Repository `.githooks/post-commit` and `.githooks/post-rewrite` automatically push the active branch and verify local/remote SHA equality after each commit or amend.
 - Workspace `after_run` emits a final sync audit and flags dirty or unsynced workspaces in Symphony logs.
+- Workspace `before_remove` prunes the issue worktree from the shared seed repo so issue cleanup does not leave behind worktree metadata.
 - Use `BIGCLAW_SKIP_AUTO_SYNC=1` only for exceptional local recovery flows; normal issue execution must leave auto-sync enabled.
 
 Execution protocol:


### PR DESCRIPTION
## Summary
- raise the repo-native refill target to the current four-slice continuation batch
- record the active continuation issue order in the queue manifest and human-readable guide
- refresh workflow guidance and regression checks so queue ordering drift is caught in-repo

## Validation
- python3 -m json.tool docs/parallel-refill-queue.json
- PYTHONPATH=src python3 - <<'PY'
from bigclaw.parallel_refill import ParallelIssueQueue, issue_state_map
q = ParallelIssueQueue('docs/parallel-refill-queue.json')
assert q.target_in_progress() == 4
assert q.issue_order() == ['OPE-271', 'OPE-270', 'OPE-269', 'OPE-268']
assert q.select_candidates({'OPE-271', 'OPE-270'}, issue_state_map([
    {'identifier': 'OPE-271', 'state': {'name': 'In Progress'}},
    {'identifier': 'OPE-270', 'state': {'name': 'In Progress'}},
    {'identifier': 'OPE-269', 'state': {'name': 'Todo'}},
    {'identifier': 'OPE-268', 'state': {'name': 'Backlog'}},
])) == ['OPE-269', 'OPE-268']
PY
- git diff --check