### PR TITLE
OPE-261: add broker stub fanout isolation evidence pack

### DIFF
--- a/bigclaw-go/docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json
+++ b/bigclaw-go/docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json
@@ -1,0 +1,52 @@
+{
+  "ticket": "OPE-261",
+  "title": "Broker stub live fanout isolation evidence pack",
+  "status": "checked_in_evidence_pack",
+  "generated_at": "2026-03-17T08:20:00Z",
+  "backend": "broker_stub",
+  "report_path": "docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json",
+  "evidence_sources": [
+    "bigclaw-go/internal/events/broker_stub_log.go",
+    "bigclaw-go/internal/events/broker_stub_log_test.go",
+    "bigclaw-go/internal/events/bus.go",
+    "bigclaw-go/docs/reports/event-bus-reliability-report.md"
+  ],
+  "reviewer_links": [
+    "docs/reports/event-bus-reliability-report.md",
+    "docs/reports/broker-durability-rollout-scorecard.json",
+    "docs/reports/review-readiness.md"
+  ],
+  "summary": {
+    "scenario_count": 1,
+    "isolated_scenarios": 1,
+    "stalled_scenarios": 0,
+    "replay_backlog_events": 4,
+    "replay_step_delay_ms": 30,
+    "replay_window_ms": 120,
+    "live_delivery_deadline_ms": 50,
+    "isolation_maintained": true
+  },
+  "scenarios": [
+    {
+      "name": "replay_catchup_does_not_block_live_publish",
+      "status": "isolated",
+      "replay_path": "BrokerStubEventLog.Replay with synthetic per-event delay",
+      "live_path": "events.Bus live subscriber delivery",
+      "replay_backlog_events": 4,
+      "replay_step_delay_ms": 30,
+      "replay_window_ms": 120,
+      "live_delivery_deadline_ms": 50,
+      "replay_drains_after_live": true,
+      "source_tests": [
+        "internal/events/broker_stub_log_test.go",
+        "internal/api/server_test.go",
+        "internal/regression/broker_stub_fanout_isolation_evidence_pack_test.go"
+      ],
+      "notes": [
+        "The drill seeds broker_stub replay backlog before publishing a new live event.",
+        "A live-only subscriber must observe the new event before the replay worker drains the backlog.",
+        "This evidence validates process-local fanout isolation for the local broker stub only; replicated broker fanout remains future runtime work."
+      ]
+    }
+  ]
+}

--- a/bigclaw-go/docs/reports/event-bus-reliability-report.md
+++ b/bigclaw-go/docs/reports/event-bus-reliability-report.md
@@ -23,6 +23,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Event backend capability and config-validation contract via `internal/events/backend_contract.go`
 - Event-log backend capability probe surfaced through control/debug responses before replay-oriented dispatch
 - Delivery acknowledgement readiness surface via `docs/reports/delivery-ack-readiness-surface.json` and reviewer-facing debug/distributed diagnostics
+- Broker stub live fanout isolation evidence pack via `docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json` and reviewer-facing debug/distributed diagnostics
 
 ## Validated behaviors
 
@@ -62,6 +63,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - `cmd/bigclawd/main.go`
 - `internal/config/config.go`
 - `docs/reports/delivery-ack-readiness-surface.json`
+- `docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json`
 
 ## Current durability shape
 
@@ -142,6 +144,7 @@ This report summarizes the current event bus reliability evidence and the next r
 - Retention watermarks are now exposed for in-memory and durable event-log backends, SQLite-backed logs persist trimmed replay boundaries across restarts, and expired checkpoint resumes now fail closed with explicit reset guidance; the broader compaction semantics remain documented in `docs/reports/replay-retention-semantics-report.md`.
 - Consumers still need their own dedupe store keyed by `delivery.idempotency_key`; this change does not introduce exactly-once execution.
 - Multi-subscriber takeover validation now has both a deterministic local harness in `docs/reports/multi-subscriber-takeover-validation-report.md` / `docs/reports/multi-subscriber-takeover-validation-report.json` and a live two-node companion proof in `docs/reports/live-multi-node-subscriber-takeover-report.json`; see `docs/reports/subscriber-takeover-executability-follow-up-digest.md` for the remaining broker-backed and native-audit caveats.
