### PR TITLE
OPE-230: add broker proof summaries for rollout gates

### DIFF
--- a/bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json
+++ b/bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json
@@ -1,0 +1,117 @@
+{
+  "generated_at": "2026-03-17T12:00:00Z",
+  "ticket": "OPE-230",
+  "title": "Checkpoint fencing proof summary from broker failover stub matrix",
+  "source_report": "bigclaw-go/docs/reports/broker-failover-stub-report.json",
+  "summary_schema_version": "2026-03-17",
+  "proof_family": "checkpoint_fencing",
+  "status": "passed",
+  "rollout_gate_statuses": [
+    {
+      "name": "durable_publish_ack",
+      "status": "unknown",
+      "detail": "Checkpoint-fencing scenarios do not independently prove replicated publish acknowledgements.",
+      "scenario_ids": []
+    },
+    {
+      "name": "replay_checkpoint_alignment",
+      "status": "passed",
+      "detail": "Replay resume cursors and checkpoint commits stay in one durable sequence domain across crash, takeover, and duplicate-delivery windows.",
+      "scenario_ids": [
+        "BF-03",
+        "BF-04",
+        "BF-08"
+      ]
+    },
+    {
+      "name": "retention_boundary_visibility",
+      "status": "unknown",
+      "detail": "Retention-boundary handling is summarized separately in the retention proof summary.",
+      "scenario_ids": []
+    },
+    {
+      "name": "live_fanout_isolation",
+      "status": "unknown",
+      "detail": "These deterministic scenarios do not exercise live SSE or in-process fanout isolation.",
+      "scenario_ids": []
+    }
+  ],
+  "focus_scenarios": [
+    {
+      "scenario_id": "BF-03",
+      "fault": "consumer_crash_before_checkpoint_commit",
+      "status": "passed",
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 4
+      },
+      "stale_write_rejections": 0,
+      "duplicate_count": 0,
+      "artifacts": {
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json"
+      }
+    },
+    {
+      "scenario_id": "BF-04",
+      "fault": "checkpoint_leader_change_with_contention",
+      "status": "passed",
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-b",
+        "lease_id": "lease-2",
+        "lease_epoch": 2,
+        "durable_sequence": 3
+      },
+      "stale_write_rejections": 1,
+      "duplicate_count": 0,
+      "artifacts": {
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json"
+      }
+    },
+    {
+      "scenario_id": "BF-08",
+      "fault": "split_brain_duplicate_delivery_window",
+      "status": "passed",
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 4
+      },
+      "stale_write_rejections": 0,
+      "duplicate_count": 1,
+      "artifacts": {
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json"
+      }
+    }
+  ],
+  "summary": {
+    "scenario_count": 3,
+    "passing_scenarios": 3,
+    "failing_scenarios": 0,
+    "stale_write_rejections": 1,
+    "duplicate_replay_windows": 1
+  }
+}

--- a/bigclaw-go/docs/reports/broker-failover-stub-report.json
+++ b/bigclaw-go/docs/reports/broker-failover-stub-report.json
@@ -613,5 +613,9 @@
     "failing_scenarios": 0,
     "duplicate_count": 1,
     "missing_event_count": 0
+  },
+  "proof_artifacts": {
+    "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+    "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
   }
 }

