### PR TITLE
OPE-264: surface delivery ack readiness diagnostics

### DIFF
--- a/bigclaw-go/docs/reports/delivery-ack-readiness-surface.json
+++ b/bigclaw-go/docs/reports/delivery-ack-readiness-surface.json
@@ -1,0 +1,113 @@
+{
+  "generated_at": "2026-03-17T15:40:00Z",
+  "ticket": "OPE-264",
+  "title": "Delivery acknowledgement readiness surface for event log backends",
+  "status": "checked_in_surface",
+  "evidence_sources": [
+    "bigclaw-go/internal/events/capabilities.go",
+    "bigclaw-go/internal/events/sqlite_log.go",
+    "bigclaw-go/internal/events/http_log.go",
+    "bigclaw-go/internal/events/broker_stub_log.go",
+    "bigclaw-go/docs/reports/event-bus-reliability-report.md",
+    "bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md"
+  ],
+  "reviewer_links": [
+    "/debug/status",
+    "/v2/control-center",
+    "/v2/reports/distributed/export",
+    "docs/reports/event-bus-reliability-report.md",
+    "docs/reports/replicated-event-log-durability-rollout-contract.md"
+  ],
+  "summary": {
+    "backend_count": 5,
+    "explicit_ack_backends": 3,
+    "durable_ack_backends": 2,
+    "best_effort_backends": 1,
+    "contract_only_backends": 1
+  },
+  "backends": [
+    {
+      "backend": "memory",
+      "scope": "process_local",
+      "publish_mode": "live_fanout",
+      "acknowledgement_class": "best_effort_only",
+      "explicit_acknowledgement": false,
+      "durable_acknowledgement": false,
+      "runtime_readiness": "best_effort",
+      "source_report_links": [
+        "docs/reports/event-bus-reliability-report.md"
+      ],
+      "notes": [
+        "In-process publish succeeds without a durable commit boundary.",
+        "Sink write failures are not promoted into a backend-level delivery acknowledgement contract."
+      ]
+    },
+    {
+      "backend": "sqlite",
+      "scope": "shared_node",
+      "publish_mode": "append_only",
+      "acknowledgement_class": "explicit_durable_commit",
+      "explicit_acknowledgement": true,
+      "durable_acknowledgement": true,
+      "runtime_readiness": "implemented",
+      "source_report_links": [
+        "docs/reports/event-bus-reliability-report.md"
+      ],
+      "notes": [
+        "Publish returns after the SQLite append succeeds.",
+        "This is a durable single-node acknowledgement, not a replicated quorum guarantee."
+      ]
+    },
+    {
+      "backend": "http",
+      "scope": "remote_service",
+      "publish_mode": "append_only",
+      "acknowledgement_class": "explicit_service_commit",
+      "explicit_acknowledgement": true,
+      "durable_acknowledgement": true,
+      "runtime_readiness": "implemented",
+      "source_report_links": [
+        "docs/reports/event-bus-reliability-report.md"
+      ],
+      "notes": [
+        "Publish success is delegated to the remote event-log service response.",
+        "Durability depends on the shared service implementation rather than local process memory."
+      ]
+    },
+    {
+      "backend": "broker_stub",
+      "scope": "process_local_stub",
+      "publish_mode": "append_only_stub",
+      "acknowledgement_class": "explicit_stub_commit",
+      "explicit_acknowledgement": true,
+      "durable_acknowledgement": false,
+      "runtime_readiness": "stub_validation_only",
+      "source_report_links": [
+        "docs/reports/event-bus-reliability-report.md",
+        "docs/reports/broker-failover-stub-report.json"
+      ],
+      "notes": [
+        "Publish returns after the local deterministic stub append succeeds.",
+        "The acknowledgement is explicit for contract validation, but the history remains process-local and non-durable."
+      ]
+    },
+    {
+      "backend": "broker_replicated",
+      "scope": "provider_defined_replicated_log",
+      "publish_mode": "contract_only",
+      "acknowledgement_class": "contract_only",
+      "explicit_acknowledgement": false,
+      "durable_acknowledgement": false,
+      "runtime_readiness": "contract_only",
+      "source_report_links": [
+        "docs/reports/event-bus-reliability-report.md",
+        "docs/reports/replicated-event-log-durability-rollout-contract.md",
+        "docs/reports/durability-rollout-scorecard.json"
+      ],
+      "notes": [
+        "The rollout contract requires explicit durable publish acknowledgement before success is reported.",
+        "No concrete replicated broker backend is shipped in this checkout yet."
+      ]
+    }
+  ]
+}

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -22,6 +22,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Subscriber-group checkpoint lease coordination via `/subscriber-groups/leases` and `/subscriber-groups/checkpoints`
 - Event backend capability and config-validation contract via `internal/events/backend_contract.go`
 - Event-log backend capability probe surfaced through control/debug responses before replay-oriented dispatch
