### PR TITLE
OPE-231: add broker review pack links to diagnostics

### DIFF
--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -71,6 +71,15 @@ type distributedDiagnosticsReport struct {
 	ExportURL string `json:"export_url"`
 }
 
+type brokerReviewPack struct {
+	Status             string   `json:"status"`
+	SummaryPath        string   `json:"summary_path"`
+	ReportPath         string   `json:"report_path"`
+	ValidationPackPath string   `json:"validation_pack_path"`
+	ArtifactDirectory  string   `json:"artifact_directory"`
+	ReviewerLinks      []string `json:"reviewer_links,omitempty"`
+}
+
 type traceExportBundleSummary struct {
 	TotalTraces             int                      `json:"total_traces"`
 	TracesWithTerminalState int                      `json:"traces_with_terminal_state"`
@@ -97,6 +106,7 @@ type distributedDiagnostics struct {
 	RoutingReasons   []routingReasonSummary        `json:"routing_reasons"`
 	ExecutorCapacity []executorCapacityView        `json:"executor_capacity"`
 	ClusterHealth    clusterHealthRollup           `json:"cluster_health"`
+	BrokerReviewPack brokerReviewPack              `json:"broker_review_pack"`
 	TraceBundle      traceExportBundleSummary      `json:"trace_export_bundle"`
 	RolloutReport    distributedDiagnosticsReport  `json:"rollout_report"`
 }
@@ -371,6 +381,7 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		RoutingReasons:   routingReasons,
 		ExecutorCapacity: executorCapacity,
 		ClusterHealth:    clusterHealth,
+		BrokerReviewPack: buildBrokerReviewPack(),
 		TraceBundle:      buildTraceExportBundle(assignments, s.Recorder.TraceSummaries(5)),
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
@@ -700,6 +711,18 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 	if len(diagnostics.TraceBundle.BackendLimitations) > 0 {
 		lines = append(lines, "- Backend limitations: "+strings.Join(diagnostics.TraceBundle.BackendLimitations, "; "))
 	}
+	lines = append(lines,
+		"",
+		"## Broker Failover Review Pack",
+		fmt.Sprintf("- Status: %s", diagnostics.BrokerReviewPack.Status),
+		fmt.Sprintf("- Canonical summary: %s", diagnostics.BrokerReviewPack.SummaryPath),
+		fmt.Sprintf("- Stub report: %s", diagnostics.BrokerReviewPack.ReportPath),
+		fmt.Sprintf("- Validation pack: %s", diagnostics.BrokerReviewPack.ValidationPackPath),
+		fmt.Sprintf("- Artifact directory: %s", diagnostics.BrokerReviewPack.ArtifactDirectory),
+	)
+	if len(diagnostics.BrokerReviewPack.ReviewerLinks) > 0 {
+		lines = append(lines, "- Reviewer links: "+strings.Join(diagnostics.BrokerReviewPack.ReviewerLinks, ", "))
+	}
 	lines = append(lines, "", "## Notes")
 	for _, note := range diagnostics.ClusterHealth.Notes {
 		lines = append(lines, "- "+note)
@@ -763,17 +786,35 @@ func buildTraceExportBundle(assignments []distributedTaskAssignment, summaries [
 			"docs/reports/live-validation-index.md",
 			"docs/reports/live-validation-summary.json",
 			"docs/reports/go-control-plane-observability-report.md",
+			"docs/reports/broker-validation-summary.json",
+			"docs/reports/broker-failover-stub-report.json",
+			"docs/reports/broker-failover-stub-artifacts",
 		},
 		ReviewerNavigation: []string{
 			"/v2/reports/distributed/export",
 			"/debug/traces",
 			"/events?trace_id=<trace_id>&limit=200",
 			"docs/reports/review-readiness.md",
+			"docs/reports/broker-failover-fault-injection-validation-pack.md",
 		},
 		BackendLimitations: []string{
 			"no external tracing backend or OTLP/Jaeger/Tempo/Zipkin export path",
 			"no cross-process span propagation beyond in-memory trace_id grouping",
 			"validation evidence is workflow-exported and repo-native, not a continuously indexed trace service",
+		},
+	}
+}
+
+func buildBrokerReviewPack() brokerReviewPack {
+	return brokerReviewPack{
+		Status:             "checked_in_stub_evidence",
+		SummaryPath:        "docs/reports/broker-validation-summary.json",
+		ReportPath:         "docs/reports/broker-failover-stub-report.json",
+		ValidationPackPath: "docs/reports/broker-failover-fault-injection-validation-pack.md",
+		ArtifactDirectory:  "docs/reports/broker-failover-stub-artifacts",
+		ReviewerLinks: []string{
+			"docs/reports/live-validation-index.json",
+			"docs/reports/review-readiness.md",
 		},
 	}
 }

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -1929,6 +1929,14 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 					Count int    `json:"count"`
 				} `json:"takeover_owners"`
 			} `json:"cluster_health"`