--- a/bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json
+++ b/bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json
@@ -1,0 +1,74 @@
+{
+  "generated_at": "2026-03-17T12:00:00Z",
+  "ticket": "OPE-230",
+  "title": "Retention boundary proof summary from broker failover stub matrix",
+  "source_report": "bigclaw-go/docs/reports/broker-failover-stub-report.json",
+  "summary_schema_version": "2026-03-17",
+  "proof_family": "retention_boundary",
+  "status": "passed",
+  "rollout_gate_statuses": [
+    {
+      "name": "durable_publish_ack",
+      "status": "unknown",
+      "detail": "Retention-boundary evidence does not independently classify replicated publish acknowledgements.",
+      "scenario_ids": []
+    },
+    {
+      "name": "replay_checkpoint_alignment",
+      "status": "passed",
+      "detail": "Expired checkpoints fail closed and require an explicit reset before replay resumes from the retained sequence domain.",
+      "scenario_ids": [
+        "BF-07"
+      ]
+    },
+    {
+      "name": "retention_boundary_visibility",
+      "status": "passed",
+      "detail": "The scenario surfaces the retention floor, marks the stale checkpoint as expired, and requires an explicit operator reset.",
+      "scenario_ids": [
+        "BF-07"
+      ]
+    },
+    {
+      "name": "live_fanout_isolation",
+      "status": "unknown",
+      "detail": "Retention-boundary validation does not measure live fanout lag isolation.",
+      "scenario_ids": []
+    }
+  ],
+  "focus_scenarios": [
+    {
+      "scenario_id": "BF-07",
+      "fault": "retention_boundary_intersects_stale_checkpoint",
+      "status": "passed",
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 1
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "operator-reset",
+        "lease_id": "manual-reset",
+        "lease_epoch": 2,
+        "durable_sequence": 3
+      },
+      "retention_floor": 3,
+      "reset_required": true,
+      "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required",
+      "artifacts": {
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json"
+      }
+    }
+  ],
+  "summary": {
+    "scenario_count": 1,
+    "passing_scenarios": 1,
+    "failing_scenarios": 0,
+    "retention_floor": 3,
+    "expired_checkpoint_sequence": 1,
+    "reset_target_sequence": 3
+  }
+}

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -147,6 +147,8 @@ This report summarizes the current event bus reliability evidence and the next r
 - `docs/reports/replicated-event-log-durability-rollout-contract.md` now captures the minimum rollout gates for a broker-backed or quorum-backed adapter, and `event_durability` now includes broker bootstrap readiness for those targets:
 - `docs/reports/broker-durability-rollout-scorecard.json` mirrors the runtime contract in one checked-in JSON scorecard so reviewers can inspect readiness, blockers, and missing evidence without reconstructing them from prose.
 - `docs/reports/durability-rollout-scorecard.json` keeps the same payload under a repo-agnostic filename for queue bootstrap and automation flows.
+- `docs/reports/broker-checkpoint-fencing-proof-summary.json` isolates the stub-matrix scenarios that prove replay/checkpoint sequence monotonicity and stale-writer fencing during takeover.
+- `docs/reports/broker-retention-boundary-proof-summary.json` isolates the retention-expiry scenario that proves aged-out checkpoints fail closed until an explicit reset is recorded.
   - replicated publish acknowledgements must distinguish committed, rejected, and ambiguous outcomes;
   - replay and checkpoint state must share the same durable sequence domain across failover;
   - retention boundaries must be operator-visible before resumable recovery is claimed;

