### PR TITLE
OPE-268 default unattended continuation gate to hold

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -66,7 +66,7 @@ cd bigclaw-go
 python3 scripts/e2e/validation_bundle_continuation_scorecard.py --pretty
 ```
 
-This writes `docs/reports/validation-bundle-continuation-scorecard.json`, summarizing the recent bundle lineage plus the current shared-queue companion proof exported with the live validation bundle. `run_all.sh` now refreshes the scorecard automatically during closeout, but the continuation surface is still workflow-triggered rather than always-on.
+This writes `docs/reports/validation-bundle-continuation-scorecard.json`, summarizing the recent bundle lineage plus the current shared-queue companion proof exported with the live validation bundle. `run_all.sh` refreshes the scorecard automatically during closeout.
 
 You can evaluate the checked-in continuation policy gate as a follow-up:
 
@@ -75,15 +75,15 @@ cd bigclaw-go
 python3 scripts/e2e/validation_bundle_continuation_policy_gate.py --pretty
 ```
 
-This writes `docs/reports/validation-bundle-continuation-policy-gate.json` and currently returns `go` for the checked-in evidence window because the latest indexed bundles now include repeated `ray` coverage across multiple runs. `run_all.sh` refreshes the gate automatically during closeout; set `BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` if you want a `hold` result to fail the command.
+This writes `docs/reports/validation-bundle-continuation-policy-gate.json` and currently returns `go` for the checked-in evidence window because the latest indexed bundles now include repeated `ray` coverage across multiple runs. `run_all.sh` refreshes the gate automatically during closeout and now defaults unattended runs to `BIGCLAW_E2E_CONTINUATION_GATE_MODE=hold`, so stale or incomplete evidence exits with code `2`.
 
 For workflow behavior, prefer `BIGCLAW_E2E_CONTINUATION_GATE_MODE`:
 
-- `review` keeps the gate reviewer-visible but does not fail the workflow on `hold`
+- `review` keeps the gate reviewer-visible but does not fail the workflow on `hold`; use this for local debugging or evidence inspection
 - `hold` exits with code `2` when the evidence is stale or incomplete
 - `fail` exits with code `1` when the evidence is stale or incomplete
 
-`BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` remains as a compatibility alias for `BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail`. `run_all.sh` now rerenders the bundle README and `docs/reports/live-validation-index.md` after the gate refresh so the exported reviewer surface always reflects the latest gate mode and outcome from the same run.
+`BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` remains as a compatibility alias for `BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail`. Set `BIGCLAW_E2E_CONTINUATION_GATE_MODE=review` when you explicitly want a review-only local run. `run_all.sh` rerenders the bundle README and `docs/reports/live-validation-index.md` after the gate refresh so the exported reviewer surface always reflects the latest gate mode and outcome from the same run.
 
 ## Mixed workload matrix
 

--- a/bigclaw-go/scripts/e2e/run_all.sh
+++ b/bigclaw-go/scripts/e2e/run_all.sh
@@ -23,7 +23,7 @@ if [[ -z "$CONTINUATION_GATE_MODE" ]]; then
   if [[ "$ENFORCE_CONTINUATION_GATE" == "1" ]]; then
     CONTINUATION_GATE_MODE="fail"
   else
-    CONTINUATION_GATE_MODE="review"
+    CONTINUATION_GATE_MODE="hold"
   fi
 fi
 

--- a/bigclaw-go/scripts/e2e/run_all_test.py
+++ b/bigclaw-go/scripts/e2e/run_all_test.py
@@ -115,7 +115,6 @@ class RunAllTest(unittest.TestCase):
                 'BIGCLAW_E2E_RUN_BROKER': '1',
                 'BIGCLAW_E2E_BROKER_BACKEND': 'stub',
                 'BIGCLAW_E2E_BROKER_REPORT_PATH': 'docs/reports/broker-failover-stub-report.json',
-                'BIGCLAW_E2E_CONTINUATION_GATE_MODE': 'review',
             }
         )
 
@@ -140,6 +139,97 @@ class RunAllTest(unittest.TestCase):
         self.assertEqual(calls[0]['run_broker'], '1')
         self.assertEqual(calls[0]['broker_backend'], 'stub')
         self.assertEqual(calls[0]['broker_report_path'], 'docs/reports/broker-failover-stub-report.json')