+			BrokerReviewPack struct {
+				Status             string   `json:"status"`
+				SummaryPath        string   `json:"summary_path"`
+				ReportPath         string   `json:"report_path"`
+				ValidationPackPath string   `json:"validation_pack_path"`
+				ArtifactDirectory  string   `json:"artifact_directory"`
+				ReviewerLinks      []string `json:"reviewer_links"`
+			} `json:"broker_review_pack"`
 			RolloutReport struct {
 				Markdown  string `json:"markdown"`
 				ExportURL string `json:"export_url"`
@@ -1968,7 +1976,24 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	if len(decoded.Diagnostics.ClusterHealth.TakeoverOwners) == 0 || decoded.Diagnostics.ClusterHealth.TakeoverOwners[0].Key != "alice" {
 		t.Fatalf("expected takeover owner rollup, got %+v", decoded.Diagnostics.ClusterHealth)
 	}
-	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") || !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") || !strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
+	if decoded.Diagnostics.BrokerReviewPack.Status != "checked_in_stub_evidence" ||
+		decoded.Diagnostics.BrokerReviewPack.SummaryPath != "docs/reports/broker-validation-summary.json" ||
+		decoded.Diagnostics.BrokerReviewPack.ReportPath != "docs/reports/broker-failover-stub-report.json" ||
+		decoded.Diagnostics.BrokerReviewPack.ValidationPackPath != "docs/reports/broker-failover-fault-injection-validation-pack.md" ||
+		decoded.Diagnostics.BrokerReviewPack.ArtifactDirectory != "docs/reports/broker-failover-stub-artifacts" {
+		t.Fatalf("unexpected broker review pack payload: %+v", decoded.Diagnostics.BrokerReviewPack)
+	}
+	if len(decoded.Diagnostics.BrokerReviewPack.ReviewerLinks) != 2 ||
+		decoded.Diagnostics.BrokerReviewPack.ReviewerLinks[0] != "docs/reports/live-validation-index.json" ||
+		decoded.Diagnostics.BrokerReviewPack.ReviewerLinks[1] != "docs/reports/review-readiness.md" {
+		t.Fatalf("unexpected broker review pack reviewer links: %+v", decoded.Diagnostics.BrokerReviewPack.ReviewerLinks)
+	}
+	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Broker Failover Review Pack") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-validation-summary.json") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-failover-stub-artifacts") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
 		t.Fatalf("unexpected rollout report payload: %+v", decoded.Diagnostics.RolloutReport)
 	}
 }


### PR DESCRIPTION
## Summary
- add a machine-readable broker review pack to distributed diagnostics responses
- thread broker validation artifacts into the distributed export markdown and trace bundle links
- cover the new control-center payload shape with a regression test

## Testing
- cd bigclaw-go && go test ./internal/api -run TestV2ControlCenterIncludesDistributedDiagnostics -count=1