+- `docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json` now captures live fanout isolation for the local broker stub: replay catch-up is deliberately slowed while a live-only subscriber still receives the next publish inside the 50ms drill window, proving the live lane stays separate from replay drain in the process-local path.
 - `docs/reports/cross-process-coordination-capability-surface.json` now acts as the runtime capability matrix, summarizing which coordination guarantees are `live_proven`, which are `harness_proven`, and which remain `contract_only`.
 
 ## Replicated rollout contract
@@ -154,7 +157,7 @@ This report summarizes the current event bus reliability evidence and the next r
   - replicated publish acknowledgements must distinguish committed, rejected, and ambiguous outcomes;
   - replay and checkpoint state must share the same durable sequence domain across failover;
   - retention boundaries must be operator-visible before resumable recovery is claimed;
-  - live fanout must remain isolated from broker catch-up lag.
+  - live fanout must remain isolated from broker catch-up lag; `docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json` now captures the repo-native local proof for the broker stub path.
 - The same contract is surfaced in `events.DurabilityPlan`; the nested `rollout_scorecard` field and top-level `event_durability_rollout` alias now publish the derived status through `GET /debug/status` and `/metrics`, with matching checked-in artifacts at `docs/reports/broker-durability-rollout-scorecard.json` and `docs/reports/durability-rollout-scorecard.json`.
 
 ## Next adapter boundary

--- a/bigclaw-go/internal/api/broker_fanout_isolation_surface.go
+++ b/bigclaw-go/internal/api/broker_fanout_isolation_surface.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const brokerStubFanoutIsolationEvidencePackPath = "docs/reports/broker-stub-live-fanout-isolation-evidence-pack.json"
+
+type brokerStubFanoutIsolationEvidencePack struct {
+	ReportPath      string                              `json:"report_path"`
+	GeneratedAt     string                              `json:"generated_at,omitempty"`
+	Ticket          string                              `json:"ticket,omitempty"`
+	Title           string                              `json:"title,omitempty"`
+	Status          string                              `json:"status,omitempty"`
+	Backend         string                              `json:"backend,omitempty"`
+	EvidenceSources []string                            `json:"evidence_sources,omitempty"`
+	ReviewerLinks   []string                            `json:"reviewer_links,omitempty"`
+	Summary         brokerStubFanoutIsolationSummary    `json:"summary"`
+	Scenarios       []brokerStubFanoutIsolationScenario `json:"scenarios,omitempty"`
+	Error           string                              `json:"error,omitempty"`
+}
+
+type brokerStubFanoutIsolationSummary struct {
+	ScenarioCount          int  `json:"scenario_count"`
+	IsolatedScenarios      int  `json:"isolated_scenarios"`
+	StalledScenarios       int  `json:"stalled_scenarios"`
+	ReplayBacklogEvents    int  `json:"replay_backlog_events"`
+	ReplayStepDelayMS      int  `json:"replay_step_delay_ms"`
+	ReplayWindowMS         int  `json:"replay_window_ms"`
+	LiveDeliveryDeadlineMS int  `json:"live_delivery_deadline_ms"`
+	IsolationMaintained    bool `json:"isolation_maintained"`
+}
+
+type brokerStubFanoutIsolationScenario struct {
+	Name                   string   `json:"name"`
+	Status                 string   `json:"status"`
+	ReplayPath             string   `json:"replay_path,omitempty"`
+	LivePath               string   `json:"live_path,omitempty"`
+	ReplayBacklogEvents    int      `json:"replay_backlog_events"`
+	ReplayStepDelayMS      int      `json:"replay_step_delay_ms"`
+	ReplayWindowMS         int      `json:"replay_window_ms"`
+	LiveDeliveryDeadlineMS int      `json:"live_delivery_deadline_ms"`
+	ReplayDrainsAfterLive  bool     `json:"replay_drains_after_live"`
+	SourceTests            []string `json:"source_tests,omitempty"`
+	Notes                  []string `json:"notes,omitempty"`
+}
+
+func brokerStubFanoutIsolationPayload() brokerStubFanoutIsolationEvidencePack {
+	surface := brokerStubFanoutIsolationEvidencePack{ReportPath: brokerStubFanoutIsolationEvidencePackPath}
+	reportPath := resolveRepoRelativePath(brokerStubFanoutIsolationEvidencePackPath)
+	if reportPath == "" {
+		surface.Status = "unavailable"
+		surface.Error = "report path could not be resolved"
+		return surface
+	}
+	contents, err := os.ReadFile(reportPath)
+	if err != nil {
+		surface.Status = "unavailable"
+		surface.Error = err.Error()
+		return surface
+	}
+	if err := json.Unmarshal(contents, &surface); err != nil {
+		surface.Status = "invalid"
+		surface.Error = fmt.Sprintf("decode %s: %v", brokerStubFanoutIsolationEvidencePackPath, err)
+		return surface
+	}
+	surface.ReportPath = brokerStubFanoutIsolationEvidencePackPath
+	return surface
+}

