### PR TITLE
OPE-269: add validation bundle continuation freshness policy

### DIFF
--- a/bigclaw-go/README.md
+++ b/bigclaw-go/README.md
@@ -78,11 +78,12 @@ This bootstrap now covers an MVP slice for all current Go rewrite planning ticke
 
 ## End-to-end scripts
 
-- `scripts/e2e/run_all.sh` runs local SQLite, Kubernetes, and Ray validation concurrently, writes a timestamped bundle under `docs/reports/live-validation-runs/`, and refreshes `docs/reports/live-validation-summary.json` plus `docs/reports/live-validation-index.md`
+- `scripts/e2e/run_all.sh` runs local SQLite, Kubernetes, and Ray validation concurrently, writes a timestamped bundle under `docs/reports/live-validation-runs/`, and refreshes `docs/reports/live-validation-summary.json`, `docs/reports/live-validation-index.md`, plus `docs/reports/validation-bundle-continuation-scorecard.json`
 - `scripts/e2e/kubernetes_smoke.sh` runs a real Kubernetes smoke task through BigClaw
 - `scripts/e2e/ray_smoke.sh` runs a real Ray Jobs API smoke task through BigClaw
 - `scripts/e2e/run_task_smoke.py` is the generic submit/poll helper used by all wrappers
-- `scripts/e2e/export_validation_bundle.py` exports repo-native evidence bundles, latest report copies, and the validation index
+- `scripts/e2e/export_validation_bundle.py` exports repo-native evidence bundles, latest report copies, the validation index, and continuation freshness policy
+- `scripts/e2e/validation_bundle_continuation_scorecard.py` scores the recent validation bundle window so closeout can distinguish fresh evidence from stale or incomplete bundles
 - `scripts/migration/shadow_compare.py` compares primary vs shadow BigClaw endpoints
 - `scripts/benchmark/run_suite.sh` regenerates benchmark evidence
 - Full instructions live in `docs/e2e-validation.md` and `docs/migration-shadow.md`

--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -57,7 +57,22 @@ export BIGCLAW_QUEUE_BACKEND=sqlite
 ./scripts/e2e/run_all.sh
 ```
 
-The script writes a consolidated summary to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, and creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`.
+The script writes a consolidated summary to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`, and regenerates `docs/reports/validation-bundle-continuation-scorecard.json`.
+
+The continuation scorecard is the closeout policy surface:
+
+- `history_window` bounds how many recent bundles are considered when reviewing continuation evidence.
+- `stale_after_hours` marks aged evidence as stale even if the latest run succeeded.
+- `stale_bundle=true` means the latest bundle is too old, failed, or incomplete for at least one enabled lane.
+- `ready_for_closeout=true` means the latest bundle is both fresh enough and complete enough for workflow closeout.
+
+You can tune the policy window without editing code:
+
+```bash
+export BIGCLAW_E2E_CONTINUATION_HISTORY_WINDOW=5
+export BIGCLAW_E2E_CONTINUATION_STALE_AFTER_HOURS=12
+./scripts/e2e/run_all.sh
+```
 
 ## Mixed workload matrix
 

--- a/bigclaw-go/docs/reports/live-validation-index.json
+++ b/bigclaw-go/docs/reports/live-validation-index.json
@@ -617,7 +617,17 @@
       "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
       "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
     },
-    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+    "continuation_policy": {
+      "scorecard_path": "docs/reports/validation-bundle-continuation-scorecard.json",
+      "history_window": 3,
+      "stale_after_hours": 24.0,
+      "stale_bundle": true,
+      "stale_reasons": [
+        "bundle_age_exceeds_threshold"
+      ],
+      "ready_for_closeout": false
+    }
   },
   "recent_runs": [
     {

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -41,6 +41,15 @@
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl`
 - Task ID: `ray-smoke-1773506812`
 
+## Continuation policy
+
+- Scorecard: `docs/reports/validation-bundle-continuation-scorecard.json`
+- History window: `3`
+- Stale after hours: `24.0`
+- Latest bundle stale: `True`
+- Ready for closeout: `False`
+- Stale reasons: `bundle_age_exceeds_threshold`
+
 ## Workflow closeout commands
 
 - `cd bigclaw-go && ./scripts/e2e/run_all.sh`