+
+    def test_run_all_defaults_to_hold_mode(self) -> None:
+        self.install_stubs()
+        self.write_file(
+            'scripts/e2e/validation_bundle_continuation_policy_gate.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            mode = args[args.index('--enforcement-mode') + 1]
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({'enforcement': {'mode': mode}}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                'BIGCLAW_E2E_RUN_KUBERNETES': '0',
+                'BIGCLAW_E2E_RUN_RAY': '0',
+                'BIGCLAW_E2E_RUN_LOCAL': '1',
+            }
+        )
+
+        result = subprocess.run(
+            [str(self.root / 'scripts' / 'e2e' / 'run_all.sh')],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        gate = json.loads(
+            (self.root / 'docs' / 'reports' / 'validation-bundle-continuation-policy-gate.json').read_text(
+                encoding='utf-8'
+            )
+        )
+        self.assertEqual(gate['enforcement']['mode'], 'hold')
+
+    def test_legacy_enforce_alias_still_maps_to_fail_mode(self) -> None:
+        self.install_stubs()
+        self.write_file(
+            'scripts/e2e/validation_bundle_continuation_policy_gate.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            mode = args[args.index('--enforcement-mode') + 1]
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({'enforcement': {'mode': mode}}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+
+        env = os.environ.copy()
+        env.update(
+            {
+                'BIGCLAW_E2E_RUN_KUBERNETES': '0',
+                'BIGCLAW_E2E_RUN_RAY': '0',
+                'BIGCLAW_E2E_RUN_LOCAL': '1',
+                'BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE': '1',
+            }
+        )
+
+        result = subprocess.run(
+            [str(self.root / 'scripts' / 'e2e' / 'run_all.sh')],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        gate = json.loads(
+            (self.root / 'docs' / 'reports' / 'validation-bundle-continuation-policy-gate.json').read_text(
+                encoding='utf-8'
+            )
+        )
+        self.assertEqual(gate['enforcement']['mode'], 'fail')
 
 
 if __name__ == '__main__':

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate.py
@@ -28,7 +28,7 @@ def build_check(name, passed, detail):
 def normalize_enforcement_mode(enforcement_mode, legacy_enforce_continuation_gate=False):
     mode = str(enforcement_mode or '').strip().lower()
     if not mode:
-        mode = 'fail' if legacy_enforce_continuation_gate else 'review'
+        mode = 'fail' if legacy_enforce_continuation_gate else 'hold'
     if mode not in {'review', 'hold', 'fail'}:
         raise ValueError(
             f"unsupported enforcement mode {enforcement_mode!r}; expected one of review, hold, fail"
@@ -109,7 +109,7 @@ def build_report(
     if 'repeated_lane_coverage_meets_policy' in failing_checks:
         next_actions.append('refresh another full validation bundle with `ray` enabled so each executor lane has repeated indexed coverage')
     if not next_actions:
-        next_actions.append('set BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail when workflow closeout should stop on continuation regressions')
+        next_actions.append('set BIGCLAW_E2E_CONTINUATION_GATE_MODE=review for local debugging when continuation holds should stay reviewer-visible')
 
     return {
         'generated_at': utc_iso(),

--- a/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py
+++ b/bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py
@@ -70,10 +70,14 @@ class ValidationBundleContinuationPolicyGateTest(unittest.TestCase):
         self.assertEqual(report['ticket'], 'OPE-262')
         self.assertEqual(report['status'], 'policy-go')
         self.assertEqual(report['recommendation'], 'go')
-        self.assertEqual(report['enforcement']['mode'], 'review')
+        self.assertEqual(report['enforcement']['mode'], 'hold')
         self.assertEqual(report['enforcement']['outcome'], 'pass')
         self.assertEqual(report['failing_checks'], [])
         self.assertEqual(report['reviewer_path']['index_path'], 'docs/reports/live-validation-index.md')
+        self.assertIn(
+            'BIGCLAW_E2E_CONTINUATION_GATE_MODE=review',
+            report['next_actions'][0],
+        )
 
     def test_build_report_returns_policy_hold_with_actionable_failures(self) -> None:
         self.write_scorecard(

--- a/workflow.md
+++ b/workflow.md
@@ -104,3 +104,9 @@ Follow the same execution quality bar as the root workflow, and ensure every run
 2) successful `git push`,
 3) local/remote SHA equality confirmation,
 4) `git log -1 --stat` output capture.
+
+Validation closeout contract:
+- `cd bigclaw-go && ./scripts/e2e/run_all.sh` is the default unattended closeout path.
+- Continuation-gate enforcement defaults to `BIGCLAW_E2E_CONTINUATION_GATE_MODE=hold`, so stale or incomplete evidence fails closeout with exit code `2`.
+- Use `BIGCLAW_E2E_CONTINUATION_GATE_MODE=review` only for explicit local debugging or reviewer-only inspection.
+- `BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE=1` remains a compatibility alias for `BIGCLAW_E2E_CONTINUATION_GATE_MODE=fail`.


### PR DESCRIPTION
## Summary
- default unattended `run_all.sh` continuation gate enforcement to `hold` while keeping the explicit review-only and legacy fail overrides
- update continuation gate tests to cover the new default and the legacy fail alias
- refresh validation and workflow docs to describe the enforced closeout contract

## Validation
- python3 bigclaw-go/scripts/e2e/run_all_test.py
- python3 bigclaw-go/scripts/e2e/validation_bundle_continuation_policy_gate_test.py

## Linear
- OPE-268
