### PR TITLE
OPE-227: add broker stub event log backend

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -50,14 +50,19 @@ func main() {
 		}
 		defer closeEventLog(eventLog)
 	default:
-		if _, err = buildEventLog(cfg); err != nil {
+		eventLog, err = buildEventLog(cfg)
+		if err != nil {
 			panic(err)
+		}
+		if eventLog != nil {
+			eventPlanBackend = eventLog.Backend()
 		}
 	}
 
 	bus := events.NewBus()
 	if eventLog != nil {
 		bus.AddSink(eventLog)
+		bus.SetCapabilities(eventLog.Capabilities())
 	}
 	recorder := buildRecorder(cfg)
 	bus.AddSink(events.RecorderSink{Recorder: recorder})
@@ -149,14 +154,17 @@ func closeSubscriberLeaseStore(store events.SubscriberLeaseStore) {
 	}
 }
 
-func buildEventLog(cfg config.Config) (*events.MemoryLog, error) {
+func buildEventLog(cfg config.Config) (events.EventLog, error) {
 	switch cfg.EventLogBackend {
 	case "", string(events.EventLogBackendMemory):
-		return events.NewMemoryLog(), nil
+		return nil, nil
 	case string(events.EventLogBackendBroker):
 		broker := brokerRuntimeConfig(cfg)
 		if err := broker.Validate(); err != nil {
 			return nil, err
+		}
+		if broker.Driver == events.BrokerDriverStub {
+			return events.NewBrokerStubEventLog(), nil
 		}
 		return nil, fmt.Errorf("event log backend %q is not implemented yet; driver=%s topic=%s contract validated for the future adapter", cfg.EventLogBackend, broker.Driver, broker.Topic)
 	default:

--- a/bigclaw-go/cmd/bigclawd/main_test.go
+++ b/bigclaw-go/cmd/bigclawd/main_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"bigclaw-go/internal/config"
+	"bigclaw-go/internal/events"
+)
+
+func TestBuildEventLogUsesBrokerStubDriver(t *testing.T) {
+	defaults := config.Default()
+	eventLog, err := buildEventLog(config.Config{
+		EventLogBackend:            string(events.EventLogBackendBroker),
+		EventLogBrokerDriver:       events.BrokerDriverStub,
+		EventLogBrokerURLs:         []string{"stub://broker-a"},
+		EventLogBrokerTopic:        "bigclaw.events",
+		EventLogPublishTimeout:     defaults.EventLogPublishTimeout,
+		EventLogReplayLimit:        defaults.EventLogReplayLimit,
+		EventLogCheckpointInterval: defaults.EventLogCheckpointInterval,
+	})
+	if err != nil {
+		t.Fatalf("build event log: %v", err)
+	}
+	if eventLog == nil || eventLog.Backend() != "broker_stub" {
+		t.Fatalf("expected broker stub backend, got %#v", eventLog)
+	}
+	if capability := eventLog.Capabilities(); capability.Backend != "broker_stub" || capability.Retention.Mode != "process_memory_stub" {
+		t.Fatalf("unexpected broker stub capability payload: %+v", capability)
+	}
+}
+
+func TestBuildEventLogRejectsUnimplementedBrokerDriver(t *testing.T) {
+	cfg := config.Default()
+	cfg.EventLogBackend = string(events.EventLogBackendBroker)
+	cfg.EventLogBrokerDriver = "kafka"
+	cfg.EventLogBrokerURLs = []string{"kafka-1:9092"}
+	cfg.EventLogBrokerTopic = "bigclaw.events"
+
+	eventLog, err := buildEventLog(cfg)
+	if err == nil {
+		t.Fatalf("expected unimplemented broker driver error, got event log %#v", eventLog)
+	}
+}

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -2974,6 +2974,32 @@ func TestDebugStatusIncludesCheckpointResetSummary(t *testing.T) {
 	}
 }
 
+func TestDebugStatusDistinguishesBrokerStubEventLog(t *testing.T) {
+	store := events.NewBrokerStubEventLog()
+	if err := store.Write(context.Background(), domain.Event{
+		ID:        "evt-broker-stub-debug-1",
+		Type:      domain.EventTaskQueued,
+		TaskID:    "task-broker-stub-debug",
+		TraceID:   "trace-broker-stub-debug",
+		Timestamp: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("write broker stub event: %v", err)
+	}
+	server := &Server{Recorder: observability.NewRecorder(), Queue: queue.NewMemoryQueue(), Bus: events.NewBus(), EventLog: store, Now: time.Now}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected debug status 200, got %d", response.Code)
+	}
+	body := response.Body.String()
+	for _, want := range []string{"broker_stub", "process_local_stub", "append_only_stub", "process_memory_stub"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in broker stub debug payload, got %s", want, body)
+		}
+	}
+}
+
 func TestStreamEventCheckpointExpiredDiagnosticsAndReset(t *testing.T) {
 	logPath := filepath.Join(t.TempDir(), "event-log.db")
 	base := time.Unix(1_700_000_000, 0).UTC()

--- a/bigclaw-go/internal/events/broker_stub_log.go
+++ b/bigclaw-go/internal/events/broker_stub_log.go
@@ -1,0 +1,227 @@
+package events
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"bigclaw-go/internal/domain"
+)
+
+type BrokerStubEventLog struct {
+	mu          sync.RWMutex
+	history     []domain.Event
+	checkpoints map[string]SubscriberCheckpoint
+	nextSeq     int64
+}
+
+func NewBrokerStubEventLog() *BrokerStubEventLog {
+	return &BrokerStubEventLog{
+		checkpoints: make(map[string]SubscriberCheckpoint),
+	}
+}
+
+func (s *BrokerStubEventLog) Backend() string {
+	return "broker_stub"
+}
+
+func (s *BrokerStubEventLog) Capabilities() BackendCapabilities {
+	return BackendCapabilities{
+		Backend: "broker_stub",
+		Scope:   "process_local_stub",
+		Publish: FeatureSupport{
+			Supported: true,
+			Mode:      "append_only_stub",
+			Detail:    "Local deterministic broker stub publishes into a repo-native in-process event log.",
+		},
+		Replay: FeatureSupport{
+			Supported: true,
+			Mode:      "ordered_stub_replay",
+			Detail:    "Replay is served from the stub history so broker append and resume flows can be validated locally.",
+		},
+		Checkpoint: FeatureSupport{
+			Supported: true,
+			Mode:      "subscriber_ack_stub",
+			Detail:    "Subscriber checkpoints are stored by the local stub for contract validation only.",
+		},
+		Dedup: FeatureSupport{
+			Supported: false,
+			Detail:    "The broker stub does not model durable deduplication.",
+		},
+		Filtering: FeatureSupport{
+			Supported: true,
+			Mode:      "server_side",
+			Detail:    "Task and trace filters are applied against stub replay history.",
+		},
+		Retention: FeatureSupport{
+			Supported: true,
+			Mode:      "process_memory_stub",
+			Detail:    "History lasts only for the current process and is not a real broker durability boundary.",
+		},
+	}
+}
+
+func (s *BrokerStubEventLog) Write(ctx context.Context, event domain.Event) error {
+	_, err := s.Publish(ctx, event)
+	return err
+}
+
+func (s *BrokerStubEventLog) Publish(_ context.Context, event domain.Event) (Record, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	recorded := cloneEvent(event)
+	if recorded.Timestamp.IsZero() {
+		recorded.Timestamp = time.Now().UTC()
+	}
+	s.nextSeq++
+	s.history = append(s.history, recorded)
+	return Record{
+		Event:       cloneEvent(recorded),
+		Position:    Position{Sequence: s.nextSeq, Partition: "stub", Offset: stubOffset(s.nextSeq)},
+		PublishedAt: recorded.Timestamp,
+	}, nil
+}
+
+func (s *BrokerStubEventLog) Replay(limit int) ([]domain.Event, error) {
+	return s.queryEvents("", "", "", limit), nil
+}
+
+func (s *BrokerStubEventLog) ReplayAfter(afterID string, limit int) ([]domain.Event, error) {
+	return s.queryEvents("", "", strings.TrimSpace(afterID), limit), nil
+}
+
+func (s *BrokerStubEventLog) EventsByTask(taskID string, limit int) ([]domain.Event, error) {
+	return s.queryEvents(strings.TrimSpace(taskID), "", "", limit), nil
+}
+
+func (s *BrokerStubEventLog) EventsByTaskAfter(taskID string, afterID string, limit int) ([]domain.Event, error) {
+	return s.queryEvents(strings.TrimSpace(taskID), "", strings.TrimSpace(afterID), limit), nil
+}
+
+func (s *BrokerStubEventLog) EventsByTrace(traceID string, limit int) ([]domain.Event, error) {
+	return s.queryEvents("", strings.TrimSpace(traceID), "", limit), nil
+}
+
+func (s *BrokerStubEventLog) EventsByTraceAfter(traceID string, afterID string, limit int) ([]domain.Event, error) {
+	return s.queryEvents("", strings.TrimSpace(traceID), strings.TrimSpace(afterID), limit), nil
+}
+
+func (s *BrokerStubEventLog) Acknowledge(subscriberID string, eventID string, at time.Time) (SubscriberCheckpoint, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriberID = strings.TrimSpace(subscriberID)
+	eventID = strings.TrimSpace(eventID)
+	if subscriberID == "" || eventID == "" {
+		return SubscriberCheckpoint{}, sql.ErrNoRows
+	}
+	sequence := int64(0)
+	for index, event := range s.history {
+		if event.ID == eventID {
+			sequence = int64(index + 1)
+			break
+		}
+	}
+	if sequence == 0 {
+		return SubscriberCheckpoint{}, sql.ErrNoRows
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	checkpoint := SubscriberCheckpoint{
+		SubscriberID:  subscriberID,
+		EventID:       eventID,
+		EventSequence: sequence,
+		UpdatedAt:     at.UTC(),
+	}
+	s.checkpoints[subscriberID] = checkpoint
+	return checkpoint, nil
+}
+
+func (s *BrokerStubEventLog) Checkpoint(subscriberID string) (SubscriberCheckpoint, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	checkpoint, ok := s.checkpoints[strings.TrimSpace(subscriberID)]
+	if !ok {
+		return SubscriberCheckpoint{}, sql.ErrNoRows
+	}
+	return checkpoint, nil
+}
+
+func (s *BrokerStubEventLog) RetentionWatermark() (RetentionWatermark, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	watermark := RetentionWatermark{
+		Backend:           "broker_stub",
+		Policy:            "process_memory_stub",
+		EventCount:        len(s.history),
+		PersistedBoundary: false,
+	}
+	if len(s.history) == 0 {
+		return watermark, nil
+	}
+	watermark.OldestEventID = s.history[0].ID
+	watermark.NewestEventID = s.history[len(s.history)-1].ID
+	watermark.OldestSequence = 1
+	watermark.NewestSequence = int64(len(s.history))
+	return watermark, nil
+}
+
+func (s *BrokerStubEventLog) Path() string {
+	return ""
+}
+
+func (s *BrokerStubEventLog) Close() error {
+	return nil
+}
+
+func (s *BrokerStubEventLog) queryEvents(taskID, traceID, afterID string, limit int) []domain.Event {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	start := 0
+	if afterID != "" {
+		for index, event := range s.history {
+			if event.ID == afterID {
+				start = index + 1
+				break
+			}
+		}
+	}
+	filtered := make([]domain.Event, 0, len(s.history)-start)
+	for _, event := range s.history[start:] {
+		if taskID != "" && event.TaskID != taskID {
+			continue
+		}
+		if traceID != "" && event.TraceID != traceID {
+			continue
+		}
+		filtered = append(filtered, cloneEvent(event))
+	}
+	if limit > 0 && len(filtered) > limit {
+		filtered = filtered[len(filtered)-limit:]
+	}
+	return filtered
+}
+
+func cloneEvent(event domain.Event) domain.Event {
+	if event.Payload == nil {
+		return event
+	}
+	copied := make(map[string]any, len(event.Payload))
+	for key, value := range event.Payload {
+		copied[key] = value
+	}
+	event.Payload = copied
+	return event
+}
+
+func stubOffset(sequence int64) string {
+	return fmt.Sprintf("stub-%d", sequence)
+}

--- a/bigclaw-go/internal/events/broker_stub_log_test.go
+++ b/bigclaw-go/internal/events/broker_stub_log_test.go
@@ -1,0 +1,78 @@
+package events
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"bigclaw-go/internal/domain"
+)
+
+func TestBrokerStubEventLogSupportsReplayAndCheckpoints(t *testing.T) {
+	log := NewBrokerStubEventLog()
+	base := time.Unix(1_700_000_000, 0).UTC()
+	for _, event := range []domain.Event{
+		{ID: "evt-broker-stub-1", Type: domain.EventTaskQueued, TaskID: "task-broker-stub", TraceID: "trace-a", Timestamp: base},
+		{ID: "evt-broker-stub-2", Type: domain.EventTaskStarted, TaskID: "task-broker-stub", TraceID: "trace-a", Timestamp: base.Add(time.Second)},
+		{ID: "evt-broker-stub-3", Type: domain.EventTaskCompleted, TaskID: "task-broker-stub-2", TraceID: "trace-b", Timestamp: base.Add(2 * time.Second)},
+	} {
+		if err := log.Write(context.Background(), event); err != nil {
+			t.Fatalf("write %s: %v", event.ID, err)
+		}
+	}
+
+	replayed, err := log.ReplayAfter("evt-broker-stub-1", 10)
+	if err != nil {
+		t.Fatalf("replay after: %v", err)
+	}
+	if len(replayed) != 2 || replayed[0].ID != "evt-broker-stub-2" || replayed[1].ID != "evt-broker-stub-3" {
+		t.Fatalf("unexpected replay after payload: %+v", replayed)
+	}
+
+	byTask, err := log.EventsByTask("task-broker-stub", 10)
+	if err != nil {
+		t.Fatalf("events by task: %v", err)
+	}
+	if len(byTask) != 2 {
+		t.Fatalf("expected two task-filtered events, got %+v", byTask)
+	}
+
+	checkpoint, err := log.Acknowledge("subscriber-broker-stub", "evt-broker-stub-2", base.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("acknowledge: %v", err)
+	}
+	if checkpoint.EventSequence != 2 {
+		t.Fatalf("expected checkpoint sequence 2, got %+v", checkpoint)
+	}
+	stored, err := log.Checkpoint("subscriber-broker-stub")
+	if err != nil {
+		t.Fatalf("checkpoint: %v", err)
+	}
+	if stored.EventID != "evt-broker-stub-2" || stored.EventSequence != 2 {
+		t.Fatalf("unexpected stored checkpoint: %+v", stored)
+	}
+
+	watermark, err := log.RetentionWatermark()
+	if err != nil {
+		t.Fatalf("retention watermark: %v", err)
+	}
+	if watermark.Backend != "broker_stub" || watermark.EventCount != 3 || watermark.NewestSequence != 3 {
+		t.Fatalf("unexpected watermark: %+v", watermark)
+	}
+}
+
+func TestBrokerStubEventLogCapabilitiesAdvertiseStubMode(t *testing.T) {
+	capability := NewBrokerStubEventLog().Capabilities()
+	if capability.Backend != "broker_stub" || capability.Scope != "process_local_stub" {
+		t.Fatalf("unexpected capability header: %+v", capability)
+	}
+	if !capability.Publish.Supported || !capability.Replay.Supported || !capability.Checkpoint.Supported {
+		t.Fatalf("expected publish/replay/checkpoint support, got %+v", capability)
+	}
+	if capability.Dedup.Supported {
+		t.Fatalf("expected dedup to stay unsupported in stub mode, got %+v", capability)
+	}
+	if capability.Retention.Mode != "process_memory_stub" {
+		t.Fatalf("expected stub retention mode, got %+v", capability.Retention)
+	}
+}

--- a/bigclaw-go/internal/events/log.go
+++ b/bigclaw-go/internal/events/log.go
@@ -14,6 +14,8 @@ type EventLogBackend string
 const (
 	EventLogBackendMemory EventLogBackend = "memory"
 	EventLogBackendBroker EventLogBackend = "broker"
+
+	BrokerDriverStub = "stub"
 )
 
 type Position struct {


### PR DESCRIPTION
## Summary
- add a local deterministic `broker_stub` event log that satisfies append, replay, checkpoint, and retention watermark contract calls
- wire `BIGCLAW_EVENT_LOG_BACKEND=broker` plus `BIGCLAW_EVENT_LOG_BROKER_DRIVER=stub` through bootstrap so local validation can run without an external broker
- add Go coverage for bootstrap selection, stub capability payloads, replay filtering, checkpoints, and debug API exposure

## Testing
- `cd bigclaw-go && go test ./cmd/bigclawd ./internal/events ./internal/api`