--- a/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/README.md
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/README.md
@@ -41,6 +41,15 @@
 - Audit log: `docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl`
 - Task ID: `ray-smoke-1773506812`
 
+## Continuation policy
+
+- Scorecard: `docs/reports/validation-bundle-continuation-scorecard.json`
+- History window: `3`
+- Stale after hours: `24.0`
+- Latest bundle stale: `True`
+- Ready for closeout: `False`
+- Stale reasons: `bundle_age_exceeds_threshold`
+
 ## Workflow closeout commands
 
 - `cd bigclaw-go && ./scripts/e2e/run_all.sh`

--- a/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/summary.json
@@ -616,5 +616,15 @@
     "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
     "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
   },
-  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+  "continuation_policy": {
+    "scorecard_path": "docs/reports/validation-bundle-continuation-scorecard.json",
+    "history_window": 3,
+    "stale_after_hours": 24.0,
+    "stale_bundle": true,
+    "stale_reasons": [
+      "bundle_age_exceeds_threshold"
+    ],
+    "ready_for_closeout": false
+  }
 }

--- a/bigclaw-go/docs/reports/live-validation-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-summary.json
@@ -616,5 +616,15 @@
     "audit_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.audit.jsonl",
     "service_log_path": "docs/reports/live-validation-runs/20260314T164647Z/ray.service.log"
   },
-  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json"
+  "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+  "continuation_policy": {
+    "scorecard_path": "docs/reports/validation-bundle-continuation-scorecard.json",
+    "history_window": 3,
+    "stale_after_hours": 24.0,
+    "stale_bundle": true,
+    "stale_reasons": [
+      "bundle_age_exceeds_threshold"
+    ],
+    "ready_for_closeout": false
+  }
 }

--- a/bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json
+++ b/bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json
@@ -1,0 +1,106 @@
+{
+  "generated_at": "2026-03-16T14:50:50.300410+00:00",
+  "history_window": 3,
+  "stale_after_hours": 24.0,
+  "required_components": [
+    "local",
+    "kubernetes",
+    "ray"
+  ],
+  "latest_run_id": "20260314T164647Z",
+  "latest_bundle_policy": {
+    "run_id": "20260314T164647Z",
+    "generated_at": "2026-03-14T16:46:57.671520+00:00",
+    "status": "succeeded",
+    "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
+    "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+    "age_hours": 46.065,
+    "components": {
+      "local": {
+        "enabled": true,
+        "status": "succeeded"
+      },
+      "kubernetes": {
+        "enabled": true,
+        "status": "succeeded"
+      },
+      "ray": {
+        "enabled": true,
+        "status": "succeeded"
+      }
+    },
+    "missing_components": [],
+    "failing_components": [],
+    "disabled_components": [],
+    "stale_bundle": true,
+    "stale_reasons": [
+      "bundle_age_exceeds_threshold"
+    ],
+    "ready_for_closeout": false
+  },
+  "window_runs": [
+    {
+      "run_id": "20260314T164647Z",
+      "generated_at": "2026-03-14T16:46:57.671520+00:00",
+      "status": "succeeded",
+      "bundle_path": "docs/reports/live-validation-runs/20260314T164647Z",
+      "summary_path": "docs/reports/live-validation-runs/20260314T164647Z/summary.json",
+      "age_hours": 46.065,
+      "components": {
+        "local": {
+          "enabled": true,
+          "status": "succeeded"
+        },
+        "kubernetes": {
+          "enabled": true,
+          "status": "succeeded"
+        },
+        "ray": {
+          "enabled": true,
+          "status": "succeeded"
+        }
+      },
+      "missing_components": [],
+      "failing_components": [],
+      "disabled_components": [],
+      "stale_bundle": true,
+      "stale_reasons": [
+        "bundle_age_exceeds_threshold"
+      ],
+      "ready_for_closeout": false
+    },
+    {
+      "run_id": "20260314T163430Z",
+      "generated_at": "2026-03-14T16:34:42.080370+00:00",
+      "status": "succeeded",
+      "bundle_path": "docs/reports/live-validation-runs/20260314T163430Z",
+      "summary_path": "docs/reports/live-validation-runs/20260314T163430Z/summary.json",
+      "age_hours": 46.269,
+      "components": {
+        "local": {
+          "enabled": true,
+          "status": "succeeded"
+        },
+        "kubernetes": {
+          "enabled": true,
+          "status": "succeeded"
+        },
+        "ray": {
+          "enabled": false,
+          "status": "skipped"
+        }
+      },
+      "missing_components": [],
+      "failing_components": [],
+      "disabled_components": [
+        "ray"
+      ],
+      "stale_bundle": true,
+      "stale_reasons": [
+        "bundle_age_exceeds_threshold",
+        "component_disabled:ray"
+      ],
+      "ready_for_closeout": false
+    }
+  ]
+}