--- a/bigclaw-go/docs/reports/replay-retention-semantics-report.md
+++ b/bigclaw-go/docs/reports/replay-retention-semantics-report.md
@@ -64,6 +64,7 @@ The current Go runtime still uses in-process replay history in `internal/events/
 
 - `OPE-212` establishes the compaction and retention contract.
 - `OPE-216` established the expired replay cursor semantics, `OPE-226` added the concrete checkpoint diagnostics / reset surface for durable checkpoint resumes, and `OPE-228` extends that flow with persisted reset audit history.
+- `docs/reports/broker-retention-boundary-proof-summary.json` now captures the deterministic broker-stub scenario where a stale checkpoint falls behind the retention floor and must be reset explicitly.
 - Durable backends extending `internal/events` should expose retention watermarks before replay-aware checkpoint cleanup is implemented.
 - SQLite-backed durable logs now persist trimmed replay boundaries across restarts when a retention window is configured, giving operators a stable replay horizon even after reboot.
 
@@ -74,3 +75,4 @@ The current Go runtime still uses in-process replay history in `internal/events/
 - `internal/api/server.go`
 - `internal/api/server_test.go`
 - `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/broker-retention-boundary-proof-summary.json`

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -12,6 +12,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - `docs/reports/broker-durability-rollout-scorecard.json` now captures the same rollout posture as one checked-in machine-readable scorecard, including blockers, missing evidence, and broker bootstrap readiness.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
 - `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
+- `docs/reports/broker-checkpoint-fencing-proof-summary.json` and `docs/reports/broker-retention-boundary-proof-summary.json` now split the deterministic stub matrix into reviewable rollout-gate proofs for checkpoint fencing and retention expiry handling.
 
 ## Runtime contract
 
@@ -68,13 +69,15 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - failure-domain summaries
 - references to the supporting validation pack and rollout contract documents
 
-The current repo-native sources for these signals are the `event_durability` payload and its nested `rollout_scorecard`, plus the top-level `event_durability_rollout` alias exposed through `GET /debug/status` and `/metrics`. Checked-in reviewer artifacts live at `docs/reports/broker-durability-rollout-scorecard.json` and `docs/reports/durability-rollout-scorecard.json`.
+The current repo-native sources for these signals are the `event_durability` payload and its nested `rollout_scorecard`, plus the top-level `event_durability_rollout` alias exposed through `GET /debug/status` and `/metrics`. Checked-in reviewer artifacts live at `docs/reports/broker-durability-rollout-scorecard.json`, `docs/reports/durability-rollout-scorecard.json`, `docs/reports/broker-checkpoint-fencing-proof-summary.json`, and `docs/reports/broker-retention-boundary-proof-summary.json`.
 
 
 ## Validation evidence required before a live adapter lands
 
 - debug/control-plane payload proving the active runtime advertises the replicated rollout contract and broker bootstrap readiness state
 - failover validation artifacts matching the scenario matrix in `docs/reports/broker-failover-fault-injection-validation-pack.md`
+- checkpoint-fencing proof summary at `docs/reports/broker-checkpoint-fencing-proof-summary.json`
+- retention-boundary proof summary at `docs/reports/broker-retention-boundary-proof-summary.json`
 - replay retention diagnostics proving expired checkpoints are surfaced explicitly
 - checkpoint takeover evidence proving stale writers cannot regress durable progress
 
@@ -85,5 +88,7 @@ The current repo-native sources for these signals are the `event_durability` pay
 - `internal/api/server_test.go`
 - `cmd/bigclawd/main.go`
 - `docs/reports/event-bus-reliability-report.md`
+- `docs/reports/broker-checkpoint-fencing-proof-summary.json`
+- `docs/reports/broker-retention-boundary-proof-summary.json`
 - `docs/reports/broker-failover-fault-injection-validation-pack.md`
 - `docs/reports/replay-retention-semantics-report.md`

--- a/bigclaw-go/internal/regression/durability_rollout_scorecard_test.go
+++ b/bigclaw-go/internal/regression/durability_rollout_scorecard_test.go
@@ -72,3 +72,111 @@ func TestDurabilityRolloutScorecardReportStaysAligned(t *testing.T) {
 		}
 	}
 }
+
+func TestBrokerProofSummariesStayAligned(t *testing.T) {
+	repoRoot := repoRoot(t)
+
+	type proofSummary struct {
+		Ticket               string `json:"ticket"`
+		SourceReport         string `json:"source_report"`
+		SummarySchemaVersion string `json:"summary_schema_version"`
+		ProofFamily          string `json:"proof_family"`
+		Status               string `json:"status"`
+		RolloutGateStatuses  []struct {
+			Name        string   `json:"name"`
+			Status      string   `json:"status"`
+			ScenarioIDs []string `json:"scenario_ids"`
+		} `json:"rollout_gate_statuses"`
+	}
+
+	cases := []struct {
+		path          string
+		proofFamily   string
+		requiredGates map[string]string
+	}{
+		{
+			path:        filepath.Join(repoRoot, "docs", "reports", "broker-checkpoint-fencing-proof-summary.json"),
+			proofFamily: "checkpoint_fencing",
+			requiredGates: map[string]string{
+				"durable_publish_ack":           "unknown",
+				"replay_checkpoint_alignment":   "passed",
+				"retention_boundary_visibility": "unknown",
+				"live_fanout_isolation":         "unknown",
+			},
+		},
+		{
+			path:        filepath.Join(repoRoot, "docs", "reports", "broker-retention-boundary-proof-summary.json"),
+			proofFamily: "retention_boundary",
+			requiredGates: map[string]string{
+				"durable_publish_ack":           "unknown",
+				"replay_checkpoint_alignment":   "passed",
+				"retention_boundary_visibility": "passed",
+				"live_fanout_isolation":         "unknown",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		var summary proofSummary
+		readJSONFile(t, tc.path, &summary)
+		if summary.Ticket != "OPE-230" {
+			t.Fatalf("%s ticket = %q, want OPE-230", tc.path, summary.Ticket)
+		}
+		if summary.SourceReport != "bigclaw-go/docs/reports/broker-failover-stub-report.json" {
+			t.Fatalf("%s source_report = %q", tc.path, summary.SourceReport)
+		}
+		if summary.SummarySchemaVersion == "" {
+			t.Fatalf("%s missing summary_schema_version", tc.path)
+		}
+		if summary.ProofFamily != tc.proofFamily {
+			t.Fatalf("%s proof_family = %q, want %q", tc.path, summary.ProofFamily, tc.proofFamily)
+		}
+		if summary.Status != "passed" {
+			t.Fatalf("%s status = %q, want passed", tc.path, summary.Status)
+		}
+		actualGates := map[string]string{}
+		for _, gate := range summary.RolloutGateStatuses {
+			actualGates[gate.Name] = gate.Status
+		}
+		for gate, want := range tc.requiredGates {
+			if actualGates[gate] != want {
+				t.Fatalf("%s gate %s = %q, want %q", tc.path, gate, actualGates[gate], want)
+			}
+		}
+	}
+
+	docCases := []struct {
+		path       string
+		substrings []string
+	}{
+		{
+			path: "docs/reports/event-bus-reliability-report.md",
+			substrings: []string{
+				"broker-checkpoint-fencing-proof-summary.json",
+				"broker-retention-boundary-proof-summary.json",
+			},
+		},
+		{
+			path: "docs/reports/replicated-event-log-durability-rollout-contract.md",
+			substrings: []string{
+				"broker-checkpoint-fencing-proof-summary.json",
+				"broker-retention-boundary-proof-summary.json",
+			},
+		},
+		{
+			path: "docs/reports/replay-retention-semantics-report.md",
+			substrings: []string{
+				"broker-retention-boundary-proof-summary.json",
+			},
+		},
+	}
+
+	for _, tc := range docCases {
+		contents := readRepoFile(t, repoRoot, tc.path)
+		for _, needle := range tc.substrings {
+			if !strings.Contains(contents, needle) {
+				t.Fatalf("%s missing substring %q", tc.path, needle)
+			}
+		}
+	}
+}

--- a/bigclaw-go/scripts/e2e/broker_failover_stub_matrix.py
+++ b/bigclaw-go/scripts/e2e/broker_failover_stub_matrix.py
@@ -10,6 +10,8 @@ from typing import Dict, List, Optional, Tuple
 
 REPORT_PATH = 'bigclaw-go/docs/reports/broker-failover-stub-report.json'
 ARTIFACT_ROOT = 'bigclaw-go/docs/reports/broker-failover-stub-artifacts'
+CHECKPOINT_FENCING_SUMMARY_PATH = 'bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json'
+RETENTION_BOUNDARY_SUMMARY_PATH = 'bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json'
 
 
 def utc_iso(value: datetime) -> str:
@@ -268,6 +270,154 @@ def required_artifacts(artifact_root: str) -> dict:
         'checkpoint_transition_log': f'{artifact_root}/checkpoint-transition-log.json',
         'fault_timeline': f'{artifact_root}/fault-timeline.json',
         'backend_health_snapshot': f'{artifact_root}/backend-health.json',
+    }
+
+
+def proof_artifact_paths() -> dict:
+    return {
+        'checkpoint_fencing_summary': CHECKPOINT_FENCING_SUMMARY_PATH,
+        'retention_boundary_summary': RETENTION_BOUNDARY_SUMMARY_PATH,
+    }
+
+
+def _proof_gate(name: str, status: str, detail: str, scenarios: List[str]) -> dict:
+    return {
+        'name': name,
+        'status': status,
+        'detail': detail,
+        'scenario_ids': scenarios,
+    }
+
+
+def build_checkpoint_fencing_summary(report: dict) -> dict:
+    scenarios = {scenario['scenario_id']: scenario for scenario in report['scenarios']}
+    focus_ids = ['BF-03', 'BF-04', 'BF-08']
+    focus = [scenarios[scenario_id] for scenario_id in focus_ids]
+    stale_write_rejections = sum(scenario.get('stale_write_rejections', 0) for scenario in focus)
+    duplicate_replay_windows = sum(scenario.get('duplicate_count', 0) for scenario in focus)
+    return {
+        'generated_at': report['generated_at'],
+        'ticket': 'OPE-230',
+        'title': 'Checkpoint fencing proof summary from broker failover stub matrix',
+        'source_report': REPORT_PATH,
+        'summary_schema_version': '2026-03-17',
+        'proof_family': 'checkpoint_fencing',
+        'status': 'passed' if all(scenario['result'] == 'passed' for scenario in focus) else 'failed',
+        'rollout_gate_statuses': [
+            _proof_gate(
+                'durable_publish_ack',
+                'unknown',
+                'Checkpoint-fencing scenarios do not independently prove replicated publish acknowledgements.',
+                [],
+            ),
+            _proof_gate(
+                'replay_checkpoint_alignment',
+                'passed',
+                'Replay resume cursors and checkpoint commits stay in one durable sequence domain across crash, takeover, and duplicate-delivery windows.',
+                focus_ids,
+            ),
+            _proof_gate(
+                'retention_boundary_visibility',
+                'unknown',
+                'Retention-boundary handling is summarized separately in the retention proof summary.',
+                [],
+            ),
+            _proof_gate(
+                'live_fanout_isolation',
+                'unknown',
+                'These deterministic scenarios do not exercise live SSE or in-process fanout isolation.',
+                [],
+            ),
+        ],
+        'focus_scenarios': [
+            {
+                'scenario_id': scenario['scenario_id'],
+                'fault': scenario['fault_window']['fault'],
+                'status': scenario['result'],
+                'checkpoint_before_fault': scenario['checkpoint_before_fault'],
+                'checkpoint_after_recovery': scenario['checkpoint_after_recovery'],
+                'stale_write_rejections': scenario.get('stale_write_rejections', 0),
+                'duplicate_count': scenario['duplicate_count'],
+                'artifacts': {
+                    'replay_capture': scenario['artifacts']['replay_capture'],
+                    'checkpoint_transition_log': scenario['artifacts']['checkpoint_transition_log'],
+                },
+            }
+            for scenario in focus
+        ],
+        'summary': {
+            'scenario_count': len(focus),
+            'passing_scenarios': sum(1 for scenario in focus if scenario['result'] == 'passed'),
+            'failing_scenarios': sum(1 for scenario in focus if scenario['result'] != 'passed'),
+            'stale_write_rejections': stale_write_rejections,
+            'duplicate_replay_windows': duplicate_replay_windows,
+        },
+    }
+
+
+def build_retention_boundary_summary(report: dict) -> dict:
+    scenario = next(scenario for scenario in report['scenarios'] if scenario['scenario_id'] == 'BF-07')
+    retention_floor = scenario['topology']['retention_floor']
+    reset_target = scenario['checkpoint_after_recovery']['durable_sequence']
+    return {
+        'generated_at': report['generated_at'],
+        'ticket': 'OPE-230',
+        'title': 'Retention boundary proof summary from broker failover stub matrix',
+        'source_report': REPORT_PATH,
+        'summary_schema_version': '2026-03-17',
+        'proof_family': 'retention_boundary',
+        'status': scenario['result'],
+        'rollout_gate_statuses': [
+            _proof_gate(
+                'durable_publish_ack',
+                'unknown',
+                'Retention-boundary evidence does not independently classify replicated publish acknowledgements.',
+                [],
+            ),
+            _proof_gate(
+                'replay_checkpoint_alignment',
+                'passed',
+                'Expired checkpoints fail closed and require an explicit reset before replay resumes from the retained sequence domain.',
+                ['BF-07'],
+            ),
+            _proof_gate(
+                'retention_boundary_visibility',
+                'passed',
+                'The scenario surfaces the retention floor, marks the stale checkpoint as expired, and requires an explicit operator reset.',
+                ['BF-07'],
+            ),
+            _proof_gate(
+                'live_fanout_isolation',
+                'unknown',
+                'Retention-boundary validation does not measure live fanout lag isolation.',
+                [],
+            ),
+        ],
+        'focus_scenarios': [
+            {
+                'scenario_id': scenario['scenario_id'],
+                'fault': scenario['fault_window']['fault'],
+                'status': scenario['result'],
+                'checkpoint_before_fault': scenario['checkpoint_before_fault'],
+                'checkpoint_after_recovery': scenario['checkpoint_after_recovery'],
+                'retention_floor': retention_floor,
+                'reset_required': bool(scenario['replay_resume_cursor'].get('reset_required')),
+                'operator_guidance': scenario.get('operator_guidance', ''),
+                'artifacts': {
+                    'fault_timeline': scenario['artifacts']['fault_timeline'],
+                    'backend_health_snapshot': scenario['artifacts']['backend_health_snapshot'],
+                    'checkpoint_transition_log': scenario['artifacts']['checkpoint_transition_log'],
+                },
+            }
+        ],
+        'summary': {
+            'scenario_count': 1,
+            'passing_scenarios': 1 if scenario['result'] == 'passed' else 0,
+            'failing_scenarios': 0 if scenario['result'] == 'passed' else 1,
+            'retention_floor': retention_floor,
+            'expired_checkpoint_sequence': scenario['checkpoint_before_fault']['durable_sequence'],
+            'reset_target_sequence': reset_target,
+        },
     }
 
 
@@ -764,14 +914,33 @@ def build_report() -> dict:
             scenario['scenario_id']: scenario['raw_artifacts']
             for scenario in scenarios
         },
+        'proof_artifacts': proof_artifact_paths(),
     }
 
 
-def write_report(report: dict, *, output: pathlib.Path, artifact_root: pathlib.Path, pretty: bool) -> None:
+def write_report(
+    report: dict,
+    *,
+    output: pathlib.Path,
+    artifact_root: pathlib.Path,
+    checkpoint_fencing_summary_output: pathlib.Path,
+    retention_boundary_summary_output: pathlib.Path,
+    pretty: bool,
+) -> None:
     output.parent.mkdir(parents=True, exist_ok=True)
     artifact_root.mkdir(parents=True, exist_ok=True)
+    checkpoint_fencing_summary_output.parent.mkdir(parents=True, exist_ok=True)
+    retention_boundary_summary_output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text(
         json.dumps({key: value for key, value in report.items() if key != 'raw_artifacts'}, indent=2 if pretty else None) + '\n',
+        encoding='utf-8',
+    )
+    checkpoint_fencing_summary_output.write_text(
+        json.dumps(build_checkpoint_fencing_summary(report), indent=2 if pretty else None) + '\n',
+        encoding='utf-8',
+    )
+    retention_boundary_summary_output.write_text(
+        json.dumps(build_retention_boundary_summary(report), indent=2 if pretty else None) + '\n',
         encoding='utf-8',
     )
     for scenario_id, artifact_payloads in report['raw_artifacts'].items():
@@ -794,6 +963,8 @@ def main() -> None:
     parser = argparse.ArgumentParser(description='Generate deterministic broker failover stub validation artifacts')
     parser.add_argument('--output', default=REPORT_PATH)
     parser.add_argument('--artifact-root', default=ARTIFACT_ROOT)
+    parser.add_argument('--checkpoint-fencing-summary-output', default=CHECKPOINT_FENCING_SUMMARY_PATH)
+    parser.add_argument('--retention-boundary-summary-output', default=RETENTION_BOUNDARY_SUMMARY_PATH)
     parser.add_argument('--pretty', action='store_true')
     args = parser.parse_args()
 
@@ -803,6 +974,8 @@ def main() -> None:
         report,
         output=repo_root / args.output,
         artifact_root=repo_root / args.artifact_root,
+        checkpoint_fencing_summary_output=repo_root / args.checkpoint_fencing_summary_output,
+        retention_boundary_summary_output=repo_root / args.retention_boundary_summary_output,
         pretty=args.pretty,
     )
 

--- a/bigclaw-go/scripts/e2e/broker_failover_stub_matrix_test.py
+++ b/bigclaw-go/scripts/e2e/broker_failover_stub_matrix_test.py
@@ -43,6 +43,13 @@ class BrokerFailoverStubMatrixTest(unittest.TestCase):
         for scenario in report['scenarios']:
             self.assertTrue(required_keys.issubset(scenario.keys()))
             self.assertEqual(scenario['result'], 'passed')
+        self.assertEqual(
+            report['proof_artifacts'],
+            {
+                'checkpoint_fencing_summary': 'bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json',
+                'retention_boundary_summary': 'bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json',
+            },
+        )
 
     def test_checkpoint_and_durable_sequence_assertions_hold_for_fencing_scenarios(self) -> None:
         report = MODULE.build_report()
@@ -63,6 +70,25 @@ class BrokerFailoverStubMatrixTest(unittest.TestCase):
         bf08 = scenarios['BF-08']
         self.assertEqual(bf08['duplicate_count'], 1)
         self.assertEqual(bf08['missing_event_ids'], [])
+
+    def test_proof_summaries_project_scenario_evidence_into_rollout_gate_statuses(self) -> None:
+        report = MODULE.build_report()
+
+        checkpoint = MODULE.build_checkpoint_fencing_summary(report)
+        self.assertEqual(checkpoint['ticket'], 'OPE-230')
+        self.assertEqual(checkpoint['proof_family'], 'checkpoint_fencing')
+        checkpoint_gates = {gate['name']: gate for gate in checkpoint['rollout_gate_statuses']}
+        self.assertEqual(checkpoint_gates['replay_checkpoint_alignment']['status'], 'passed')
+        self.assertEqual(checkpoint_gates['retention_boundary_visibility']['status'], 'unknown')
+        self.assertEqual(checkpoint['summary']['stale_write_rejections'], 1)
+
+        retention = MODULE.build_retention_boundary_summary(report)
+        self.assertEqual(retention['ticket'], 'OPE-230')
+        self.assertEqual(retention['proof_family'], 'retention_boundary')
+        retention_gates = {gate['name']: gate for gate in retention['rollout_gate_statuses']}
+        self.assertEqual(retention_gates['retention_boundary_visibility']['status'], 'passed')
+        self.assertTrue(retention['focus_scenarios'][0]['reset_required'])
+        self.assertEqual(retention['summary']['retention_floor'], 3)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- derive checkpoint-fencing and retention-boundary proof summary JSON from the broker failover stub matrix
- check in the generated proof summaries and wire them into the broker failover report output
- reference the new proof summaries from rollout and retention docs and lock them with regression tests

## Validation
- python3 -m unittest bigclaw-go/scripts/e2e/broker_failover_stub_matrix_test.py
- go test ./internal/regression ./internal/events