+- Delivery acknowledgement readiness surface via `docs/reports/delivery-ack-readiness-surface.json` and reviewer-facing debug/distributed diagnostics
 
 ## Validated behaviors
 
@@ -60,6 +61,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - `internal/api/server_test.go`
 - `cmd/bigclawd/main.go`
 - `internal/config/config.go`
+- `docs/reports/delivery-ack-readiness-surface.json`
 
 ## Current durability shape
 
@@ -134,7 +136,7 @@ This report summarizes the current event bus reliability evidence and the next r
 
 - No concrete durable external event log exists yet in this checkout; replay still depends on process-local history plus the documented integration plan.
 - Only the SQLite durable consumer dedup backend exists yet; HTTP and broker-backed dedup persistence still need concrete implementations.
-- No delivery acknowledgement protocol exists beyond sink-level best effort.
+- Memory bus delivery acknowledgements remain sink-level best effort; explicit commit acknowledgements exist for SQLite, the remote HTTP event-log service, and the local broker stub, while replicated broker acknowledgements remain contract-only.
 - Lease coordination now has a shared durable SQLite-backed scaffold for shared multi-node subscriber groups, but broker-backed and replicated ownership semantics still need a durable backend beyond SQLite.
 - No runtime partitioned topic model or broker-backed cross-process subscriber coordination exists yet; only the contract-only `PartitionRoute` and `SubscriberOwnershipContract` targets are defined today. See `docs/reports/cross-process-coordination-boundary-digest.md`.
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.

--- a/bigclaw-go/internal/api/delivery_ack_surface.go
+++ b/bigclaw-go/internal/api/delivery_ack_surface.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const deliveryAckReadinessSurfacePath = "docs/reports/delivery-ack-readiness-surface.json"
+
+type deliveryAckReadinessSurface struct {
+	ReportPath      string                      `json:"report_path"`
+	GeneratedAt     string                      `json:"generated_at,omitempty"`
+	Ticket          string                      `json:"ticket,omitempty"`
+	Title           string                      `json:"title,omitempty"`
+	Status          string                      `json:"status,omitempty"`
+	EvidenceSources []string                    `json:"evidence_sources,omitempty"`
+	ReviewerLinks   []string                    `json:"reviewer_links,omitempty"`
+	Summary         deliveryAckReadinessSummary `json:"summary"`
+	Backends        []deliveryAckBackendView    `json:"backends,omitempty"`
+	Error           string                      `json:"error,omitempty"`
+}
+
+type deliveryAckReadinessSummary struct {
+	BackendCount         int `json:"backend_count"`
+	ExplicitAckBackends  int `json:"explicit_ack_backends"`
+	DurableAckBackends   int `json:"durable_ack_backends"`
+	BestEffortBackends   int `json:"best_effort_backends"`
+	ContractOnlyBackends int `json:"contract_only_backends"`
+}
+
+type deliveryAckBackendView struct {
+	Backend                 string   `json:"backend"`
+	Scope                   string   `json:"scope,omitempty"`
+	PublishMode             string   `json:"publish_mode,omitempty"`
+	AcknowledgementClass    string   `json:"acknowledgement_class"`
+	ExplicitAcknowledgement bool     `json:"explicit_acknowledgement"`
+	DurableAcknowledgement  bool     `json:"durable_acknowledgement"`
+	RuntimeReadiness        string   `json:"runtime_readiness"`
+	SourceReportLinks       []string `json:"source_report_links,omitempty"`
+	Notes                   []string `json:"notes,omitempty"`
+}
+
+func deliveryAckReadinessPayload() deliveryAckReadinessSurface {
+	surface := deliveryAckReadinessSurface{ReportPath: deliveryAckReadinessSurfacePath}
+	reportPath := resolveRepoRelativePath(deliveryAckReadinessSurfacePath)
+	if reportPath == "" {
+		surface.Status = "unavailable"
+		surface.Error = "report path could not be resolved"
+		return surface
+	}
+	contents, err := os.ReadFile(reportPath)
+	if err != nil {
+		surface.Status = "unavailable"
+		surface.Error = err.Error()
+		return surface
+	}
+	if err := json.Unmarshal(contents, &surface); err != nil {
+		surface.Status = "invalid"
+		surface.Error = fmt.Sprintf("decode %s: %v", deliveryAckReadinessSurfacePath, err)
+		return surface
+	}
+	surface.ReportPath = deliveryAckReadinessSurfacePath
+	return surface
+}