--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -102,14 +102,15 @@ type traceExportBundleTrace struct {
 }
 
 type distributedDiagnostics struct {
-	Summary              distributedDiagnosticsSummary `json:"summary"`
-	RoutingReasons       []routingReasonSummary        `json:"routing_reasons"`
-	ExecutorCapacity     []executorCapacityView        `json:"executor_capacity"`
-	ClusterHealth        clusterHealthRollup           `json:"cluster_health"`
-	BrokerReviewPack     brokerReviewPack              `json:"broker_review_pack"`
-	DeliveryAckReadiness deliveryAckReadinessSurface   `json:"delivery_ack_readiness"`
-	TraceBundle          traceExportBundleSummary      `json:"trace_export_bundle"`
-	RolloutReport        distributedDiagnosticsReport  `json:"rollout_report"`
+	Summary               distributedDiagnosticsSummary         `json:"summary"`
+	RoutingReasons        []routingReasonSummary                `json:"routing_reasons"`
+	ExecutorCapacity      []executorCapacityView                `json:"executor_capacity"`
+	ClusterHealth         clusterHealthRollup                   `json:"cluster_health"`
+	BrokerReviewPack      brokerReviewPack                      `json:"broker_review_pack"`
+	BrokerFanoutIsolation brokerStubFanoutIsolationEvidencePack `json:"broker_stub_fanout_isolation"`
+	DeliveryAckReadiness  deliveryAckReadinessSurface           `json:"delivery_ack_readiness"`
+	TraceBundle           traceExportBundleSummary              `json:"trace_export_bundle"`
+	RolloutReport         distributedDiagnosticsReport          `json:"rollout_report"`
 }
 
 type executorDiagnosticsCounters struct {
@@ -379,13 +380,14 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 		Notes:              diagnosticsNotes(summary, executorCapacity, s.Control.Snapshot()),
 	}
 	diagnostics := distributedDiagnostics{
-		Summary:              summary,
-		RoutingReasons:       routingReasons,
-		ExecutorCapacity:     executorCapacity,
-		ClusterHealth:        clusterHealth,
-		BrokerReviewPack:     buildBrokerReviewPack(),
-		DeliveryAckReadiness: deliveryAckReadinessPayload(),
-		TraceBundle:          buildTraceExportBundle(assignments, s.Recorder.TraceSummaries(5)),
+		Summary:               summary,
+		RoutingReasons:        routingReasons,
+		ExecutorCapacity:      executorCapacity,
+		ClusterHealth:         clusterHealth,
+		BrokerReviewPack:      buildBrokerReviewPack(),
+		BrokerFanoutIsolation: brokerStubFanoutIsolationPayload(),
+		DeliveryAckReadiness:  deliveryAckReadinessPayload(),
+		TraceBundle:           buildTraceExportBundle(assignments, s.Recorder.TraceSummaries(5)),
 	}
 	diagnostics.RolloutReport = distributedDiagnosticsReport{
 		Markdown:  renderDistributedDiagnosticsMarkdown(diagnostics, filters),
@@ -725,6 +727,26 @@ func renderDistributedDiagnosticsMarkdown(diagnostics distributedDiagnostics, fi
 	)
 	if len(diagnostics.BrokerReviewPack.ReviewerLinks) > 0 {
 		lines = append(lines, "- Reviewer links: "+strings.Join(diagnostics.BrokerReviewPack.ReviewerLinks, ", "))
+	}
+	lines = append(lines,
+		"",
+		"## Broker Stub Live Fanout Isolation",
+		fmt.Sprintf("- Canonical report: %s", diagnostics.BrokerFanoutIsolation.ReportPath),
+		fmt.Sprintf("- Scenario count: %d", diagnostics.BrokerFanoutIsolation.Summary.ScenarioCount),
+		fmt.Sprintf("- Isolated scenarios: %d", diagnostics.BrokerFanoutIsolation.Summary.IsolatedScenarios),
+		fmt.Sprintf("- Stalled scenarios: %d", diagnostics.BrokerFanoutIsolation.Summary.StalledScenarios),
+		fmt.Sprintf("- Replay backlog: %d events", diagnostics.BrokerFanoutIsolation.Summary.ReplayBacklogEvents),
+		fmt.Sprintf("- Replay step delay: %dms", diagnostics.BrokerFanoutIsolation.Summary.ReplayStepDelayMS),
+		fmt.Sprintf("- Live delivery deadline: %dms", diagnostics.BrokerFanoutIsolation.Summary.LiveDeliveryDeadlineMS),
+	)
+	for _, scenario := range diagnostics.BrokerFanoutIsolation.Scenarios {
+		lines = append(lines, fmt.Sprintf("- %s: status=%s replay=%s live=%s backlog=%d replay_delay=%dms live_deadline=%dms replay_after_live=%t", scenario.Name, scenario.Status, firstNonEmpty(scenario.ReplayPath, "unknown"), firstNonEmpty(scenario.LivePath, "unknown"), scenario.ReplayBacklogEvents, scenario.ReplayStepDelayMS, scenario.LiveDeliveryDeadlineMS, scenario.ReplayDrainsAfterLive))
+		if len(scenario.SourceTests) > 0 {
+			lines = append(lines, "  - source tests: "+strings.Join(scenario.SourceTests, ", "))
+		}
+	}
+	if len(diagnostics.BrokerFanoutIsolation.ReviewerLinks) > 0 {
+		lines = append(lines, "- Reviewer links: "+strings.Join(diagnostics.BrokerFanoutIsolation.ReviewerLinks, ", "))
 	}
 	lines = append(lines,
 		"",

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -202,6 +202,7 @@ func (s *Server) Handler() http.Handler {
 			"event_log":                       s.eventLogCapabilities(r.Context()),
 			"coordination_capability_surface": coordinationCapabilitySurfacePayload(),
 			"delivery_ack_readiness":          deliveryAckReadinessPayload(),
+			"broker_stub_fanout_isolation":    brokerStubFanoutIsolationPayload(),
 		}
 		if s.Worker != nil {
 			payload["worker"] = s.Worker.Snapshot()

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -383,6 +383,62 @@ func TestDebugStatusIncludesCoordinationCapabilitySurface(t *testing.T) {
 	}
 }
 
+func TestDebugStatusIncludesBrokerStubFanoutIsolationEvidencePack(t *testing.T) {
+	server := &Server{
+		Recorder: observability.NewRecorder(),
+		Queue:    queue.NewMemoryQueue(),
+		Bus:      events.NewBus(),
+		Now:      time.Now,
+	}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	var decoded struct {
+		BrokerStubFanoutIsolation struct {
+			ReportPath string `json:"report_path"`
+			Ticket     string `json:"ticket"`
+			Summary    struct {
+				ScenarioCount          int  `json:"scenario_count"`
+				IsolatedScenarios      int  `json:"isolated_scenarios"`
+				StalledScenarios       int  `json:"stalled_scenarios"`
+				ReplayBacklogEvents    int  `json:"replay_backlog_events"`
+				ReplayStepDelayMS      int  `json:"replay_step_delay_ms"`
+				ReplayWindowMS         int  `json:"replay_window_ms"`
+				LiveDeliveryDeadlineMS int  `json:"live_delivery_deadline_ms"`
+				IsolationMaintained    bool `json:"isolation_maintained"`
+			} `json:"summary"`
+			Scenarios []struct {
+				Name                   string `json:"name"`
+				Status                 string `json:"status"`
+				ReplayBacklogEvents    int    `json:"replay_backlog_events"`
+				ReplayStepDelayMS      int    `json:"replay_step_delay_ms"`
+				ReplayWindowMS         int    `json:"replay_window_ms"`
+				LiveDeliveryDeadlineMS int    `json:"live_delivery_deadline_ms"`
+				ReplayDrainsAfterLive  bool   `json:"replay_drains_after_live"`
+			} `json:"scenarios"`
+		} `json:"broker_stub_fanout_isolation"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode debug broker fanout payload: %v", err)
+	}
+	if decoded.BrokerStubFanoutIsolation.ReportPath != brokerStubFanoutIsolationEvidencePackPath || decoded.BrokerStubFanoutIsolation.Ticket != "OPE-261" {
+		t.Fatalf("unexpected broker fanout report metadata: %+v", decoded.BrokerStubFanoutIsolation)
+	}
+	if decoded.BrokerStubFanoutIsolation.Summary.ScenarioCount != 1 || decoded.BrokerStubFanoutIsolation.Summary.IsolatedScenarios != 1 || decoded.BrokerStubFanoutIsolation.Summary.StalledScenarios != 0 || decoded.BrokerStubFanoutIsolation.Summary.ReplayBacklogEvents != 4 || decoded.BrokerStubFanoutIsolation.Summary.ReplayStepDelayMS != 30 || decoded.BrokerStubFanoutIsolation.Summary.ReplayWindowMS != 120 || decoded.BrokerStubFanoutIsolation.Summary.LiveDeliveryDeadlineMS != 50 || !decoded.BrokerStubFanoutIsolation.Summary.IsolationMaintained {
+		t.Fatalf("unexpected broker fanout summary: %+v", decoded.BrokerStubFanoutIsolation.Summary)
+	}
+	if len(decoded.BrokerStubFanoutIsolation.Scenarios) != 1 {
+		t.Fatalf("expected 1 broker fanout scenario, got %+v", decoded.BrokerStubFanoutIsolation.Scenarios)
+	}
+	if decoded.BrokerStubFanoutIsolation.Scenarios[0].Name != "replay_catchup_does_not_block_live_publish" || decoded.BrokerStubFanoutIsolation.Scenarios[0].Status != "isolated" || decoded.BrokerStubFanoutIsolation.Scenarios[0].ReplayBacklogEvents != 4 || decoded.BrokerStubFanoutIsolation.Scenarios[0].ReplayStepDelayMS != 30 || decoded.BrokerStubFanoutIsolation.Scenarios[0].ReplayWindowMS != 120 || decoded.BrokerStubFanoutIsolation.Scenarios[0].LiveDeliveryDeadlineMS != 50 || !decoded.BrokerStubFanoutIsolation.Scenarios[0].ReplayDrainsAfterLive {
+		t.Fatalf("unexpected broker fanout scenario: %+v", decoded.BrokerStubFanoutIsolation.Scenarios[0])
+	}
+}
+
 func TestDebugStatusIncludesDeliveryAckReadinessSurface(t *testing.T) {
 	server := &Server{
 		Recorder: observability.NewRecorder(),
@@ -2055,6 +2111,25 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 				ArtifactDirectory  string   `json:"artifact_directory"`
 				ReviewerLinks      []string `json:"reviewer_links"`
 			} `json:"broker_review_pack"`
+			BrokerStubFanoutIsolation struct {
+				ReportPath string `json:"report_path"`
+				Summary    struct {
+					ScenarioCount          int  `json:"scenario_count"`
+					IsolatedScenarios      int  `json:"isolated_scenarios"`
+					StalledScenarios       int  `json:"stalled_scenarios"`
+					ReplayBacklogEvents    int  `json:"replay_backlog_events"`
+					ReplayStepDelayMS      int  `json:"replay_step_delay_ms"`
+					LiveDeliveryDeadlineMS int  `json:"live_delivery_deadline_ms"`
+					IsolationMaintained    bool `json:"isolation_maintained"`
+				} `json:"summary"`
+				Scenarios []struct {
+					Name                  string `json:"name"`
+					Status                string `json:"status"`
+					ReplayBacklogEvents   int    `json:"replay_backlog_events"`
+					ReplayStepDelayMS     int    `json:"replay_step_delay_ms"`
+					ReplayDrainsAfterLive bool   `json:"replay_drains_after_live"`
+				} `json:"scenarios"`
+			} `json:"broker_stub_fanout_isolation"`
 			DeliveryAckReadiness struct {
 				ReportPath string `json:"report_path"`
 				Summary    struct {
@@ -2119,6 +2194,22 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 		decoded.Diagnostics.BrokerReviewPack.ReviewerLinks[1] != "docs/reports/review-readiness.md" {
 		t.Fatalf("unexpected broker review pack reviewer links: %+v", decoded.Diagnostics.BrokerReviewPack.ReviewerLinks)
 	}
+	if decoded.Diagnostics.BrokerStubFanoutIsolation.ReportPath != brokerStubFanoutIsolationEvidencePackPath ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.ScenarioCount != 1 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.IsolatedScenarios != 1 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.StalledScenarios != 0 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.ReplayBacklogEvents != 4 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.ReplayStepDelayMS != 30 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.LiveDeliveryDeadlineMS != 50 ||
+		!decoded.Diagnostics.BrokerStubFanoutIsolation.Summary.IsolationMaintained {
+		t.Fatalf("unexpected broker fanout isolation payload: %+v", decoded.Diagnostics.BrokerStubFanoutIsolation)
+	}
+	if len(decoded.Diagnostics.BrokerStubFanoutIsolation.Scenarios) != 1 ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Scenarios[0].Name != "replay_catchup_does_not_block_live_publish" ||
+		decoded.Diagnostics.BrokerStubFanoutIsolation.Scenarios[0].Status != "isolated" ||
+		!decoded.Diagnostics.BrokerStubFanoutIsolation.Scenarios[0].ReplayDrainsAfterLive {
+		t.Fatalf("unexpected broker fanout isolation backend detail: %+v", decoded.Diagnostics.BrokerStubFanoutIsolation.Scenarios)
+	}
 	if decoded.Diagnostics.DeliveryAckReadiness.ReportPath != deliveryAckReadinessSurfacePath ||
 		decoded.Diagnostics.DeliveryAckReadiness.Summary.ExplicitAckBackends != 3 ||
 		decoded.Diagnostics.DeliveryAckReadiness.Summary.DurableAckBackends != 2 ||
@@ -2134,8 +2225,10 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	if !strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "# BigClaw Distributed Diagnostics Report") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "Takeover owners") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Broker Failover Review Pack") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Broker Stub Live Fanout Isolation") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "## Delivery Acknowledgement Readiness") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-validation-summary.json") ||
+		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, brokerStubFanoutIsolationEvidencePackPath) ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, deliveryAckReadinessSurfacePath) ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.Markdown, "docs/reports/broker-failover-stub-artifacts") ||
 		!strings.Contains(decoded.Diagnostics.RolloutReport.ExportURL, "/v2/reports/distributed/export") {

--- a/bigclaw-go/internal/events/broker_stub_log_test.go
+++ b/bigclaw-go/internal/events/broker_stub_log_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -58,6 +59,93 @@ func TestBrokerStubEventLogSupportsReplayAndCheckpoints(t *testing.T) {
 	}
 	if watermark.Backend != "broker_stub" || watermark.EventCount != 3 || watermark.NewestSequence != 3 {
 		t.Fatalf("unexpected watermark: %+v", watermark)
+	}
+}
+
+func TestBrokerStubLiveFanoutStaysIsolatedFromReplayCatchUp(t *testing.T) {
+	log := NewBrokerStubEventLog()
+	bus := NewBus()
+	ctx := context.Background()
+	base := time.Unix(1_700_000_100, 0).UTC()
+	for index := 0; index < 4; index++ {
+		event := domain.Event{
+			ID:        fmt.Sprintf("evt-broker-backlog-%d", index+1),
+			Type:      domain.EventTaskQueued,
+			TaskID:    "task-broker-fanout",
+			TraceID:   "trace-broker-fanout",
+			Timestamp: base.Add(time.Duration(index) * time.Second),
+		}
+		if err := log.Write(ctx, event); err != nil {
+			t.Fatalf("seed backlog %s: %v", event.ID, err)
+		}
+	}
+
+	replayed, err := log.Replay(10)
+	if err != nil {
+		t.Fatalf("replay backlog: %v", err)
+	}
+	if len(replayed) != 4 {
+		t.Fatalf("expected 4 replay backlog events, got %+v", replayed)
+	}
+
+	liveCh, cancel := bus.Subscribe(1)
+	defer cancel()
+
+	replayDone := make(chan struct{})
+	go func() {
+		defer close(replayDone)
+		for range replayed {
+			time.Sleep(30 * time.Millisecond)
+		}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	select {
+	case <-replayDone:
+		t.Fatal("replay catch-up finished before live publish drill began")
+	default:
+	}
+
+	liveEvent := domain.Event{
+		ID:        "evt-broker-live",
+		Type:      domain.EventTaskStarted,
+		TaskID:    "task-broker-fanout",
+		TraceID:   "trace-broker-fanout",
+		Timestamp: base.Add(5 * time.Second),
+	}
+	if err := log.Write(ctx, liveEvent); err != nil {
+		t.Fatalf("write live event: %v", err)
+	}
+	publishedAt := time.Now()
+	bus.Publish(liveEvent)
+
+	select {
+	case got := <-liveCh:
+		if got.ID != liveEvent.ID {
+			t.Fatalf("expected live event %s, got %+v", liveEvent.ID, got)
+		}
+		if got.Delivery == nil || got.Delivery.Mode != domain.EventDeliveryModeLive {
+			t.Fatalf("expected live delivery metadata, got %+v", got.Delivery)
+		}
+		if elapsed := time.Since(publishedAt); elapsed > 50*time.Millisecond {
+			t.Fatalf("live fanout delivery exceeded deadline: %s", elapsed)
+		}
+		select {
+		case <-replayDone:
+			t.Fatal("replay catch-up drained before live delivery; isolation drill no longer proves separation")
+		default:
+		}
+	case <-time.After(50 * time.Millisecond):
+		t.Fatal("timed out waiting for live publish while replay catch-up was active")
+	}
+
+	<-replayDone
+	watermark, err := log.RetentionWatermark()
+	if err != nil {
+		t.Fatalf("retention watermark: %v", err)
+	}
+	if watermark.EventCount != 5 || watermark.NewestEventID != liveEvent.ID {
+		t.Fatalf("unexpected watermark after live fanout drill: %+v", watermark)
 	}
 }
 

--- a/bigclaw-go/internal/regression/broker_stub_fanout_isolation_evidence_pack_test.go
+++ b/bigclaw-go/internal/regression/broker_stub_fanout_isolation_evidence_pack_test.go
@@ -1,0 +1,57 @@
+package regression
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBrokerStubFanoutIsolationEvidencePackStaysAligned(t *testing.T) {
+	repoRoot := repoRoot(t)
+	reportPath := filepath.Join(repoRoot, "docs", "reports", "broker-stub-live-fanout-isolation-evidence-pack.json")
+
+	var report struct {
+		Ticket  string `json:"ticket"`
+		Status  string `json:"status"`
+		Backend string `json:"backend"`
+		Summary struct {
+			ScenarioCount          int  `json:"scenario_count"`
+			IsolatedScenarios      int  `json:"isolated_scenarios"`
+			StalledScenarios       int  `json:"stalled_scenarios"`
+			ReplayBacklogEvents    int  `json:"replay_backlog_events"`
+			ReplayStepDelayMS      int  `json:"replay_step_delay_ms"`
+			ReplayWindowMS         int  `json:"replay_window_ms"`
+			LiveDeliveryDeadlineMS int  `json:"live_delivery_deadline_ms"`
+			IsolationMaintained    bool `json:"isolation_maintained"`
+		} `json:"summary"`
+		Scenarios []struct {
+			Name                   string `json:"name"`
+			Status                 string `json:"status"`
+			ReplayBacklogEvents    int    `json:"replay_backlog_events"`
+			ReplayStepDelayMS      int    `json:"replay_step_delay_ms"`
+			ReplayWindowMS         int    `json:"replay_window_ms"`
+			LiveDeliveryDeadlineMS int    `json:"live_delivery_deadline_ms"`
+			ReplayDrainsAfterLive  bool   `json:"replay_drains_after_live"`
+		} `json:"scenarios"`
+	}
+	readJSONFile(t, reportPath, &report)
+	if report.Ticket != "OPE-261" || report.Status != "checked_in_evidence_pack" || report.Backend != "broker_stub" {
+		t.Fatalf("unexpected broker stub fanout report metadata: %+v", report)
+	}
+	if report.Summary.ScenarioCount != 1 || report.Summary.IsolatedScenarios != 1 || report.Summary.StalledScenarios != 0 || report.Summary.ReplayBacklogEvents != 4 || report.Summary.ReplayStepDelayMS != 30 || report.Summary.ReplayWindowMS != 120 || report.Summary.LiveDeliveryDeadlineMS != 50 || !report.Summary.IsolationMaintained {
+		t.Fatalf("unexpected broker stub fanout summary: %+v", report.Summary)
+	}
+	if len(report.Scenarios) != 1 {
+		t.Fatalf("expected 1 scenario row, got %+v", report.Scenarios)
+	}
+	if report.Scenarios[0].Name != "replay_catchup_does_not_block_live_publish" || report.Scenarios[0].Status != "isolated" || report.Scenarios[0].ReplayBacklogEvents != 4 || report.Scenarios[0].ReplayStepDelayMS != 30 || report.Scenarios[0].ReplayWindowMS != 120 || report.Scenarios[0].LiveDeliveryDeadlineMS != 50 || !report.Scenarios[0].ReplayDrainsAfterLive {
+		t.Fatalf("unexpected broker stub fanout scenario: %+v", report.Scenarios[0])
+	}
+
+	contents := readRepoFile(t, repoRoot, "docs/reports/event-bus-reliability-report.md")
+	for _, needle := range []string{"broker-stub-live-fanout-isolation-evidence-pack.json", "live fanout isolation for the local broker stub"} {
+		if !strings.Contains(contents, needle) {
+			t.Fatalf("event-bus reliability report missing substring %q", needle)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a checked-in broker stub live fanout isolation evidence pack and expose it through debug/distributed diagnostics
- cover the broker stub replay-vs-live isolation drill in event tests and regression tests
- thread the evidence pack into the event bus reliability report for rollout reviewers

## Validation
- cd bigclaw-go && go test ./internal/api ./internal/events ./internal/regression -count=1