--- a/bigclaw-go/scripts/e2e/export_validation_bundle.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
+from validation_bundle_continuation_scorecard import build_scorecard, write_json as write_scorecard_json
+
 
 LATEST_REPORTS = {
     'local': 'docs/reports/sqlite-smoke-report.json',
@@ -35,6 +37,8 @@ def relpath(path: Path, root: Path) -> str:
 def copy_text_artifact(source: Path, destination: Path) -> str:
     if not source.exists():
         return ''
+    if source.resolve() == destination.resolve():
+        return str(destination)
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
     return str(destination)
@@ -43,6 +47,8 @@ def copy_text_artifact(source: Path, destination: Path) -> str:
 def copy_json_artifact(source: Path, destination: Path) -> str:
     if not source.exists():
         return ''
+    if source.resolve() == destination.resolve():
+        return str(destination)
     payload = read_json(source)
     if payload is None:
         return ''
@@ -181,6 +187,19 @@ def render_index(summary: dict[str, Any], recent_runs: list[dict[str, Any]]) -> 
             lines.append(f"- Task ID: `{section['task_id']}`")
         lines.append('')
 
+    continuation = summary.get('continuation_policy')
+    if isinstance(continuation, dict):
+        lines.extend(['## Continuation policy', ''])
+        lines.append(f"- Scorecard: `{continuation.get('scorecard_path', '')}`")
+        lines.append(f"- History window: `{continuation.get('history_window', '')}`")
+        lines.append(f"- Stale after hours: `{continuation.get('stale_after_hours', '')}`")
+        lines.append(f"- Latest bundle stale: `{continuation.get('stale_bundle', '')}`")
+        lines.append(f"- Ready for closeout: `{continuation.get('ready_for_closeout', '')}`")
+        stale_reasons = continuation.get('stale_reasons') or []
+        if stale_reasons:
+            lines.append(f"- Stale reasons: `{', '.join(stale_reasons)}`")
+        lines.append('')
+
     lines.extend(['## Workflow closeout commands', ''])
     for command in summary['closeout_commands']:
         lines.append(f'- `{command}`')
@@ -208,6 +227,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('--run-local', default='1')
     parser.add_argument('--run-kubernetes', default='1')
     parser.add_argument('--run-ray', default='1')
+    parser.add_argument('--continuation-history-window', type=int, default=3)
+    parser.add_argument('--continuation-stale-after-hours', type=float, default=24.0)
+    parser.add_argument(
+        '--continuation-scorecard-path',
+        default='docs/reports/validation-bundle-continuation-scorecard.json',
+    )
     parser.add_argument('--validation-status', default='0')
     parser.add_argument('--local-report-path', required=True)
     parser.add_argument('--local-stdout-path', required=True)
@@ -226,10 +251,14 @@ def main() -> int:
     root = Path(args.go_root).resolve()
     bundle_dir = (root / args.bundle_dir).resolve()
     bundle_dir.mkdir(parents=True, exist_ok=True)
+    existing_bundle_summary = read_json(bundle_dir / 'summary.json')
+    existing_generated_at = None
+    if isinstance(existing_bundle_summary, dict) and existing_bundle_summary.get('run_id') == args.run_id:
+        existing_generated_at = existing_bundle_summary.get('generated_at')
 
     summary = {
         'run_id': args.run_id,
-        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'generated_at': existing_generated_at or datetime.now(timezone.utc).isoformat(),
         'status': 'succeeded' if args.validation_status == '0' else 'failed',
         'bundle_path': relpath(bundle_dir, root),
         'closeout_commands': [
@@ -274,6 +303,25 @@ def main() -> int:
 
     bundle_root = bundle_dir.parent
     recent_runs = build_recent_runs(bundle_root, root)
+    scorecard = build_scorecard(
+        root=root,
+        bundle_root=bundle_root,
+        history_window=max(args.continuation_history_window, 1),
+        stale_after_hours=max(args.continuation_stale_after_hours, 0.0),
+        required_components=('local', 'kubernetes', 'ray'),
+    )
+    write_scorecard_json(root / args.continuation_scorecard_path, scorecard)
+    latest_policy = scorecard['latest_bundle_policy']
+    summary['continuation_policy'] = {
+        'scorecard_path': args.continuation_scorecard_path,
+        'history_window': scorecard['history_window'],
+        'stale_after_hours': scorecard['stale_after_hours'],
+        'stale_bundle': latest_policy['stale_bundle'],
+        'stale_reasons': latest_policy['stale_reasons'],
+        'ready_for_closeout': latest_policy['ready_for_closeout'],
+    }
+    write_json(bundle_summary_path, summary)
+    write_json(canonical_summary_path, summary)
     manifest = {'latest': summary, 'recent_runs': recent_runs}
     write_json(root / args.manifest_path, manifest)
 

--- a/bigclaw-go/scripts/e2e/run_all.sh
+++ b/bigclaw-go/scripts/e2e/run_all.sh
@@ -10,6 +10,8 @@ BUNDLE_DIR_REL="${ARTIFACT_ROOT_REL}/${RUN_ID}"
 RUN_LOCAL="${BIGCLAW_E2E_RUN_LOCAL:-1}"
 RUN_KUBERNETES="${BIGCLAW_E2E_RUN_KUBERNETES:-1}"
 RUN_RAY="${BIGCLAW_E2E_RUN_RAY:-1}"
+CONTINUATION_HISTORY_WINDOW="${BIGCLAW_E2E_CONTINUATION_HISTORY_WINDOW:-3}"
+CONTINUATION_STALE_AFTER_HOURS="${BIGCLAW_E2E_CONTINUATION_STALE_AFTER_HOURS:-24}"
 
 mkdir -p "$ROOT/$BUNDLE_DIR_REL"
 
@@ -72,6 +74,8 @@ python3 "$ROOT/scripts/e2e/export_validation_bundle.py" \
   --run-local "$RUN_LOCAL" \
   --run-kubernetes "$RUN_KUBERNETES" \
   --run-ray "$RUN_RAY" \
+  --continuation-history-window "$CONTINUATION_HISTORY_WINDOW" \
+  --continuation-stale-after-hours "$CONTINUATION_STALE_AFTER_HOURS" \
   --validation-status "$status" \
   --local-report-path "$LOCAL_REPORT_REL" \
   --local-stdout-path "$LOCAL_OUT" \

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_REQUIRED_COMPONENTS = ("local", "kubernetes", "ray")
+
+
+def read_json(path: Path) -> Any:
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def relpath(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def component_snapshot(summary: dict[str, Any], component: str) -> dict[str, Any]:
+    section = summary.get(component)
+    if not isinstance(section, dict):
+        return {"enabled": False, "status": "missing_component"}
+    enabled = bool(section.get("enabled", False))
+    status = str(section.get("status", "unknown"))
+    return {"enabled": enabled, "status": status}
+
+
+def evaluate_run(
+    *,
+    summary: dict[str, Any],
+    root: Path,
+    stale_after_hours: float,
+    required_components: tuple[str, ...],
+    now: datetime,
+) -> dict[str, Any]:
+    generated_at = parse_timestamp(summary.get("generated_at"))
+    age_hours = None
+    stale_for_age = False
+    if generated_at is not None:
+        age_hours = round((now - generated_at).total_seconds() / 3600, 3)
+        stale_for_age = age_hours > stale_after_hours
+
+    components = {name: component_snapshot(summary, name) for name in required_components}
+    missing_components = [name for name, component in components.items() if component["enabled"] and component["status"] == "missing_report"]
+    failing_components = [
+        name
+        for name, component in components.items()
+        if component["enabled"] and component["status"] not in {"succeeded", "skipped"}
+    ]
+    disabled_components = [name for name, component in components.items() if not component["enabled"]]
+
+    stale_reasons: list[str] = []
+    if stale_for_age:
+        stale_reasons.append("bundle_age_exceeds_threshold")
+    if str(summary.get("status")) != "succeeded":
+        stale_reasons.append("bundle_status_not_succeeded")
+    stale_reasons.extend(f"component_incomplete:{name}" for name in failing_components)
+    stale_reasons.extend(f"component_disabled:{name}" for name in disabled_components)
+
+    bundle_path = summary.get("bundle_path")
+    if isinstance(bundle_path, str) and bundle_path:
+        summary_path = str((root / bundle_path / "summary.json"))
+    else:
+        summary_path = ""
+
+    return {
+        "run_id": str(summary.get("run_id", "")),
+        "generated_at": summary.get("generated_at", ""),
+        "status": str(summary.get("status", "unknown")),
+        "bundle_path": bundle_path or "",
+        "summary_path": relpath(Path(summary_path), root) if summary_path else "",
+        "age_hours": age_hours,
+        "components": components,
+        "missing_components": missing_components,
+        "failing_components": failing_components,
+        "disabled_components": disabled_components,
+        "stale_bundle": bool(stale_reasons),
+        "stale_reasons": stale_reasons,
+        "ready_for_closeout": not stale_reasons,
+    }
+
+
+def load_recent_runs(bundle_root: Path, history_window: int) -> list[dict[str, Any]]:
+    runs: list[tuple[datetime, dict[str, Any]]] = []
+    if not bundle_root.exists():
+        return []
+    for child in bundle_root.iterdir():
+        if not child.is_dir():
+            continue
+        summary = read_json(child / "summary.json")
+        if not isinstance(summary, dict):
+            continue
+        generated_at = parse_timestamp(summary.get("generated_at")) or datetime.min.replace(tzinfo=timezone.utc)
+        runs.append((generated_at, summary))
+    runs.sort(key=lambda item: item[0], reverse=True)
+    return [summary for _, summary in runs[:history_window]]
+
+
+def build_scorecard(
+    *,
+    root: Path,
+    bundle_root: Path,
+    history_window: int,
+    stale_after_hours: float,
+    required_components: tuple[str, ...],
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    recent_summaries = load_recent_runs(bundle_root, history_window)
+    runs = [
+        evaluate_run(
+            summary=summary,
+            root=root,
+            stale_after_hours=stale_after_hours,
+            required_components=required_components,
+            now=now,
+        )
+        for summary in recent_summaries
+    ]
+    latest = runs[0] if runs else None
+    return {
+        "generated_at": now.isoformat(),
+        "history_window": history_window,
+        "stale_after_hours": stale_after_hours,
+        "required_components": list(required_components),
+        "latest_run_id": latest["run_id"] if latest else "",
+        "latest_bundle_policy": latest
+        or {
+            "run_id": "",
+            "status": "missing",
+            "stale_bundle": True,
+            "stale_reasons": ["no_validation_bundles_found"],
+            "ready_for_closeout": False,
+        },
+        "window_runs": runs,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Score validation bundle continuation freshness across recent runs")
+    parser.add_argument("--go-root", required=True)
+    parser.add_argument("--bundle-root", default="docs/reports/live-validation-runs")
+    parser.add_argument("--history-window", type=int, default=3)
+    parser.add_argument("--stale-after-hours", type=float, default=24.0)
+    parser.add_argument(
+        "--required-components",
+        nargs="*",
+        default=list(DEFAULT_REQUIRED_COMPONENTS),
+    )
+    parser.add_argument(
+        "--output-path",
+        default="docs/reports/validation-bundle-continuation-scorecard.json",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.go_root).resolve()
+    scorecard = build_scorecard(
+        root=root,
+        bundle_root=root / args.bundle_root,
+        history_window=max(args.history_window, 1),
+        stale_after_hours=max(args.stale_after_hours, 0.0),
+        required_components=tuple(args.required_components or DEFAULT_REQUIRED_COMPONENTS),
+    )
+    output_path = root / args.output_path
+    write_json(output_path, scorecard)
+    print(json.dumps(scorecard, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_parallel_validation_bundle.py
+++ b/tests/test_parallel_validation_bundle.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -12,6 +13,7 @@ def write_json(path: Path, payload: dict) -> None:
 def test_export_validation_bundle_generates_latest_reports_and_index(tmp_path: Path):
     root = tmp_path / 'repo'
     bundle = root / 'docs' / 'reports' / 'live-validation-runs' / '20260315T120000Z'
+    previous_bundle = root / 'docs' / 'reports' / 'live-validation-runs' / '20260314T120000Z'
     state_dir = tmp_path / 'state-local'
     state_dir.mkdir(parents=True)
     (state_dir / 'audit.jsonl').write_text('{"event":"ok"}\n', encoding='utf-8')
@@ -27,7 +29,18 @@ def test_export_validation_bundle_generates_latest_reports_and_index(tmp_path: P
     }
     write_json(bundle / 'sqlite-smoke-report.json', local_report)
     write_json(bundle / 'kubernetes-live-smoke-report.json', {'task': {'id': 'k8s-1'}, 'status': {'state': 'succeeded'}})
-    write_json(bundle / 'ray-live-smoke-report.json', {'task': {'id': 'ray-1'}, 'status': {'state': 'succeeded'}})
+    write_json(
+        previous_bundle / 'summary.json',
+        {
+            'run_id': '20260314T120000Z',
+            'generated_at': (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat(),
+            'status': 'succeeded',
+            'bundle_path': 'docs/reports/live-validation-runs/20260314T120000Z',
+            'local': {'enabled': True, 'status': 'succeeded'},
+            'kubernetes': {'enabled': True, 'status': 'succeeded'},
+            'ray': {'enabled': True, 'status': 'succeeded'},
+        },
+    )
 
     local_stdout = tmp_path / 'local.stdout'
     local_stderr = tmp_path / 'local.stderr'
@@ -59,6 +72,8 @@ def test_export_validation_bundle_generates_latest_reports_and_index(tmp_path: P
             '--run-local', '1',
             '--run-kubernetes', '1',
             '--run-ray', '1',
+            '--continuation-history-window', '2',
+            '--continuation-stale-after-hours', '24',
             '--validation-status', '0',
             '--local-report-path', 'docs/reports/live-validation-runs/20260315T120000Z/sqlite-smoke-report.json',
             '--local-stdout-path', str(local_stdout),
@@ -82,6 +97,9 @@ def test_export_validation_bundle_generates_latest_reports_and_index(tmp_path: P
     assert summary['local']['canonical_report_path'] == 'docs/reports/sqlite-smoke-report.json'
     assert summary['local']['audit_log_path'].endswith('local.audit.jsonl')
     assert summary['local']['service_log_path'].endswith('local.service.log')
+    assert summary['continuation_policy']['history_window'] == 2
+    assert summary['continuation_policy']['stale_bundle'] is True
+    assert 'component_incomplete:ray' in summary['continuation_policy']['stale_reasons']
 
     latest_local = json.loads((root / 'docs' / 'reports' / 'sqlite-smoke-report.json').read_text(encoding='utf-8'))
     assert latest_local['task']['id'] == 'local-1'
@@ -90,7 +108,49 @@ def test_export_validation_bundle_generates_latest_reports_and_index(tmp_path: P
     assert 'Live Validation Index' in index_text
     assert '20260315T120000Z' in index_text
     assert 'docs/reports/live-validation-runs/20260315T120000Z' in index_text
+    assert 'Continuation policy' in index_text
 
     manifest = json.loads((root / 'docs' / 'reports' / 'live-validation-index.json').read_text(encoding='utf-8'))
     assert manifest['latest']['run_id'] == '20260315T120000Z'
     assert manifest['recent_runs'][0]['run_id'] == '20260315T120000Z'
+
+    scorecard = json.loads(
+        (root / 'docs' / 'reports' / 'validation-bundle-continuation-scorecard.json').read_text(encoding='utf-8')
+    )
+    assert scorecard['history_window'] == 2
+    assert len(scorecard['window_runs']) == 2
+    assert scorecard['latest_bundle_policy']['run_id'] == '20260315T120000Z'
+    assert scorecard['latest_bundle_policy']['stale_bundle'] is True
+    assert scorecard['latest_bundle_policy']['ready_for_closeout'] is False
+
+    rerun = subprocess.run(
+        [
+            sys.executable,
+            str(script),
+            '--go-root', str(root),
+            '--run-id', '20260315T120000Z',
+            '--bundle-dir', 'docs/reports/live-validation-runs/20260315T120000Z',
+            '--summary-path', 'docs/reports/live-validation-summary.json',
+            '--index-path', 'docs/reports/live-validation-index.md',
+            '--manifest-path', 'docs/reports/live-validation-index.json',
+            '--run-local', '1',
+            '--run-kubernetes', '1',
+            '--run-ray', '1',
+            '--continuation-history-window', '2',
+            '--continuation-stale-after-hours', '24',
+            '--validation-status', '0',
+            '--local-report-path', 'docs/reports/live-validation-runs/20260315T120000Z/sqlite-smoke-report.json',
+            '--local-stdout-path', str(bundle / 'local.stdout.log'),
+            '--local-stderr-path', str(bundle / 'local.stderr.log'),
+            '--kubernetes-report-path', 'docs/reports/live-validation-runs/20260315T120000Z/kubernetes-live-smoke-report.json',
+            '--kubernetes-stdout-path', str(bundle / 'kubernetes.stdout.log'),
+            '--kubernetes-stderr-path', str(bundle / 'kubernetes.stderr.log'),
+            '--ray-report-path', 'docs/reports/live-validation-runs/20260315T120000Z/ray-live-smoke-report.json',
+            '--ray-stdout-path', str(bundle / 'ray.stdout.log'),
+            '--ray-stderr-path', str(bundle / 'ray.stderr.log'),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert rerun.returncode == 0, rerun.stderr


### PR DESCRIPTION
## Summary
- add a continuation scorecard that evaluates recent validation bundles with a bounded history window and stale-age policy
- wire bundle export/run_all output to persist continuation policy in the summary, manifest, and reviewer-facing index
- document fresh vs stale interpretation and cover the export/rerender policy path in tests

## Validation
- python3 -m py_compile bigclaw-go/scripts/e2e/export_validation_bundle.py bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py
- python3 bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py --go-root /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go --history-window 3 --stale-after-hours 24 --output-path docs/reports/validation-bundle-continuation-scorecard.json
- python3 bigclaw-go/scripts/e2e/export_validation_bundle.py --go-root /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go --run-id 20260314T164647Z --bundle-dir docs/reports/live-validation-runs/20260314T164647Z --summary-path docs/reports/live-validation-summary.json --index-path docs/reports/live-validation-index.md --manifest-path docs/reports/live-validation-index.json --run-local 1 --run-kubernetes 1 --run-ray 1 --continuation-history-window 3 --continuation-stale-after-hours 24 --validation-status 0 --local-report-path docs/reports/live-validation-runs/20260314T164647Z/sqlite-smoke-report.json --local-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/local.stdout.log --local-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/local.stderr.log --kubernetes-report-path docs/reports/live-validation-runs/20260314T164647Z/kubernetes-live-smoke-report.json --kubernetes-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stdout.log --kubernetes-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/kubernetes.stderr.log --ray-report-path docs/reports/live-validation-runs/20260314T164647Z/ray-live-smoke-report.json --ray-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/ray.stdout.log --ray-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/docs/reports/live-validation-runs/20260314T164647Z/ray.stderr.log
- python3 - <<'PY'
import json, subprocess, sys
from datetime import datetime, timedelta, timezone
from pathlib import Path
from tempfile import TemporaryDirectory

with TemporaryDirectory() as td:
    tmp_path = Path(td)
    root = tmp_path / "repo"
    bundle = root / "docs" / "reports" / "live-validation-runs" / "20260315T120000Z"
    previous_bundle = root / "docs" / "reports" / "live-validation-runs" / "20260314T120000Z"
    state_dir = tmp_path / "state-local"
    state_dir.mkdir(parents=True)
    (state_dir / "audit.jsonl").write_text("{"event":"ok"}
", encoding="utf-8")
    service_log = tmp_path / "local-service.log"
    service_log.write_text("local service ready
", encoding="utf-8")

    def write_json(path: Path, payload: dict):
        path.parent.mkdir(parents=True, exist_ok=True)
        path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "
", encoding="utf-8")

    write_json(bundle / "sqlite-smoke-report.json", {
        "base_url": "http://127.0.0.1:19090",
        "task": {"id": "local-1"},
        "status": {"state": "succeeded"},
        "state_dir": str(state_dir),
        "service_log": str(service_log),
    })
    write_json(bundle / "kubernetes-live-smoke-report.json", {"task": {"id": "k8s-1"}, "status": {"state": "succeeded"}})
    write_json(previous_bundle / "summary.json", {
        "run_id": "20260314T120000Z",
        "generated_at": (datetime.now(timezone.utc) - timedelta(hours=30)).isoformat(),
        "status": "succeeded",
        "bundle_path": "docs/reports/live-validation-runs/20260314T120000Z",
        "local": {"enabled": True, "status": "succeeded"},
        "kubernetes": {"enabled": True, "status": "succeeded"},
        "ray": {"enabled": True, "status": "succeeded"},
    })

    local_stdout = tmp_path / "local.stdout"
    local_stderr = tmp_path / "local.stderr"
    k8s_stdout = tmp_path / "k8s.stdout"
    k8s_stderr = tmp_path / "k8s.stderr"
    ray_stdout = tmp_path / "ray.stdout"
    ray_stderr = tmp_path / "ray.stderr"
    for path, content in [
        (local_stdout, "local ok
"),
        (local_stderr, ""),
        (k8s_stdout, "k8s ok
"),
        (k8s_stderr, ""),
        (ray_stdout, "ray ok
"),
        (ray_stderr, ""),
    ]:
        path.write_text(content, encoding="utf-8")

    script = Path("/Users/jxrt/code/symphony-workspaces/OPE-269/bigclaw-go/scripts/e2e/export_validation_bundle.py")
    args = [
        sys.executable, str(script),
        "--go-root", str(root),
        "--run-id", "20260315T120000Z",
        "--bundle-dir", "docs/reports/live-validation-runs/20260315T120000Z",
        "--summary-path", "docs/reports/live-validation-summary.json",
        "--index-path", "docs/reports/live-validation-index.md",
        "--manifest-path", "docs/reports/live-validation-index.json",
        "--run-local", "1", "--run-kubernetes", "1", "--run-ray", "1",
        "--continuation-history-window", "2", "--continuation-stale-after-hours", "24",
        "--validation-status", "0",
        "--local-report-path", "docs/reports/live-validation-runs/20260315T120000Z/sqlite-smoke-report.json",
        "--local-stdout-path", str(local_stdout), "--local-stderr-path", str(local_stderr),
        "--kubernetes-report-path", "docs/reports/live-validation-runs/20260315T120000Z/kubernetes-live-smoke-report.json",
        "--kubernetes-stdout-path", str(k8s_stdout), "--kubernetes-stderr-path", str(k8s_stderr),
        "--ray-report-path", "docs/reports/live-validation-runs/20260315T120000Z/ray-live-smoke-report.json",
        "--ray-stdout-path", str(ray_stdout), "--ray-stderr-path", str(ray_stderr),
    ]
    first = subprocess.run(args, capture_output=True, text=True)
    rerun = subprocess.run(args[:-6] + [
        "--ray-report-path", "docs/reports/live-validation-runs/20260315T120000Z/ray-live-smoke-report.json",
        "--ray-stdout-path", str(bundle / "ray.stdout.log"), "--ray-stderr-path", str(bundle / "ray.stderr.log"),
    ], capture_output=True, text=True)
    assert first.returncode == 0, first.stderr
    assert rerun.returncode == 0, rerun.stderr
PY