--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -102,13 +102,14 @@ type traceExportBundleTrace struct {
 }
 
 type distributedDiagnostics struct {
-	Summary          distributedDiagnosticsSummary `json:"summary"`
-	RoutingReasons   []routingReasonSummary        `json:"routing_reasons"`
-	ExecutorCapacity []executorCapacityView        `json:"executor_capacity"`
-	ClusterHealth    clusterHealthRollup           `json:"cluster_health"`
-	BrokerReviewPack brokerReviewPack              `json:"broker_review_pack"`
-	TraceBundle      traceExportBundleSummary      `json:"trace_export_bundle"`
-	RolloutReport    distributedDiagnosticsReport  `json:"rollout_report"`
+	Summary              distributedDiagnosticsSummary `json:"summary"`
+	RoutingReasons       []routingReasonSummary        `json:"routing_reasons"`
+	ExecutorCapacity     []executorCapacityView        `json:"executor_capacity"`
+	ClusterHealth        clusterHealthRollup           `json:"cluster_health"`
+	BrokerReviewPack     brokerReviewPack              `json:"broker_review_pack"`
+	DeliveryAckReadiness deliveryAckReadinessSurface   `json:"delivery_ack_readiness"`
+	TraceBundle          traceExportBundleSummary      `json:"trace_export_bundle"`
+	RolloutReport        distributedDiagnosticsReport  `json:"rollout_report"`
 }
 
 type executorDiagnosticsCounters struct {
@@ -151,13 +152,14 @@ func (s *Server) handleV2DistributedReport(w http.ResponseWriter, r *http.Reques
 			"limit":      filters.Limit,
 			"priority":   filters.Priority,
 		},
-		"event_durability":    s.EventPlan,
-		"summary":             diagnostics.Summary,
-		"routing_reasons":     diagnostics.RoutingReasons,
-		"executor_capacity":   diagnostics.ExecutorCapacity,
-		"cluster_health":      diagnostics.ClusterHealth,
-		"trace_export_bundle": diagnostics.TraceBundle,
-		"report":              diagnostics.RolloutReport,
+		"event_durability":       s.EventPlan,
+		"summary":                diagnostics.Summary,
+		"routing_reasons":        diagnostics.RoutingReasons,
+		"executor_capacity":      diagnostics.ExecutorCapacity,
+		"cluster_health":         diagnostics.ClusterHealth,
+		"trace_export_bundle":    diagnostics.TraceBundle,
+		"delivery_ack_readiness": diagnostics.DeliveryAckReadiness,
+		"report":                 diagnostics.RolloutReport,
 	})
 }
 
