### PR TITLE
OPE-262: enforce continuation gate workflow modes

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -77,6 +77,14 @@ python3 scripts/e2e/validation_bundle_continuation_policy_gate.py --pretty
 
 This writes `docs/reports/validation-bundle-continuation-policy-gate.json` and currently returns `go` for the checked-in evidence window because the latest indexed bundles now include repeated `ray` coverage across multiple runs. `run_all.sh` refreshes the gate automatically during closeout; set `BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` if you want a `hold` result to fail the command.
 
+For workflow behavior, prefer `BIGCLAW_E2E_CONTINUATION_GATE_MODE`:
+
+- `review` keeps the gate reviewer-visible but does not fail the workflow on `hold`
+- `hold` exits with code `2` when the evidence is stale or incomplete
+- `fail` exits with code `1` when the evidence is stale or incomplete
+
+`BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` remains as a compatibility alias for `BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail`. `run_all.sh` now rerenders the bundle README and `docs/reports/live-validation-index.md` after the gate refresh so the exported reviewer surface always reflects the latest gate mode and outcome from the same run.
+
 ## Mixed workload matrix
 
 ```bash

--- a/bigclaw-go/docs/reports/live-validation-index.json
+++ b/bigclaw-go/docs/reports/live-validation-index.json
@@ -1,7 +1,7 @@
 {
   "latest": {
     "run_id": "20260316T140138Z",
-    "generated_at": "2026-03-16T14:48:42.581505+00:00",
+    "generated_at": "2026-03-16T15:54:25.340839+00:00",
     "status": "succeeded",
     "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
     "closeout_commands": [
@@ -723,7 +723,7 @@
   "recent_runs": [
     {
       "run_id": "20260316T140138Z",
-      "generated_at": "2026-03-16T14:48:42.581505+00:00",
+      "generated_at": "2026-03-16T15:54:25.340839+00:00",
       "status": "succeeded",
       "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
       "summary_path": "docs/reports/live-validation-runs/20260316T140138Z/summary.json"
@@ -748,14 +748,22 @@
     "status": "policy-go",
     "recommendation": "go",
     "failing_checks": [],
+    "enforcement": {
+      "mode": "review",
+      "outcome": "pass",
+      "exit_code": 0
+    },
     "summary": {
       "latest_run_id": "20260316T140138Z",
-      "latest_bundle_age_hours": 0.06,
+      "latest_bundle_age_hours": 0.01,
       "recent_bundle_count": 3,
       "latest_all_executor_tracks_succeeded": true,
       "recent_bundle_chain_has_no_failures": true,
       "all_executor_tracks_have_repeated_recent_coverage": true,
       "recommendation": "go",
+      "enforcement_mode": "review",
+      "workflow_outcome": "pass",
+      "workflow_exit_code": 0,
       "passing_check_count": 6,
       "failing_check_count": 0
     },
@@ -764,7 +772,7 @@
       "digest_path": "docs/reports/validation-bundle-continuation-digest.md"
     },
     "next_actions": [
-      "enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 when workflow closeout should fail on continuation regressions"
+      "set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions"
     ]
   }
 }

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -1,7 +1,7 @@
 # Live Validation Index
 
 - Latest run: `20260316T140138Z`
-- Generated at: `2026-03-16T14:48:42.581505+00:00`
+- Generated at: `2026-03-16T15:54:25.340839+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260316T140138Z`
 - Summary JSON: `docs/reports/live-validation-runs/20260316T140138Z/summary.json`
@@ -61,21 +61,23 @@
 
 ## Recent bundles
 
-- `20260316T140138Z` · `succeeded` · `2026-03-16T14:48:42.581505+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
+- `20260316T140138Z` · `succeeded` · `2026-03-16T15:54:25.340839+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`
-
 
 ## Continuation gate
 
 - Status: `policy-go`
 - Recommendation: `go`
 - Report: `docs/reports/validation-bundle-continuation-policy-gate.json`
+- Workflow mode: `review`
+- Workflow outcome: `pass`
 - Latest reviewed run: `20260316T140138Z`
 - Failing checks: `0`
+- Workflow exit code on current evidence: `0`
 - Reviewer digest: `docs/reports/validation-bundle-continuation-digest.md`
 - Reviewer index: `docs/reports/live-validation-index.md`