@@ -377,12 +379,13 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		Notes:              diagnosticsNotes(summary, executorCapacity, s.Control.Snapshot()),
 	}
 	diagnostics := distributedDiagnostics{
-		Summary:          summary,
-		RoutingReasons:   routingReasons,
-		ExecutorCapacity: executorCapacity,
-		ClusterHealth:    clusterHealth,
-		BrokerReviewPack: buildBrokerReviewPack(),
-		TraceBundle:      buildTraceExportBundle(assignments, s.Recorder.TraceSummaries(5)),
+		Summary:              summary,
+		RoutingReasons:       routingReasons,
+		ExecutorCapacity:     executorCapacity,
+		ClusterHealth:        clusterHealth,
+		BrokerReviewPack:     buildBrokerReviewPack(),
+		DeliveryAckReadiness: deliveryAckReadinessPayload(),
+		TraceBundle:          buildTraceExportBundle(assignments, s.Recorder.TraceSummaries(5)),
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
 		Markdown:  renderDistributedDiagnosticsMarkdown(diagnostics, filters),
@@ -722,6 +725,24 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 	)
 	if len(diagnostics.BrokerReviewPack.ReviewerLinks) > 0 {
 		lines = append(lines, "- Reviewer links: "+strings.Join(diagnostics.BrokerReviewPack.ReviewerLinks, ", "))
+	}
+	lines = append(lines,
+		"",
+		"## Delivery Acknowledgement Readiness",
+		fmt.Sprintf("- Canonical report: %s", diagnostics.DeliveryAckReadiness.ReportPath),
+		fmt.Sprintf("- Explicit ACK backends: %d", diagnostics.DeliveryAckReadiness.Summary.ExplicitAckBackends),
+		fmt.Sprintf("- Durable ACK backends: %d", diagnostics.DeliveryAckReadiness.Summary.DurableAckBackends),
+		fmt.Sprintf("- Best-effort backends: %d", diagnostics.DeliveryAckReadiness.Summary.BestEffortBackends),
+		fmt.Sprintf("- Contract-only backends: %d", diagnostics.DeliveryAckReadiness.Summary.ContractOnlyBackends),
+	)
+	for _, backend := range diagnostics.DeliveryAckReadiness.Backends {
+		lines = append(lines, fmt.Sprintf("- %s: class=%s explicit_ack=%t durable_ack=%t readiness=%s", backend.Backend, backend.AcknowledgementClass, backend.ExplicitAcknowledgement, backend.DurableAcknowledgement, backend.RuntimeReadiness))
+		if len(backend.SourceReportLinks) > 0 {
+			lines = append(lines, "  - sources: "+strings.Join(backend.SourceReportLinks, ", "))
+		}
+	}
+	if len(diagnostics.DeliveryAckReadiness.ReviewerLinks) > 0 {
+		lines = append(lines, "- Reviewer links: "+strings.Join(diagnostics.DeliveryAckReadiness.ReviewerLinks, ", "))
 	}
 	lines = append(lines, "", "## Notes")
 	for _, note := range diagnostics.ClusterHealth.Notes {

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -201,6 +201,7 @@ func (s *Server) Handler() http.Handler {
 			"event_durability_rollout":        rolloutScorecard,
 			"event_log":                       s.eventLogCapabilities(r.Context()),
 			"coordination_capability_surface": coordinationCapabilitySurfacePayload(),
+			"delivery_ack_readiness":          deliveryAckReadinessPayload(),
 		}
 		if s.Worker != nil {
 			payload["worker"] = s.Worker.Snapshot()

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -383,6 +383,63 @@ func TestDebugStatusIncludesCoordinationCapabilitySurface(t *testing.T) {
 	}
 }
 
+func TestDebugStatusIncludesDeliveryAckReadinessSurface(t *testing.T) {
+	server := &Server{
+		Recorder: observability.NewRecorder(),
+		Queue:    queue.NewMemoryQueue(),
+		Bus:      events.NewBus(),
+		Now:      time.Now,
+	}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	var decoded struct {
+		DeliveryAckReadiness struct {
+			ReportPath string `json:"report_path"`
+			Ticket     string `json:"ticket"`
+			Summary    struct {
+				BackendCount         int `json:"backend_count"`
+				ExplicitAckBackends  int `json:"explicit_ack_backends"`
+				DurableAckBackends   int `json:"durable_ack_backends"`
+				BestEffortBackends   int `json:"best_effort_backends"`
+				ContractOnlyBackends int `json:"contract_only_backends"`
+			} `json:"summary"`
+			Backends []struct {
+				Backend                 string `json:"backend"`
+				AcknowledgementClass    string `json:"acknowledgement_class"`
+				ExplicitAcknowledgement bool   `json:"explicit_acknowledgement"`
+				DurableAcknowledgement  bool   `json:"durable_acknowledgement"`
+				RuntimeReadiness        string `json:"runtime_readiness"`
+			} `json:"backends"`
+		} `json:"delivery_ack_readiness"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode debug ack readiness payload: %v", err)
+	}
+	if decoded.DeliveryAckReadiness.ReportPath != deliveryAckReadinessSurfacePath || decoded.DeliveryAckReadiness.Ticket != "OPE-264" {
+		t.Fatalf("unexpected delivery ack report metadata: %+v", decoded.DeliveryAckReadiness)
+	}
+	if decoded.DeliveryAckReadiness.Summary.BackendCount != 5 || decoded.DeliveryAckReadiness.Summary.ExplicitAckBackends != 3 || decoded.DeliveryAckReadiness.Summary.DurableAckBackends != 2 || decoded.DeliveryAckReadiness.Summary.BestEffortBackends != 1 || decoded.DeliveryAckReadiness.Summary.ContractOnlyBackends != 1 {
+		t.Fatalf("unexpected delivery ack summary: %+v", decoded.DeliveryAckReadiness.Summary)
+	}
+	if len(decoded.DeliveryAckReadiness.Backends) != 5 {
+		t.Fatalf("expected 5 ack readiness backends, got %+v", decoded.DeliveryAckReadiness.Backends)
+	}
+	if decoded.DeliveryAckReadiness.Backends[0].Backend != "memory" || decoded.DeliveryAckReadiness.Backends[0].AcknowledgementClass != "best_effort_only" || decoded.DeliveryAckReadiness.Backends[0].ExplicitAcknowledgement || decoded.DeliveryAckReadiness.Backends[0].DurableAcknowledgement {
+		t.Fatalf("unexpected memory ack readiness payload: %+v", decoded.DeliveryAckReadiness.Backends[0])
+	}
+	if decoded.DeliveryAckReadiness.Backends[1].Backend != "sqlite" || !decoded.DeliveryAckReadiness.Backends[1].ExplicitAcknowledgement || !decoded.DeliveryAckReadiness.Backends[1].DurableAcknowledgement {
+		t.Fatalf("unexpected sqlite ack readiness payload: %+v", decoded.DeliveryAckReadiness.Backends[1])
+	}
+	if decoded.DeliveryAckReadiness.Backends[4].Backend != "broker_replicated" || decoded.DeliveryAckReadiness.Backends[4].RuntimeReadiness != "contract_only" {
+		t.Fatalf("unexpected broker replicated ack readiness payload: %+v", decoded.DeliveryAckReadiness.Backends[4])
+	}
+}
+
 func TestDeadLetterEndpoints(t *testing.T) {
 	recorder := observability.NewRecorder()
 	bus := events.NewBus()
@@ -1998,6 +2055,19 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 				ArtifactDirectory  string   `json:"artifact_directory"`
 				ReviewerLinks      []string `json:"reviewer_links"`
 			} `json:"broker_review_pack"`
+			DeliveryAckReadiness struct {
+				ReportPath string `json:"report_path"`
+				Summary    struct {
+					ExplicitAckBackends  int `json:"explicit_ack_backends"`
+					DurableAckBackends   int `json:"durable_ack_backends"`
+					BestEffortBackends   int `json:"best_effort_backends"`
+					ContractOnlyBackends int `json:"contract_only_backends"`
+				} `json:"summary"`
+				Backends []struct {
+					Backend              string `json:"backend"`
+					AcknowledgementClass string `json:"acknowledgement_class"`
+				} `json:"backends"`
+			} `json:"delivery_ack_readiness"`
 			RolloutReport struct {
 				Markdown  string `json:"markdown"`
 				ExportURL string `json:"export_url"`
@@ -2049,10 +2119,24 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 		decoded.Diagnostics.BrokerReviewPack.ReviewerLinks[1] != "docs/reports/review-readiness.md" {
 		t.Fatalf("unexpected broker review pack reviewer links: %+v", decoded.Diagnostics.BrokerReviewPack.ReviewerLinks)
 	}
+	if decoded.Diagnostics.DeliveryAckReadiness.ReportPath != deliveryAckReadinessSurfacePath ||
+		decoded.Diagnostics.DeliveryAckReadiness.Summary.ExplicitAckBackends != 3 ||
+		decoded.Diagnostics.DeliveryAckReadiness.Summary.DurableAckBackends != 2 ||
+		decoded.Diagnostics.DeliveryAckReadiness.Summary.BestEffortBackends != 1 ||
+		decoded.Diagnostics.DeliveryAckReadiness.Summary.ContractOnlyBackends != 1 {
+		t.Fatalf("unexpected delivery ack readiness payload: %+v", decoded.Diagnostics.DeliveryAckReadiness)
+	}
+	if len(decoded.Diagnostics.DeliveryAckReadiness.Backends) != 5 ||
+		decoded.Diagnostics.DeliveryAckReadiness.Backends[0].Backend != "memory" ||
+		decoded.Diagnostics.DeliveryAckReadiness.Backends[0].AcknowledgementClass != "best_effort_only" {
+		t.Fatalf("unexpected delivery ack readiness backend detail: %+v", decoded.Diagnostics.DeliveryAckReadiness.Backends)
+	}
 	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Broker Failover Review Pack") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Delivery Acknowledgement Readiness") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-validation-summary.json") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, deliveryAckReadinessSurfacePath) ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-failover-stub-artifacts") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {
 		t.Fatalf("unexpected rollout report payload: %+v", decoded.Diagnostics.RolloutReport)

--- a/bigclaw-go/internal/regression/delivery_ack_readiness_surface_test.go
+++ b/bigclaw-go/internal/regression/delivery_ack_readiness_surface_test.go
@@ -1,0 +1,58 @@
+package regression
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDeliveryAckReadinessSurfaceReportStaysAligned(t *testing.T) {
+	repoRoot := repoRoot(t)
+	reportPath := filepath.Join(repoRoot, "docs", "reports", "delivery-ack-readiness-surface.json")
+
+	var report struct {
+		Ticket  string `json:"ticket"`
+		Title   string `json:"title"`
+		Status  string `json:"status"`
+		Summary struct {
+			BackendCount         int `json:"backend_count"`
+			ExplicitAckBackends  int `json:"explicit_ack_backends"`
+			DurableAckBackends   int `json:"durable_ack_backends"`
+			BestEffortBackends   int `json:"best_effort_backends"`
+			ContractOnlyBackends int `json:"contract_only_backends"`
+		} `json:"summary"`
+		Backends []struct {
+			Backend                 string `json:"backend"`
+			AcknowledgementClass    string `json:"acknowledgement_class"`
+			ExplicitAcknowledgement bool   `json:"explicit_acknowledgement"`
+			DurableAcknowledgement  bool   `json:"durable_acknowledgement"`
+			RuntimeReadiness        string `json:"runtime_readiness"`
+		} `json:"backends"`
+	}
+	readJSONFile(t, reportPath, &report)
+	if report.Ticket != "OPE-264" || report.Status != "checked_in_surface" {
+		t.Fatalf("unexpected delivery ack report metadata: %+v", report)
+	}
+	if report.Summary.BackendCount != 5 || report.Summary.ExplicitAckBackends != 3 || report.Summary.DurableAckBackends != 2 || report.Summary.BestEffortBackends != 1 || report.Summary.ContractOnlyBackends != 1 {
+		t.Fatalf("unexpected delivery ack summary: %+v", report.Summary)
+	}
+	if len(report.Backends) != 5 {
+		t.Fatalf("expected 5 backend rows, got %+v", report.Backends)
+	}
+	if report.Backends[0].Backend != "memory" || report.Backends[0].AcknowledgementClass != "best_effort_only" || report.Backends[0].ExplicitAcknowledgement || report.Backends[0].DurableAcknowledgement {
+		t.Fatalf("unexpected memory delivery ack row: %+v", report.Backends[0])
+	}
+	if report.Backends[1].Backend != "sqlite" || !report.Backends[1].ExplicitAcknowledgement || !report.Backends[1].DurableAcknowledgement {
+		t.Fatalf("unexpected sqlite delivery ack row: %+v", report.Backends[1])
+	}
+	if report.Backends[4].Backend != "broker_replicated" || report.Backends[4].RuntimeReadiness != "contract_only" {
+		t.Fatalf("unexpected broker replicated delivery ack row: %+v", report.Backends[4])
+	}
+
+	contents := readRepoFile(t, repoRoot, "docs/reports/event-bus-reliability-report.md")
+	for _, needle := range []string{"delivery-ack-readiness-surface.json", "Memory bus delivery acknowledgements remain sink-level best effort"} {
+		if !strings.Contains(contents, needle) {
+			t.Fatalf("event-bus reliability report missing substring %q", needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary\n- add a checked-in delivery acknowledgement readiness surface for event log backends\n- expose the readiness summary in \/debug\/status and distributed diagnostics responses\n- extend API and regression tests to pin the new reviewer-facing report links\n\n## Testing\n- go test ./internal/api ./internal/regression\n\nRefs: OPE-264