-- Next action: `enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 when workflow closeout should fail on continuation regressions`
+- Next action: `set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions`
 
 ## Continuation artifacts
 

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/README.md
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/README.md
@@ -1,7 +1,7 @@
 # Live Validation Index
 
 - Latest run: `20260316T140138Z`
-- Generated at: `2026-03-16T14:48:42.581505+00:00`
+- Generated at: `2026-03-16T15:54:25.340839+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260316T140138Z`
 - Summary JSON: `docs/reports/live-validation-runs/20260316T140138Z/summary.json`
@@ -61,21 +61,23 @@
 
 ## Recent bundles
 
-- `20260316T140138Z` · `succeeded` · `2026-03-16T14:48:42.581505+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
+- `20260316T140138Z` · `succeeded` · `2026-03-16T15:54:25.340839+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`
-
 
 ## Continuation gate
 
 - Status: `policy-go`
 - Recommendation: `go`
 - Report: `docs/reports/validation-bundle-continuation-policy-gate.json`
+- Workflow mode: `review`
+- Workflow outcome: `pass`
 - Latest reviewed run: `20260316T140138Z`
 - Failing checks: `0`
+- Workflow exit code on current evidence: `0`
 - Reviewer digest: `docs/reports/validation-bundle-continuation-digest.md`
 - Reviewer index: `docs/reports/live-validation-index.md`
-- Next action: `enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 when workflow closeout should fail on continuation regressions`
+- Next action: `set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions`
 
 ## Continuation artifacts
 

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/summary.json
@@ -1,6 +1,6 @@
 {
   "run_id": "20260316T140138Z",
-  "generated_at": "2026-03-16T14:48:42.581505+00:00",
+  "generated_at": "2026-03-16T15:54:25.340839+00:00",
   "status": "succeeded",
   "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
   "closeout_commands": [

--- a/bigclaw-go/docs/reports/live-validation-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-summary.json
@@ -1,6 +1,6 @@
 {
   "run_id": "20260316T140138Z",
-  "generated_at": "2026-03-16T14:48:42.581505+00:00",
+  "generated_at": "2026-03-16T15:54:25.340839+00:00",
   "status": "succeeded",
   "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
   "closeout_commands": [

--- a/bigclaw-go/docs/reports/validation-bundle-continuation-policy-gate.json
+++ b/bigclaw-go/docs/reports/validation-bundle-continuation-policy-gate.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-03-16T14:52:25.403377Z",
-  "ticket": "OPE-271",
-  "title": "Workflow-enforced continuation gate for closeout",
+  "generated_at": "2026-03-16T15:54:25.308192Z",
+  "ticket": "OPE-262",
+  "title": "Validation workflow continuation gate",
   "status": "policy-go",
   "recommendation": "go",
   "evidence_inputs": {
@@ -13,14 +13,22 @@
     "min_recent_bundles": 2,
     "require_repeated_lane_coverage": true
   },
+  "enforcement": {
+    "mode": "review",
+    "outcome": "pass",
+    "exit_code": 0
+  },
   "summary": {
     "latest_run_id": "20260316T140138Z",
-    "latest_bundle_age_hours": 0.06,
+    "latest_bundle_age_hours": 0.01,
     "recent_bundle_count": 3,
     "latest_all_executor_tracks_succeeded": true,
     "recent_bundle_chain_has_no_failures": true,
     "all_executor_tracks_have_repeated_recent_coverage": true,
     "recommendation": "go",
+    "enforcement_mode": "review",
+    "workflow_outcome": "pass",
+    "workflow_exit_code": 0,
     "passing_check_count": 6,
     "failing_check_count": 0
   },
@@ -28,7 +36,7 @@
     {
       "name": "latest_bundle_age_within_threshold",
       "passed": true,
-      "detail": "latest_bundle_age_hours=0.06 threshold=72.0"
+      "detail": "latest_bundle_age_hours=0.01 threshold=72.0"
     },
     {
       "name": "recent_bundle_count_meets_floor",
@@ -57,6 +65,10 @@
     }
   ],
   "failing_checks": [],
+  "reviewer_path": {
+    "index_path": "docs/reports/live-validation-index.md",
+    "digest_path": "docs/reports/validation-bundle-continuation-digest.md"
+  },
   "shared_queue_companion": {
     "available": true,
     "report_path": "docs/reports/multi-node-shared-queue-report.json",
@@ -69,10 +81,6 @@
     "mode": "bundle-companion-summary"
   },
   "next_actions": [
-    "enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 when workflow closeout should fail on continuation regressions"
-  ],
-  "reviewer_path": {
-    "index_path": "docs/reports/live-validation-index.md",
-    "digest_path": "docs/reports/validation-bundle-continuation-digest.md"
-  }
+    "set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions"
+  ]
 }

--- a/bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json
+++ b/bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-03-16T14:52:25.376397Z",
+  "generated_at": "2026-03-16T15:54:25.278091Z",
   "ticket": "BIG-PAR-086-local-prework",
   "title": "Validation bundle continuation scorecard",
   "status": "local-continuation-scorecard",
@@ -19,11 +19,11 @@
     "recent_bundle_count": 3,
     "latest_run_id": "20260316T140138Z",
     "latest_status": "succeeded",
-    "latest_bundle_age_hours": 0.06,
+    "latest_bundle_age_hours": 0.01,
     "latest_all_executor_tracks_succeeded": true,
     "recent_bundle_chain_has_no_failures": true,
     "all_executor_tracks_have_repeated_recent_coverage": true,
-    "bundle_gap_minutes": 2761.75,
+    "bundle_gap_minutes": 2826.67,
     "bundle_root_exists": true
   },
   "executor_lanes": [
@@ -119,7 +119,7 @@
     "recent history is bounded to the exported bundle index and not an always-on service"
   ],
   "next_runtime_hooks": [
-    "enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 in workflow closeout when continuation holds should fail the run",
+    "set BIGCLAW_E2E_CONTINUATION_GATE_MODE=hold or fail in workflow closeout when continuation holds should block or fail the run",
     "decide whether shared-queue coordination should stay as adjacent bundle metadata or gain its own executor-native validation lane",
     "extend the automatic continuation refresh beyond run_all.sh into broader workflow orchestrators",
     "extend the scorecard beyond the latest recent_runs window when more longitudinal evidence exists"

--- a/bigclaw-go/scripts/e2e/export_validation_bundle.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle.py
@@ -39,6 +39,7 @@ def build_continuation_gate_summary(root: Path) -> Optional[dict[str, Any]]:
     gate = read_json(gate_path)
     if not isinstance(gate, dict):
         return None
+    enforcement = gate.get('enforcement')
     summary = gate.get('summary')
     reviewer_path = gate.get('reviewer_path')
     next_actions = gate.get('next_actions')
@@ -47,6 +48,7 @@ def build_continuation_gate_summary(root: Path) -> Optional[dict[str, Any]]:
         'status': gate.get('status', 'unknown'),
         'recommendation': gate.get('recommendation', 'unknown'),
         'failing_checks': gate.get('failing_checks', []),
+        'enforcement': enforcement if isinstance(enforcement, dict) else {},
         'summary': summary if isinstance(summary, dict) else {},
         'reviewer_path': reviewer_path if isinstance(reviewer_path, dict) else {},
         'next_actions': next_actions if isinstance(next_actions, list) else [],
@@ -324,11 +326,18 @@ def render_index(
         lines.append(f"- Status: `{continuation_gate['status']}`")
         lines.append(f"- Recommendation: `{continuation_gate['recommendation']}`")
         lines.append(f"- Report: `{continuation_gate['path']}`")
+        enforcement = continuation_gate.get('enforcement', {})
+        if enforcement.get('mode'):
+            lines.append(f"- Workflow mode: `{enforcement['mode']}`")
+        if enforcement.get('outcome'):
+            lines.append(f"- Workflow outcome: `{enforcement['outcome']}`")
         gate_summary = continuation_gate.get('summary', {})
         if gate_summary.get('latest_run_id'):
             lines.append(f"- Latest reviewed run: `{gate_summary['latest_run_id']}`")
         if 'failing_check_count' in gate_summary:
             lines.append(f"- Failing checks: `{gate_summary['failing_check_count']}`")
+        if 'workflow_exit_code' in gate_summary:
+            lines.append(f"- Workflow exit code on current evidence: `{gate_summary['workflow_exit_code']}`")
         reviewer_path = continuation_gate.get('reviewer_path', {})
         if reviewer_path.get('digest_path'):
             lines.append(f"- Reviewer digest: `{reviewer_path['digest_path']}`")

--- a/bigclaw-go/scripts/e2e/export_validation_bundle_test.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle_test.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().with_name('export_validation_bundle.py')
+SPEC = importlib.util.spec_from_file_location('export_validation_bundle', MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f'Unable to load module from {MODULE_PATH}')
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class ExportValidationBundleTest(unittest.TestCase):
+    def test_render_index_surfaces_continuation_workflow_mode_and_outcome(self) -> None:
+        summary = {
+            'run_id': '20260316T140138Z',
+            'generated_at': '2026-03-16T14:48:42.581505+00:00',
+            'status': 'succeeded',
+            'bundle_path': 'docs/reports/live-validation-runs/20260316T140138Z',
+            'summary_path': 'docs/reports/live-validation-runs/20260316T140138Z/summary.json',
+            'closeout_commands': ['cd bigclaw-go && ./scripts/e2e/run_all.sh'],
+            'local': {
+                'enabled': True,
+                'status': 'succeeded',
+                'bundle_report_path': 'docs/reports/live-validation-runs/20260316T140138Z/sqlite-smoke-report.json',
+                'canonical_report_path': 'docs/reports/sqlite-smoke-report.json',
+            },
+            'kubernetes': {
+                'enabled': False,
+                'status': 'skipped',
+                'bundle_report_path': 'docs/reports/live-validation-runs/20260316T140138Z/kubernetes-live-smoke-report.json',
+                'canonical_report_path': 'docs/reports/kubernetes-live-smoke-report.json',
+            },
+            'ray': {
+                'enabled': False,
+                'status': 'skipped',
+                'bundle_report_path': 'docs/reports/live-validation-runs/20260316T140138Z/ray-live-smoke-report.json',
+                'canonical_report_path': 'docs/reports/ray-live-smoke-report.json',
+            },
+        }
+        continuation_gate = {
+            'path': 'docs/reports/validation-bundle-continuation-policy-gate.json',
+            'status': 'policy-hold',
+            'recommendation': 'hold',
+            'enforcement': {'mode': 'hold', 'outcome': 'hold', 'exit_code': 2},
+            'summary': {'latest_run_id': '20260316T140138Z', 'failing_check_count': 2, 'workflow_exit_code': 2},
+            'reviewer_path': {'digest_path': 'docs/reports/validation-bundle-continuation-digest.md'},
+            'next_actions': ['rerun `cd bigclaw-go && ./scripts/e2e/run_all.sh` to refresh the latest validation bundle'],
+        }
+
+        index_text = MODULE.render_index(summary, [], continuation_gate, [], [])
+
+        self.assertIn('- Workflow mode: `hold`', index_text)
+        self.assertIn('- Workflow outcome: `hold`', index_text)
+        self.assertIn('- Workflow exit code on current evidence: `2`', index_text)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bigclaw-go/scripts/e2e/run_all.sh
+++ b/bigclaw-go/scripts/e2e/run_all.sh
@@ -12,8 +12,17 @@ RUN_KUBERNETES="${BIGCLAW_E2E_RUN_KUBERNETES:-1}"
 RUN_RAY="${BIGCLAW_E2E_RUN_RAY:-1}"
 REFRESH_CONTINUATION="${BIGCLAW_E2E_REFRESH_CONTINUATION:-1}"
 ENFORCE_CONTINUATION_GATE="${BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE:-0}"
+CONTINUATION_GATE_MODE="${BIGCLAW_E2E_CONTINUATION_GATE_MODE:-}"
 CONTINUATION_SCORECARD_PATH="${BIGCLAW_E2E_CONTINUATION_SCORECARD_PATH:-docs/reports/validation-bundle-continuation-scorecard.json}"
 CONTINUATION_POLICY_GATE_PATH="${BIGCLAW_E2E_CONTINUATION_POLICY_GATE_PATH:-docs/reports/validation-bundle-continuation-policy-gate.json}"
+
+if [[ -z "$CONTINUATION_GATE_MODE" ]]; then
+  if [[ "$ENFORCE_CONTINUATION_GATE" == "1" ]]; then
+    CONTINUATION_GATE_MODE="fail"
+  else
+    CONTINUATION_GATE_MODE="review"
+  fi
+fi
 
 mkdir -p "$ROOT/$BUNDLE_DIR_REL"
 
@@ -66,27 +75,31 @@ if (( ${#pids[@]} > 0 )); then
   done
 fi
 
+export_bundle() {
+  python3 "$ROOT/scripts/e2e/export_validation_bundle.py" \
+    --go-root "$ROOT" \
+    --run-id "$RUN_ID" \
+    --bundle-dir "$BUNDLE_DIR_REL" \
+    --summary-path "$SUMMARY_REPORT_PATH" \
+    --index-path "$INDEX_REPORT_PATH" \
+    --manifest-path "$MANIFEST_REPORT_PATH" \
+    --run-local "$RUN_LOCAL" \
+    --run-kubernetes "$RUN_KUBERNETES" \
+    --run-ray "$RUN_RAY" \
+    --validation-status "$status" \
+    --local-report-path "$LOCAL_REPORT_REL" \
+    --local-stdout-path "$LOCAL_OUT" \
+    --local-stderr-path "$LOCAL_ERR" \
+    --kubernetes-report-path "$K8S_REPORT_REL" \
+    --kubernetes-stdout-path "$K8S_OUT" \
+    --kubernetes-stderr-path "$K8S_ERR" \
+    --ray-report-path "$RAY_REPORT_REL" \
+    --ray-stdout-path "$RAY_OUT" \
+    --ray-stderr-path "$RAY_ERR"
+}
+
 export_status=0
-if ! python3 "$ROOT/scripts/e2e/export_validation_bundle.py" \
-  --go-root "$ROOT" \
-  --run-id "$RUN_ID" \
-  --bundle-dir "$BUNDLE_DIR_REL" \
-  --summary-path "$SUMMARY_REPORT_PATH" \
-  --index-path "$INDEX_REPORT_PATH" \
-  --manifest-path "$MANIFEST_REPORT_PATH" \
-  --run-local "$RUN_LOCAL" \
-  --run-kubernetes "$RUN_KUBERNETES" \
-  --run-ray "$RUN_RAY" \
-  --validation-status "$status" \
-  --local-report-path "$LOCAL_REPORT_REL" \
-  --local-stdout-path "$LOCAL_OUT" \
-  --local-stderr-path "$LOCAL_ERR" \
-  --kubernetes-report-path "$K8S_REPORT_REL" \
-  --kubernetes-stdout-path "$K8S_OUT" \
-  --kubernetes-stderr-path "$K8S_ERR" \
-  --ray-report-path "$RAY_REPORT_REL" \
-  --ray-stdout-path "$RAY_OUT" \
-  --ray-stderr-path "$RAY_ERR"; then
+if ! export_bundle; then
   export_status=$?
 fi
 
@@ -97,11 +110,20 @@ if [[ "$REFRESH_CONTINUATION" == "1" ]]; then
   gate_status=0
   if ! python3 "$ROOT/scripts/e2e/validation_bundle_continuation_policy_gate.py" \
     --scorecard "$CONTINUATION_SCORECARD_PATH" \
+    --enforcement-mode "$CONTINUATION_GATE_MODE" \
     --output "$CONTINUATION_POLICY_GATE_PATH"; then
     gate_status=$?
   fi
 
-  if [[ "$gate_status" -ne 0 && "$ENFORCE_CONTINUATION_GATE" == "1" ]]; then
+  rerender_status=0
+  if ! export_bundle; then
+    rerender_status=$?
+  fi
+  if [[ "$export_status" -eq 0 && "$rerender_status" -ne 0 ]]; then
+    export_status=$rerender_status
+  fi
+
+  if [[ "$gate_status" -ne 0 ]]; then
     exit "$gate_status"
   fi
 fi

--- a/bigclaw-go/scripts/e2e/run_all_test.py
+++ b/bigclaw-go/scripts/e2e/run_all_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+import json
+import os
+import stat
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SOURCE_RUN_ALL = REPO_ROOT / 'scripts' / 'e2e' / 'run_all.sh'
+
+
+class RunAllTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmpdir.cleanup)
+        self.root = Path(self.tmpdir.name)
+        scripts_dir = self.root / 'scripts' / 'e2e'
+        scripts_dir.mkdir(parents=True, exist_ok=True)
+        run_all_path = scripts_dir / 'run_all.sh'
+        run_all_path.write_text(SOURCE_RUN_ALL.read_text(encoding='utf-8'), encoding='utf-8')
+        run_all_path.chmod(run_all_path.stat().st_mode | stat.S_IXUSR)
+
+    def write_file(self, relpath: str, content: str, *, executable: bool = False) -> None:
+        path = self.root / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(textwrap.dedent(content), encoding='utf-8')
+        if executable:
+            path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+    def install_stubs(self) -> None:
+        self.write_file(
+            'scripts/e2e/run_task_smoke.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            report_path = pathlib.Path(args[args.index('--report-path') + 1])
+            report_path.parent.mkdir(parents=True, exist_ok=True)
+            report_path.write_text(json.dumps({'status': 'succeeded', 'all_ok': True}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+        self.write_file(
+            'scripts/e2e/export_validation_bundle.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            root = pathlib.Path(args[args.index('--go-root') + 1])
+            bundle_dir = root / args[args.index('--bundle-dir') + 1]
+            bundle_dir.mkdir(parents=True, exist_ok=True)
+            calls_path = root / 'calls.jsonl'
+            gate_path = root / 'docs/reports/validation-bundle-continuation-policy-gate.json'
+            payload = {'gate_exists': gate_path.exists()}
+            with calls_path.open('a', encoding='utf-8') as handle:
+                handle.write(json.dumps(payload) + '\\n')
+            """,
+            executable=True,
+        )
+        self.write_file(
+            'scripts/e2e/validation_bundle_continuation_scorecard.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({'summary': {}, 'shared_queue_companion': {'available': True}}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+        self.write_file(
+            'scripts/e2e/validation_bundle_continuation_policy_gate.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            mode = args[args.index('--enforcement-mode') + 1]
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({'status': 'policy-go', 'recommendation': 'go', 'enforcement': {'mode': mode, 'outcome': 'pass', 'exit_code': 0}}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+
+    def test_run_all_rerenders_bundle_after_gate_refresh(self) -> None:
+        self.install_stubs()
+        env = os.environ.copy()
+        env.update(
+            {
+                'BIGCLAW_E2E_RUN_KUBERNETES': '0',
+                'BIGCLAW_E2E_RUN_RAY': '0',
+                'BIGCLAW_E2E_RUN_LOCAL': '1',
+                'BIGCLAW_E2E_CONTINUATION_GATE_MODE': 'review',
+            }
+        )
+
+        result = subprocess.run(
+            [str(self.root / 'scripts' / 'e2e' / 'run_all.sh')],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        calls = [
+            json.loads(line)
+            for line in (self.root / 'calls.jsonl').read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
+        self.assertEqual(len(calls), 2)
+        self.assertFalse(calls[0]['gate_exists'])
+        self.assertTrue(calls[1]['gate_exists'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate.py
@@ -25,16 +25,43 @@ def build_check(name, passed, detail):
     return {'name': name, 'passed': passed, 'detail': detail}
 
 
+def normalize_enforcement_mode(enforcement_mode, legacy_enforce_continuation_gate=False):
+    mode = str(enforcement_mode or '').strip().lower()
+    if not mode:
+        mode = 'fail' if legacy_enforce_continuation_gate else 'review'
+    if mode not in {'review', 'hold', 'fail'}:
+        raise ValueError(
+            f"unsupported enforcement mode {enforcement_mode!r}; expected one of review, hold, fail"
+        )
+    return mode
+
+
+def build_enforcement_summary(recommendation, enforcement_mode):
+    if recommendation == 'go':
+        return {'mode': enforcement_mode, 'outcome': 'pass', 'exit_code': 0}
+    if enforcement_mode == 'review':
+        return {'mode': enforcement_mode, 'outcome': 'review-only', 'exit_code': 0}
+    if enforcement_mode == 'hold':
+        return {'mode': enforcement_mode, 'outcome': 'hold', 'exit_code': 2}
+    return {'mode': enforcement_mode, 'outcome': 'fail', 'exit_code': 1}
+
+
 def build_report(
     scorecard_path='bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json',
     max_latest_age_hours=72.0,
     min_recent_bundles=2,
     require_repeated_lane_coverage=True,
+    enforcement_mode=None,
+    legacy_enforce_continuation_gate=False,
 ):
     repo_root = pathlib.Path(__file__).resolve().parents[3]
     scorecard = load_json(resolve_repo_path(repo_root, scorecard_path))
     summary = scorecard['summary']
     shared_queue = scorecard['shared_queue_companion']
+    normalized_mode = normalize_enforcement_mode(
+        enforcement_mode,
+        legacy_enforce_continuation_gate=legacy_enforce_continuation_gate,
+    )
 
     checks = [
         build_check(
@@ -71,6 +98,7 @@ def build_report(
 
     failing_checks = [item['name'] for item in checks if not item['passed']]
     recommendation = 'go' if not failing_checks else 'hold'
+    enforcement = build_enforcement_summary(recommendation, normalized_mode)
     next_actions = []
     if 'latest_bundle_age_within_threshold' in failing_checks:
         next_actions.append('rerun `cd bigclaw-go && ./scripts/e2e/run_all.sh` to refresh the latest validation bundle')
@@ -81,12 +109,12 @@ def build_report(
     if 'repeated_lane_coverage_meets_policy' in failing_checks:
         next_actions.append('refresh another full validation bundle with `ray` enabled so each executor lane has repeated indexed coverage')
     if not next_actions:
-        next_actions.append('enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 when workflow closeout should fail on continuation regressions')
+        next_actions.append('set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions')
 
     return {
         'generated_at': utc_iso(),
-        'ticket': 'OPE-271',
-        'title': 'Workflow-enforced continuation gate for closeout',
+        'ticket': 'OPE-262',
+        'title': 'Validation workflow continuation gate',
         'status': 'policy-go' if recommendation == 'go' else 'policy-hold',
         'recommendation': recommendation,
         'evidence_inputs': {
@@ -98,6 +126,7 @@ def build_report(
             'min_recent_bundles': int(min_recent_bundles),
             'require_repeated_lane_coverage': bool(require_repeated_lane_coverage),
         },
+        'enforcement': enforcement,
         'summary': {
             'latest_run_id': summary.get('latest_run_id'),
             'latest_bundle_age_hours': summary.get('latest_bundle_age_hours'),
@@ -106,6 +135,9 @@ def build_report(
             'recent_bundle_chain_has_no_failures': summary.get('recent_bundle_chain_has_no_failures'),
             'all_executor_tracks_have_repeated_recent_coverage': summary.get('all_executor_tracks_have_repeated_recent_coverage'),
             'recommendation': recommendation,
+            'enforcement_mode': enforcement['mode'],
+            'workflow_outcome': enforcement['outcome'],
+            'workflow_exit_code': enforcement['exit_code'],
             'passing_check_count': len([item for item in checks if item['passed']]),
             'failing_check_count': len(failing_checks),
         },
@@ -128,6 +160,8 @@ def main():
     parser.add_argument('--min-recent-bundles', type=int, default=2)
     parser.add_argument('--require-repeated-lane-coverage', action='store_true', default=True)
     parser.add_argument('--allow-partial-lane-history', action='store_true')
+    parser.add_argument('--enforcement-mode', choices=('review', 'hold', 'fail'))
+    parser.add_argument('--enforce', action='store_true')
     parser.add_argument('--pretty', action='store_true')
     args = parser.parse_args()
 
@@ -137,13 +171,15 @@ def main():
         max_latest_age_hours=args.max_latest_age_hours,
         min_recent_bundles=args.min_recent_bundles,
         require_repeated_lane_coverage=not args.allow_partial_lane_history,
+        enforcement_mode=args.enforcement_mode,
+        legacy_enforce_continuation_gate=args.enforce,
     )
     output_path = resolve_repo_path(repo_root, args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(report, indent=2) + '\n', encoding='utf-8')
     if args.pretty:
         print(json.dumps(report, indent=2))
-    return 0 if report['recommendation'] == 'go' else 1
+    return int(report['enforcement']['exit_code'])
 
 
 if __name__ == '__main__':

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py
@@ -67,9 +67,11 @@ class ValidationBundleContinuationPolicyGateTest(unittest.TestCase):
 
         report = self.build_report()
 
-        self.assertEqual(report['ticket'], 'OPE-271')
+        self.assertEqual(report['ticket'], 'OPE-262')
         self.assertEqual(report['status'], 'policy-go')
         self.assertEqual(report['recommendation'], 'go')
+        self.assertEqual(report['enforcement']['mode'], 'review')
+        self.assertEqual(report['enforcement']['outcome'], 'pass')
         self.assertEqual(report['failing_checks'], [])
         self.assertEqual(report['reviewer_path']['index_path'], 'docs/reports/live-validation-index.md')
 
@@ -92,6 +94,39 @@ class ValidationBundleContinuationPolicyGateTest(unittest.TestCase):
         self.assertTrue(
             any('./scripts/e2e/run_all.sh' in action for action in report['next_actions'])
         )
+
+    def test_build_report_supports_hold_mode_without_failing_generation(self) -> None:
+        self.write_scorecard(recent_bundle_count=1)
+
+        fake_script_path = self.repo_root / 'bigclaw-go' / 'scripts' / 'e2e' / 'validation_bundle_continuation_policy_gate.py'
+        fake_script_path.parent.mkdir(parents=True, exist_ok=True)
+        fake_script_path.write_text('# test shim\n', encoding='utf-8')
+        with unittest.mock.patch.object(MODULE, '__file__', str(fake_script_path)):
+            report = MODULE.build_report(
+                scorecard_path='docs/reports/validation-bundle-continuation-scorecard.json',
+                enforcement_mode='hold',
+            )
+
+        self.assertEqual(report['recommendation'], 'hold')
+        self.assertEqual(report['enforcement']['mode'], 'hold')
+        self.assertEqual(report['enforcement']['outcome'], 'hold')
+        self.assertEqual(report['enforcement']['exit_code'], 2)
+
+    def test_legacy_enforce_flag_maps_to_fail_mode(self) -> None:
+        self.write_scorecard(recent_bundle_count=1)
+
+        fake_script_path = self.repo_root / 'bigclaw-go' / 'scripts' / 'e2e' / 'validation_bundle_continuation_policy_gate.py'
+        fake_script_path.parent.mkdir(parents=True, exist_ok=True)
+        fake_script_path.write_text('# test shim\n', encoding='utf-8')
+        with unittest.mock.patch.object(MODULE, '__file__', str(fake_script_path)):
+            report = MODULE.build_report(
+                scorecard_path='docs/reports/validation-bundle-continuation-scorecard.json',
+                legacy_enforce_continuation_gate=True,
+            )
+
+        self.assertEqual(report['enforcement']['mode'], 'fail')
+        self.assertEqual(report['enforcement']['outcome'], 'fail')
+        self.assertEqual(report['enforcement']['exit_code'], 1)
 
 
 if __name__ == '__main__':

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py
@@ -180,7 +180,7 @@ def build_report(
         current_ceiling.append('not every executor lane is enabled across every indexed bundle in the current recent window')
 
     next_runtime_hooks = [
-        'enable BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1 in workflow closeout when continuation holds should fail the run',
+        'set BIGCLAW_E2E_CONTINUATION_GATE_MODE=hold or fail in workflow closeout when continuation holds should block or fail the run',
         'decide whether shared-queue coordination should stay as adjacent bundle metadata or gain its own executor-native validation lane',
         'extend the automatic continuation refresh beyond run_all.sh into broader workflow orchestrators',
         'extend the scorecard beyond the latest recent_runs window when more longitudinal evidence exists',


### PR DESCRIPTION
## Summary
- add explicit continuation gate modes (`review`, `hold`, `fail`) and keep the legacy enforce flag as a fail-mode alias
- rerender the validation bundle export after the continuation scorecard and gate refresh so the index and bundle README stay current in the same run
- add targeted tests for gate modes, exported index visibility, and the run_all rerender pass

## Validation
- python3 -m unittest bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py bigclaw-go/scripts/e2e/export_validation_bundle_test.py bigclaw-go/scripts/e2e/run_all_test.py
- python3 bigclaw-go/scripts/e2e/validation_bundle_continuation_scorecard.py --output bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json
- python3 bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate.py --scorecard bigclaw-go/docs/reports/validation-bundle-continuation-scorecard.json --enforcement-mode review --output bigclaw-go/docs/reports/validation-bundle-continuation-policy-gate.json
- python3 bigclaw-go/scripts/e2e/export_validation_bundle.py --go-root /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go --run-id 20260316T140138Z --bundle-dir docs/reports/live-validation-runs/20260316T140138Z --summary-path docs/reports/live-validation-summary.json --index-path docs/reports/live-validation-index.md --manifest-path docs/reports/live-validation-index.json --run-local 1 --run-kubernetes 1 --run-ray 1 --validation-status 0 --local-report-path docs/reports/live-validation-runs/20260316T140138Z/sqlite-smoke-report.json --local-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/local.stdout.log --local-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/local.stderr.log --kubernetes-report-path docs/reports/live-validation-runs/20260316T140138Z/kubernetes-live-smoke-report.json --kubernetes-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/kubernetes.stdout.log --kubernetes-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/kubernetes.stderr.log --ray-report-path docs/reports/live-validation-runs/20260316T140138Z/ray-live-smoke-report.json --ray-stdout-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/ray.stdout.log --ray-stderr-path /Users/jxrt/code/symphony-workspaces/OPE-262/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/ray.stderr.log
