### PR TITLE
OPE-2: enable external-store broker stub validation in bundle workflow

### DIFF
--- a/bigclaw-go/docs/e2e-validation.md
+++ b/bigclaw-go/docs/e2e-validation.md
@@ -57,7 +57,7 @@ export BIGCLAW_QUEUE_BACKEND=sqlite
 ./scripts/e2e/run_all.sh
 ```
 
-The script writes a consolidated summary to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, exports a machine-readable shared-queue companion summary to `docs/reports/shared-queue-companion-summary.json`, writes a broker-lane summary to `docs/reports/broker-validation-summary.json`, and creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`.
+The script writes a consolidated summary to `docs/reports/live-validation-summary.json`, refreshes the canonical component reports for local, Kubernetes, and Ray validation, exports a machine-readable shared-queue companion summary to `docs/reports/shared-queue-companion-summary.json`, refreshes the deterministic broker stub lane at `docs/reports/broker-failover-stub-report.json`, writes a broker-lane summary to `docs/reports/broker-validation-summary.json`, and creates a timestamped bundle plus index under `docs/reports/live-validation-runs/` and `docs/reports/live-validation-index.md`.
 
 You can then refresh the rolling continuation overlay from the checked-in bundle evidence:
 
@@ -182,7 +182,7 @@ export BIGCLAW_E2E_SUMMARY_REPORT_PATH=docs/reports/live-validation-summary.json
 ./scripts/e2e/run_all.sh
 ```
 
-Leave `BIGCLAW_E2E_RUN_BROKER=0` when no live broker backend is available. The exported bundle will keep a reviewer-visible `broker` section with `status: skipped` and `configuration_state: not_configured` so the closeout surface stays explicit without requiring broker infrastructure.
+The default broker lane uses `BIGCLAW_E2E_BROKER_BACKEND=stub`, which keeps the bundle reviewer-visible without pretending a live broker backend exists. Set `BIGCLAW_E2E_RUN_BROKER=0` only when you intentionally want to skip the deterministic external-store proof. For future live adapters, override both `BIGCLAW_E2E_BROKER_BACKEND` and `BIGCLAW_E2E_BROKER_REPORT_PATH` so the bundle points at the backend-specific report instead of the stub output.
 
 ```bash
 cd bigclaw-go

--- a/bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md
+++ b/bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md
@@ -11,7 +11,9 @@ It turns the current durability planning work into an implementation-ready check
 - `docs/e2e-validation.md` covers local SQLite smoke, mixed workload runs, and two-node shared queue proof.
 - `docs/reports/event-bus-reliability-report.md` proves replay only for the in-process event bus.
 - `docs/reports/queue-reliability-report.md` and `docs/reports/lease-recovery-report.md` prove lease recovery and dead-letter replay for local queue backends.
-- No broker-backed event log, provider failover harness, or cross-backend checkpoint recovery report exists yet.
+- No live broker-backed event log exists yet.
+- The repo now ships a deterministic provider-neutral failover harness in `scripts/e2e/broker_failover_stub_matrix.py` with reports at `docs/reports/broker-failover-stub-report.json`, `docs/reports/broker-checkpoint-fencing-proof-summary.json`, and `docs/reports/broker-retention-boundary-proof-summary.json`.
+- Cross-backend checkpoint recovery is still validated through the deterministic harness rather than a live provider adapter.
 
 ## Validation Objectives
 
@@ -111,10 +113,10 @@ Each scenario report should include at least:
 
 ## Implementation Order
 
-1. Add a provider-neutral scenario runner that can emit the report schema above against a fake broker or deterministic stub.
+1. Keep the provider-neutral stub scenario runner aligned with the report schema above so future adapters inherit the same scenario ids and artifacts.
 2. Reuse the existing replay and checkpoint semantics already documented in `docs/e2e-validation.md`, `docs/reports/queue-reliability-report.md`, and `docs/reports/lease-recovery-report.md`.
 3. Introduce one backend adapter at a time behind the same scenario ids so result diffs stay comparable.
-4. Promote the pack into live broker validation only after the stubbed harness can prove sequence accounting and checkpoint fencing deterministically.
+4. Promote the pack into live broker validation only after the stubbed harness keeps proving sequence accounting, checkpoint fencing, and retention-boundary reset behavior deterministically.
 
 ## Live Validation Follow-On Path
 

--- a/bigclaw-go/docs/reports/broker-validation-summary.json
+++ b/bigclaw-go/docs/reports/broker-validation-summary.json
@@ -1,10 +1,632 @@
 {
-  "enabled": false,
-  "backend": null,
+  "enabled": true,
+  "backend": "stub",
   "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
   "canonical_summary_path": "docs/reports/broker-validation-summary.json",
   "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
-  "configuration_state": "not_configured",
-  "status": "skipped",
-  "reason": "not_configured"
+  "configuration_state": "configured",
+  "canonical_report_path": "docs/reports/broker-failover-stub-report.json",
+  "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json",
+  "report": {
+    "generated_at": "2026-03-17T12:00:00Z",
+    "ticket": "OPE-272",
+    "title": "Deterministic broker failover stub validation report",
+    "backend": "stub_broker",
+    "status": "deterministic-harness",
+    "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+    "report_schema_version": "2026-03-17",
+    "scenarios": [
+      {
+        "scenario_id": "BF-01",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "leader_before": "broker-a",
+          "leader_after": "broker-b"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:07Z",
+          "fault": "leader_restart_during_publish"
+        },
+        "published_count": 5,
+        "committed_count": 5,
+        "replayed_count": 5,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 0,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-02",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "replication_factor": 3,
+          "replica_lost": "broker-c"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "follower_loss_during_publish_and_replay"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a",
+          "publish_latency_spike_ms": 180
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-03",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "consumer_group": "group-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "consumer_crash_before_checkpoint_commit"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-04",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "consumer_group": "group-a",
+          "contenders": [
+            "consumer-a",
+            "consumer-b"
+          ]
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:03Z",
+          "end": "2026-03-17T12:00:04Z",
+          "fault": "checkpoint_leader_change_with_contention"
+        },
+        "published_count": 3,
+        "committed_count": 1,
+        "replayed_count": 1,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-b",
+          "lease_id": "lease-2",
+          "lease_epoch": 2,
+          "durable_sequence": 3
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          },
+          {
+            "owner_id": "consumer-b",
+            "lease_id": "lease-2",
+            "lease_epoch": 2
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 3,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ],
+        "stale_write_rejections": 1
+      },
+      {
+        "scenario_id": "BF-05",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "producer": "producer-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:01Z",
+          "end": "2026-03-17T12:00:02Z",
+          "fault": "producer_timeout_after_commit_ambiguity"
+        },
+        "published_count": 3,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 1,
+          "rejected": 1,
+          "unknown_commit": 1
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 0,
+          "resumed_from_node": "broker-a"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-06",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "replay_client": "consumer-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:06Z",
+          "fault": "replay_client_disconnect_and_reconnect"
+        },
+        "published_count": 5,
+        "committed_count": 2,
+        "replayed_count": 7,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 3
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 5
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 3,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-07",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "retention_floor": 3
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "retention_boundary_intersects_stale_checkpoint"
+        },
+        "published_count": 5,
+        "committed_count": 3,
+        "replayed_count": 3,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 1
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "operator-reset",
+          "lease_id": "manual-reset",
+          "lease_epoch": 2,
+          "durable_sequence": 3
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a",
+          "reset_required": true
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ],
+        "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+      },
+      {
+        "scenario_id": "BF-08",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "duplicate_window": true
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:04Z",
+          "fault": "split_brain_duplicate_delivery_window"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 3,
+        "duplicate_count": 1,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      }
+    ],
+    "summary": {
+      "scenario_count": 8,
+      "passing_scenarios": 8,
+      "failing_scenarios": 0,
+      "duplicate_count": 1,
+      "missing_event_count": 0
+    },
+    "proof_artifacts": {
+      "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+      "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+    }
+  },
+  "status": "deterministic-harness"
 }

--- a/bigclaw-go/docs/reports/epic-closure-readiness-report.md
+++ b/bigclaw-go/docs/reports/epic-closure-readiness-report.md
@@ -24,6 +24,11 @@
 - Completion distribution was `73` on `node-a` and `127` on `node-b`, with `99` cross-node completions.
 - Supporting report: `docs/reports/multi-node-coordination-report.md`
 
+## External-Store Replay Boundary
+
+- A deterministic provider-neutral broker harness now covers replay continuity, checkpoint fencing, retention-boundary reset behavior, and duplicate-delivery accounting outside the SQLite-only proof.
+- Supporting reports: `docs/reports/broker-failover-stub-report.json`, `docs/reports/broker-checkpoint-fencing-proof-summary.json`, and `docs/reports/broker-retention-boundary-proof-summary.json`
+
 ## Meaning
 
 The three previously open closure items are now covered by fresh same-day evidence:

--- a/bigclaw-go/docs/reports/live-validation-index.json
+++ b/bigclaw-go/docs/reports/live-validation-index.json
@@ -1,7 +1,7 @@
 {
   "latest": {
     "run_id": "20260316T140138Z",
-    "generated_at": "2026-03-17T04:32:13.251910+00:00",
+    "generated_at": "2026-03-17T10:09:21.845192+00:00",
     "status": "succeeded",
     "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
     "closeout_commands": [
@@ -693,14 +693,636 @@
       "service_log_path": "docs/reports/live-validation-runs/20260316T140138Z/ray.service.log"
     },
     "broker": {
-      "enabled": false,
-      "backend": null,
+      "enabled": true,
+      "backend": "stub",
       "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
       "canonical_summary_path": "docs/reports/broker-validation-summary.json",
       "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
-      "configuration_state": "not_configured",
-      "status": "skipped",
-      "reason": "not_configured"
+      "configuration_state": "configured",
+      "canonical_report_path": "docs/reports/broker-failover-stub-report.json",
+      "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json",
+      "report": {
+        "generated_at": "2026-03-17T12:00:00Z",
+        "ticket": "OPE-272",
+        "title": "Deterministic broker failover stub validation report",
+        "backend": "stub_broker",
+        "status": "deterministic-harness",
+        "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+        "report_schema_version": "2026-03-17",
+        "scenarios": [
+          {
+            "scenario_id": "BF-01",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "leader_before": "broker-a",
+              "leader_after": "broker-b"
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:05Z",
+              "end": "2026-03-17T12:00:07Z",
+              "fault": "leader_restart_during_publish"
+            },
+            "published_count": 5,
+            "committed_count": 5,
+            "replayed_count": 5,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 0
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 0
+            },
+            "lease_transitions": [],
+            "publish_outcomes": {
+              "committed": 5,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 0,
+              "resumed_from_node": "broker-b"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          },
+          {
+            "scenario_id": "BF-02",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "replication_factor": 3,
+              "replica_lost": "broker-c"
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:04Z",
+              "end": "2026-03-17T12:00:05Z",
+              "fault": "follower_loss_during_publish_and_replay"
+            },
+            "published_count": 4,
+            "committed_count": 2,
+            "replayed_count": 2,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 2
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 4
+            },
+            "lease_transitions": [],
+            "publish_outcomes": {
+              "committed": 4,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 2,
+              "resumed_from_node": "broker-a",
+              "publish_latency_spike_ms": 180
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          },
+          {
+            "scenario_id": "BF-03",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "consumer_group": "group-a"
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:04Z",
+              "end": "2026-03-17T12:00:05Z",
+              "fault": "consumer_crash_before_checkpoint_commit"
+            },
+            "published_count": 4,
+            "committed_count": 2,
+            "replayed_count": 2,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 2
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 4
+            },
+            "lease_transitions": [
+              {
+                "owner_id": "consumer-a",
+                "lease_id": "lease-1",
+                "lease_epoch": 1
+              }
+            ],
+            "publish_outcomes": {
+              "committed": 4,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 2,
+              "resumed_from_node": "broker-a"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          },
+          {
+            "scenario_id": "BF-04",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "consumer_group": "group-a",
+              "contenders": [
+                "consumer-a",
+                "consumer-b"
+              ]
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:03Z",
+              "end": "2026-03-17T12:00:04Z",
+              "fault": "checkpoint_leader_change_with_contention"
+            },
+            "published_count": 3,
+            "committed_count": 1,
+            "replayed_count": 1,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 2
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-b",
+              "lease_id": "lease-2",
+              "lease_epoch": 2,
+              "durable_sequence": 3
+            },
+            "lease_transitions": [
+              {
+                "owner_id": "consumer-a",
+                "lease_id": "lease-1",
+                "lease_epoch": 1
+              },
+              {
+                "owner_id": "consumer-b",
+                "lease_id": "lease-2",
+                "lease_epoch": 2
+              }
+            ],
+            "publish_outcomes": {
+              "committed": 3,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 2,
+              "resumed_from_node": "broker-b"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ],
+            "stale_write_rejections": 1
+          },
+          {
+            "scenario_id": "BF-05",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "producer": "producer-a"
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:01Z",
+              "end": "2026-03-17T12:00:02Z",
+              "fault": "producer_timeout_after_commit_ambiguity"
+            },
+            "published_count": 3,
+            "committed_count": 2,
+            "replayed_count": 2,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 0
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 0
+            },
+            "lease_transitions": [],
+            "publish_outcomes": {
+              "committed": 1,
+              "rejected": 1,
+              "unknown_commit": 1
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 0,
+              "resumed_from_node": "broker-a"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          },
+          {
+            "scenario_id": "BF-06",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "replay_client": "consumer-a"
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:05Z",
+              "end": "2026-03-17T12:00:06Z",
+              "fault": "replay_client_disconnect_and_reconnect"
+            },
+            "published_count": 5,
+            "committed_count": 2,
+            "replayed_count": 7,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 3
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-none",
+              "lease_epoch": 0,
+              "durable_sequence": 5
+            },
+            "lease_transitions": [],
+            "publish_outcomes": {
+              "committed": 5,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 3,
+              "resumed_from_node": "broker-b"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          },
+          {
+            "scenario_id": "BF-07",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "retention_floor": 3
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:05Z",
+              "end": "2026-03-17T12:00:05Z",
+              "fault": "retention_boundary_intersects_stale_checkpoint"
+            },
+            "published_count": 5,
+            "committed_count": 3,
+            "replayed_count": 3,
+            "duplicate_count": 0,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 1
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "operator-reset",
+              "lease_id": "manual-reset",
+              "lease_epoch": 2,
+              "durable_sequence": 3
+            },
+            "lease_transitions": [
+              {
+                "owner_id": "consumer-a",
+                "lease_id": "lease-1",
+                "lease_epoch": 1
+              }
+            ],
+            "publish_outcomes": {
+              "committed": 5,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 2,
+              "resumed_from_node": "broker-a",
+              "reset_required": true
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ],
+            "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+          },
+          {
+            "scenario_id": "BF-08",
+            "backend": "stub_broker",
+            "topology": {
+              "nodes": [
+                "broker-a",
+                "broker-b",
+                "broker-c"
+              ],
+              "duplicate_window": true
+            },
+            "fault_window": {
+              "start": "2026-03-17T12:00:04Z",
+              "end": "2026-03-17T12:00:04Z",
+              "fault": "split_brain_duplicate_delivery_window"
+            },
+            "published_count": 4,
+            "committed_count": 2,
+            "replayed_count": 3,
+            "duplicate_count": 1,
+            "missing_event_ids": [],
+            "checkpoint_before_fault": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 2
+            },
+            "checkpoint_after_recovery": {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1,
+              "durable_sequence": 4
+            },
+            "lease_transitions": [
+              {
+                "owner_id": "consumer-a",
+                "lease_id": "lease-1",
+                "lease_epoch": 1
+              }
+            ],
+            "publish_outcomes": {
+              "committed": 4,
+              "rejected": 0,
+              "unknown_commit": 0
+            },
+            "replay_resume_cursor": {
+              "after_sequence": 2,
+              "resumed_from_node": "broker-b"
+            },
+            "artifacts": {
+              "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+              "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+              "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+              "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+              "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+            },
+            "result": "passed",
+            "assertions": [
+              {
+                "label": "all committed events remain replayable after recovery",
+                "passed": true
+              },
+              {
+                "label": "checkpoint sequence stays monotonic across recovery",
+                "passed": true
+              },
+              {
+                "label": "stale writers are fenced instead of regressing the checkpoint",
+                "passed": true
+              },
+              {
+                "label": "ambiguous publish outcomes resolve from replay evidence",
+                "passed": true
+              }
+            ]
+          }
+        ],
+        "summary": {
+          "scenario_count": 8,
+          "passing_scenarios": 8,
+          "failing_scenarios": 0,
+          "duplicate_count": 1,
+          "missing_event_count": 0
+        },
+        "proof_artifacts": {
+          "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+          "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+        }
+      },
+      "status": "deterministic-harness"
     },
     "shared_queue_companion": {
       "available": true,
@@ -709,7 +1331,7 @@
       "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json",
       "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json",
       "status": "succeeded",
-      "generated_at": "2026-03-13T09:45:19Z",
+      "generated_at": "2026-03-16T15:59:45Z",
       "count": 200,
       "cross_node_completions": 99,
       "duplicate_started_tasks": 0,
@@ -733,7 +1355,7 @@
   "recent_runs": [
     {
       "run_id": "20260316T140138Z",
-      "generated_at": "2026-03-17T04:32:13.251910+00:00",
+      "generated_at": "2026-03-17T10:09:21.845192+00:00",
       "status": "succeeded",
       "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
       "summary_path": "docs/reports/live-validation-runs/20260316T140138Z/summary.json"

--- a/bigclaw-go/docs/reports/live-validation-index.md
+++ b/bigclaw-go/docs/reports/live-validation-index.md
@@ -1,7 +1,7 @@
 # Live Validation Index
 
 - Latest run: `20260316T140138Z`
-- Generated at: `2026-03-17T04:32:13.251910+00:00`
+- Generated at: `2026-03-17T10:09:21.845192+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260316T140138Z`
 - Summary JSON: `docs/reports/live-validation-runs/20260316T140138Z/summary.json`
@@ -42,13 +42,15 @@
 - Task ID: `ray-smoke-1773669703`
 
 ### broker
-- Enabled: `False`
-- Status: `skipped`
-- Configuration state: `not_configured`
+- Enabled: `True`
+- Status: `deterministic-harness`
+- Configuration state: `configured`
 - Bundle summary: `docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json`
 - Canonical summary: `docs/reports/broker-validation-summary.json`
 - Validation pack: `docs/reports/broker-failover-fault-injection-validation-pack.md`
-- Reason: `not_configured`
+- Backend: `stub`
+- Bundle report: `docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json`
+- Canonical report: `docs/reports/broker-failover-stub-report.json`
 
 ### shared-queue companion
 - Available: `True`
@@ -70,7 +72,7 @@
 
 ## Recent bundles
 
-- `20260316T140138Z` · `succeeded` · `2026-03-17T04:32:13.251910+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
+- `20260316T140138Z` · `succeeded` · `2026-03-17T10:09:21.845192+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`
 

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/README.md
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/README.md
@@ -1,7 +1,7 @@
 # Live Validation Index
 
 - Latest run: `20260316T140138Z`
-- Generated at: `2026-03-17T04:32:13.251910+00:00`
+- Generated at: `2026-03-17T10:09:21.845192+00:00`
 - Status: `succeeded`
 - Bundle: `docs/reports/live-validation-runs/20260316T140138Z`
 - Summary JSON: `docs/reports/live-validation-runs/20260316T140138Z/summary.json`
@@ -42,13 +42,15 @@
 - Task ID: `ray-smoke-1773669703`
 
 ### broker
-- Enabled: `False`
-- Status: `skipped`
-- Configuration state: `not_configured`
+- Enabled: `True`
+- Status: `deterministic-harness`
+- Configuration state: `configured`
 - Bundle summary: `docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json`
 - Canonical summary: `docs/reports/broker-validation-summary.json`
 - Validation pack: `docs/reports/broker-failover-fault-injection-validation-pack.md`
-- Reason: `not_configured`
+- Backend: `stub`
+- Bundle report: `docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json`
+- Canonical report: `docs/reports/broker-failover-stub-report.json`
 
 ### shared-queue companion
 - Available: `True`
@@ -70,7 +72,7 @@
 
 ## Recent bundles
 
-- `20260316T140138Z` · `succeeded` · `2026-03-17T04:32:13.251910+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
+- `20260316T140138Z` · `succeeded` · `2026-03-17T10:09:21.845192+00:00` · `docs/reports/live-validation-runs/20260316T140138Z`
 - `20260314T164647Z` · `succeeded` · `2026-03-14T16:46:57.671520+00:00` · `docs/reports/live-validation-runs/20260314T164647Z`
 - `20260314T163430Z` · `succeeded` · `2026-03-14T16:34:42.080370+00:00` · `docs/reports/live-validation-runs/20260314T163430Z`
 

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json
@@ -1,0 +1,621 @@
+{
+  "generated_at": "2026-03-17T12:00:00Z",
+  "ticket": "OPE-272",
+  "title": "Deterministic broker failover stub validation report",
+  "backend": "stub_broker",
+  "status": "deterministic-harness",
+  "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+  "report_schema_version": "2026-03-17",
+  "scenarios": [
+    {
+      "scenario_id": "BF-01",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "leader_before": "broker-a",
+        "leader_after": "broker-b"
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:05Z",
+        "end": "2026-03-17T12:00:07Z",
+        "fault": "leader_restart_during_publish"
+      },
+      "published_count": 5,
+      "committed_count": 5,
+      "replayed_count": 5,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 0
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 0
+      },
+      "lease_transitions": [],
+      "publish_outcomes": {
+        "committed": 5,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 0,
+        "resumed_from_node": "broker-b"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    },
+    {
+      "scenario_id": "BF-02",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "replication_factor": 3,
+        "replica_lost": "broker-c"
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:04Z",
+        "end": "2026-03-17T12:00:05Z",
+        "fault": "follower_loss_during_publish_and_replay"
+      },
+      "published_count": 4,
+      "committed_count": 2,
+      "replayed_count": 2,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 4
+      },
+      "lease_transitions": [],
+      "publish_outcomes": {
+        "committed": 4,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 2,
+        "resumed_from_node": "broker-a",
+        "publish_latency_spike_ms": 180
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    },
+    {
+      "scenario_id": "BF-03",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "consumer_group": "group-a"
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:04Z",
+        "end": "2026-03-17T12:00:05Z",
+        "fault": "consumer_crash_before_checkpoint_commit"
+      },
+      "published_count": 4,
+      "committed_count": 2,
+      "replayed_count": 2,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 4
+      },
+      "lease_transitions": [
+        {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1
+        }
+      ],
+      "publish_outcomes": {
+        "committed": 4,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 2,
+        "resumed_from_node": "broker-a"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    },
+    {
+      "scenario_id": "BF-04",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "consumer_group": "group-a",
+        "contenders": [
+          "consumer-a",
+          "consumer-b"
+        ]
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:03Z",
+        "end": "2026-03-17T12:00:04Z",
+        "fault": "checkpoint_leader_change_with_contention"
+      },
+      "published_count": 3,
+      "committed_count": 1,
+      "replayed_count": 1,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-b",
+        "lease_id": "lease-2",
+        "lease_epoch": 2,
+        "durable_sequence": 3
+      },
+      "lease_transitions": [
+        {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1
+        },
+        {
+          "owner_id": "consumer-b",
+          "lease_id": "lease-2",
+          "lease_epoch": 2
+        }
+      ],
+      "publish_outcomes": {
+        "committed": 3,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 2,
+        "resumed_from_node": "broker-b"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ],
+      "stale_write_rejections": 1
+    },
+    {
+      "scenario_id": "BF-05",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "producer": "producer-a"
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:01Z",
+        "end": "2026-03-17T12:00:02Z",
+        "fault": "producer_timeout_after_commit_ambiguity"
+      },
+      "published_count": 3,
+      "committed_count": 2,
+      "replayed_count": 2,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 0
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 0
+      },
+      "lease_transitions": [],
+      "publish_outcomes": {
+        "committed": 1,
+        "rejected": 1,
+        "unknown_commit": 1
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 0,
+        "resumed_from_node": "broker-a"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    },
+    {
+      "scenario_id": "BF-06",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "replay_client": "consumer-a"
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:05Z",
+        "end": "2026-03-17T12:00:06Z",
+        "fault": "replay_client_disconnect_and_reconnect"
+      },
+      "published_count": 5,
+      "committed_count": 2,
+      "replayed_count": 7,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 3
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-none",
+        "lease_epoch": 0,
+        "durable_sequence": 5
+      },
+      "lease_transitions": [],
+      "publish_outcomes": {
+        "committed": 5,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 3,
+        "resumed_from_node": "broker-b"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    },
+    {
+      "scenario_id": "BF-07",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "retention_floor": 3
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:05Z",
+        "end": "2026-03-17T12:00:05Z",
+        "fault": "retention_boundary_intersects_stale_checkpoint"
+      },
+      "published_count": 5,
+      "committed_count": 3,
+      "replayed_count": 3,
+      "duplicate_count": 0,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 1
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "operator-reset",
+        "lease_id": "manual-reset",
+        "lease_epoch": 2,
+        "durable_sequence": 3
+      },
+      "lease_transitions": [
+        {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1
+        }
+      ],
+      "publish_outcomes": {
+        "committed": 5,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 2,
+        "resumed_from_node": "broker-a",
+        "reset_required": true
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ],
+      "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+    },
+    {
+      "scenario_id": "BF-08",
+      "backend": "stub_broker",
+      "topology": {
+        "nodes": [
+          "broker-a",
+          "broker-b",
+          "broker-c"
+        ],
+        "duplicate_window": true
+      },
+      "fault_window": {
+        "start": "2026-03-17T12:00:04Z",
+        "end": "2026-03-17T12:00:04Z",
+        "fault": "split_brain_duplicate_delivery_window"
+      },
+      "published_count": 4,
+      "committed_count": 2,
+      "replayed_count": 3,
+      "duplicate_count": 1,
+      "missing_event_ids": [],
+      "checkpoint_before_fault": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 2
+      },
+      "checkpoint_after_recovery": {
+        "owner_id": "consumer-a",
+        "lease_id": "lease-1",
+        "lease_epoch": 1,
+        "durable_sequence": 4
+      },
+      "lease_transitions": [
+        {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1
+        }
+      ],
+      "publish_outcomes": {
+        "committed": 4,
+        "rejected": 0,
+        "unknown_commit": 0
+      },
+      "replay_resume_cursor": {
+        "after_sequence": 2,
+        "resumed_from_node": "broker-b"
+      },
+      "artifacts": {
+        "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+        "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+        "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+        "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+        "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+      },
+      "result": "passed",
+      "assertions": [
+        {
+          "label": "all committed events remain replayable after recovery",
+          "passed": true
+        },
+        {
+          "label": "checkpoint sequence stays monotonic across recovery",
+          "passed": true
+        },
+        {
+          "label": "stale writers are fenced instead of regressing the checkpoint",
+          "passed": true
+        },
+        {
+          "label": "ambiguous publish outcomes resolve from replay evidence",
+          "passed": true
+        }
+      ]
+    }
+  ],
+  "summary": {
+    "scenario_count": 8,
+    "passing_scenarios": 8,
+    "failing_scenarios": 0,
+    "duplicate_count": 1,
+    "missing_event_count": 0
+  },
+  "proof_artifacts": {
+    "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+    "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+  }
+}

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json
@@ -1,10 +1,632 @@
 {
-  "enabled": false,
-  "backend": null,
+  "enabled": true,
+  "backend": "stub",
   "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
   "canonical_summary_path": "docs/reports/broker-validation-summary.json",
   "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
-  "configuration_state": "not_configured",
-  "status": "skipped",
-  "reason": "not_configured"
+  "configuration_state": "configured",
+  "canonical_report_path": "docs/reports/broker-failover-stub-report.json",
+  "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json",
+  "report": {
+    "generated_at": "2026-03-17T12:00:00Z",
+    "ticket": "OPE-272",
+    "title": "Deterministic broker failover stub validation report",
+    "backend": "stub_broker",
+    "status": "deterministic-harness",
+    "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+    "report_schema_version": "2026-03-17",
+    "scenarios": [
+      {
+        "scenario_id": "BF-01",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "leader_before": "broker-a",
+          "leader_after": "broker-b"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:07Z",
+          "fault": "leader_restart_during_publish"
+        },
+        "published_count": 5,
+        "committed_count": 5,
+        "replayed_count": 5,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 0,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-02",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "replication_factor": 3,
+          "replica_lost": "broker-c"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "follower_loss_during_publish_and_replay"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a",
+          "publish_latency_spike_ms": 180
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-03",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "consumer_group": "group-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "consumer_crash_before_checkpoint_commit"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-04",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "consumer_group": "group-a",
+          "contenders": [
+            "consumer-a",
+            "consumer-b"
+          ]
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:03Z",
+          "end": "2026-03-17T12:00:04Z",
+          "fault": "checkpoint_leader_change_with_contention"
+        },
+        "published_count": 3,
+        "committed_count": 1,
+        "replayed_count": 1,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-b",
+          "lease_id": "lease-2",
+          "lease_epoch": 2,
+          "durable_sequence": 3
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          },
+          {
+            "owner_id": "consumer-b",
+            "lease_id": "lease-2",
+            "lease_epoch": 2
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 3,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ],
+        "stale_write_rejections": 1
+      },
+      {
+        "scenario_id": "BF-05",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "producer": "producer-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:01Z",
+          "end": "2026-03-17T12:00:02Z",
+          "fault": "producer_timeout_after_commit_ambiguity"
+        },
+        "published_count": 3,
+        "committed_count": 2,
+        "replayed_count": 2,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 0
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 1,
+          "rejected": 1,
+          "unknown_commit": 1
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 0,
+          "resumed_from_node": "broker-a"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-06",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "replay_client": "consumer-a"
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:06Z",
+          "fault": "replay_client_disconnect_and_reconnect"
+        },
+        "published_count": 5,
+        "committed_count": 2,
+        "replayed_count": 7,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 3
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-none",
+          "lease_epoch": 0,
+          "durable_sequence": 5
+        },
+        "lease_transitions": [],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 3,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      },
+      {
+        "scenario_id": "BF-07",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "retention_floor": 3
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:05Z",
+          "end": "2026-03-17T12:00:05Z",
+          "fault": "retention_boundary_intersects_stale_checkpoint"
+        },
+        "published_count": 5,
+        "committed_count": 3,
+        "replayed_count": 3,
+        "duplicate_count": 0,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 1
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "operator-reset",
+          "lease_id": "manual-reset",
+          "lease_epoch": 2,
+          "durable_sequence": 3
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 5,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-a",
+          "reset_required": true
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ],
+        "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+      },
+      {
+        "scenario_id": "BF-08",
+        "backend": "stub_broker",
+        "topology": {
+          "nodes": [
+            "broker-a",
+            "broker-b",
+            "broker-c"
+          ],
+          "duplicate_window": true
+        },
+        "fault_window": {
+          "start": "2026-03-17T12:00:04Z",
+          "end": "2026-03-17T12:00:04Z",
+          "fault": "split_brain_duplicate_delivery_window"
+        },
+        "published_count": 4,
+        "committed_count": 2,
+        "replayed_count": 3,
+        "duplicate_count": 1,
+        "missing_event_ids": [],
+        "checkpoint_before_fault": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 2
+        },
+        "checkpoint_after_recovery": {
+          "owner_id": "consumer-a",
+          "lease_id": "lease-1",
+          "lease_epoch": 1,
+          "durable_sequence": 4
+        },
+        "lease_transitions": [
+          {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1
+          }
+        ],
+        "publish_outcomes": {
+          "committed": 4,
+          "rejected": 0,
+          "unknown_commit": 0
+        },
+        "replay_resume_cursor": {
+          "after_sequence": 2,
+          "resumed_from_node": "broker-b"
+        },
+        "artifacts": {
+          "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+          "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+          "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+          "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+          "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+        },
+        "result": "passed",
+        "assertions": [
+          {
+            "label": "all committed events remain replayable after recovery",
+            "passed": true
+          },
+          {
+            "label": "checkpoint sequence stays monotonic across recovery",
+            "passed": true
+          },
+          {
+            "label": "stale writers are fenced instead of regressing the checkpoint",
+            "passed": true
+          },
+          {
+            "label": "ambiguous publish outcomes resolve from replay evidence",
+            "passed": true
+          }
+        ]
+      }
+    ],
+    "summary": {
+      "scenario_count": 8,
+      "passing_scenarios": 8,
+      "failing_scenarios": 0,
+      "duplicate_count": 1,
+      "missing_event_count": 0
+    },
+    "proof_artifacts": {
+      "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+      "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+    }
+  },
+  "status": "deterministic-harness"
 }

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json
@@ -1,7 +1,7 @@
 {
-  "generated_at": "2026-03-13T09:45:19Z",
-  "root_state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-mm2mjimi",
-  "queue_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-mm2mjimi/shared-queue.db",
+  "generated_at": "2026-03-16T15:59:45Z",
+  "root_state_dir": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-wvg32k1n",
+  "queue_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-wvg32k1n/shared-queue.db",
   "count": 200,
   "submitted_by_node": {
     "node-a": 100,
@@ -19,15 +19,15 @@
   "nodes": [
     {
       "name": "node-a",
-      "base_url": "http://127.0.0.1:55005",
-      "audit_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-mm2mjimi/node-a-audit.jsonl",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/node-a-1ww0l3ux.log"
+      "base_url": "http://127.0.0.1:63044",
+      "audit_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-wvg32k1n/node-a-audit.jsonl",
+      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/node-a-ufqioa77.log"
     },
     {
       "name": "node-b",
-      "base_url": "http://127.0.0.1:55006",
-      "audit_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-mm2mjimi/node-b-audit.jsonl",
-      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/node-b-m8u1cact.log"
+      "base_url": "http://127.0.0.1:63045",
+      "audit_path": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/bigclawd-multinode-wvg32k1n/node-b-audit.jsonl",
+      "service_log": "/var/folders/hk/51n7fnmd61z1gd61v3znybxm0000gn/T/node-b-0aaa_lax.log"
     }
   ]
 }

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json
@@ -5,7 +5,7 @@
   "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json",
   "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json",
   "status": "succeeded",
-  "generated_at": "2026-03-13T09:45:19Z",
+  "generated_at": "2026-03-16T15:59:45Z",
   "count": 200,
   "cross_node_completions": 99,
   "duplicate_started_tasks": 0,

--- a/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/summary.json
+++ b/bigclaw-go/docs/reports/live-validation-runs/20260316T140138Z/summary.json
@@ -1,6 +1,6 @@
 {
   "run_id": "20260316T140138Z",
-  "generated_at": "2026-03-17T04:32:13.251910+00:00",
+  "generated_at": "2026-03-17T10:09:21.845192+00:00",
   "status": "succeeded",
   "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
   "closeout_commands": [
@@ -692,14 +692,636 @@
     "service_log_path": "docs/reports/live-validation-runs/20260316T140138Z/ray.service.log"
   },
   "broker": {
-    "enabled": false,
-    "backend": null,
+    "enabled": true,
+    "backend": "stub",
     "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
     "canonical_summary_path": "docs/reports/broker-validation-summary.json",
     "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
-    "configuration_state": "not_configured",
-    "status": "skipped",
-    "reason": "not_configured"
+    "configuration_state": "configured",
+    "canonical_report_path": "docs/reports/broker-failover-stub-report.json",
+    "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json",
+    "report": {
+      "generated_at": "2026-03-17T12:00:00Z",
+      "ticket": "OPE-272",
+      "title": "Deterministic broker failover stub validation report",
+      "backend": "stub_broker",
+      "status": "deterministic-harness",
+      "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+      "report_schema_version": "2026-03-17",
+      "scenarios": [
+        {
+          "scenario_id": "BF-01",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "leader_before": "broker-a",
+            "leader_after": "broker-b"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:07Z",
+            "fault": "leader_restart_during_publish"
+          },
+          "published_count": 5,
+          "committed_count": 5,
+          "replayed_count": 5,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 0,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-02",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "replication_factor": 3,
+            "replica_lost": "broker-c"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "follower_loss_during_publish_and_replay"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a",
+            "publish_latency_spike_ms": 180
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-03",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "consumer_group": "group-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "consumer_crash_before_checkpoint_commit"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-04",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "consumer_group": "group-a",
+            "contenders": [
+              "consumer-a",
+              "consumer-b"
+            ]
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:03Z",
+            "end": "2026-03-17T12:00:04Z",
+            "fault": "checkpoint_leader_change_with_contention"
+          },
+          "published_count": 3,
+          "committed_count": 1,
+          "replayed_count": 1,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-b",
+            "lease_id": "lease-2",
+            "lease_epoch": 2,
+            "durable_sequence": 3
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            },
+            {
+              "owner_id": "consumer-b",
+              "lease_id": "lease-2",
+              "lease_epoch": 2
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 3,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ],
+          "stale_write_rejections": 1
+        },
+        {
+          "scenario_id": "BF-05",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "producer": "producer-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:01Z",
+            "end": "2026-03-17T12:00:02Z",
+            "fault": "producer_timeout_after_commit_ambiguity"
+          },
+          "published_count": 3,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 1,
+            "rejected": 1,
+            "unknown_commit": 1
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 0,
+            "resumed_from_node": "broker-a"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-06",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "replay_client": "consumer-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:06Z",
+            "fault": "replay_client_disconnect_and_reconnect"
+          },
+          "published_count": 5,
+          "committed_count": 2,
+          "replayed_count": 7,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 3
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 5
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 3,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-07",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "retention_floor": 3
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "retention_boundary_intersects_stale_checkpoint"
+          },
+          "published_count": 5,
+          "committed_count": 3,
+          "replayed_count": 3,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 1
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "operator-reset",
+            "lease_id": "manual-reset",
+            "lease_epoch": 2,
+            "durable_sequence": 3
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a",
+            "reset_required": true
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ],
+          "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+        },
+        {
+          "scenario_id": "BF-08",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "duplicate_window": true
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:04Z",
+            "fault": "split_brain_duplicate_delivery_window"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 3,
+          "duplicate_count": 1,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "scenario_count": 8,
+        "passing_scenarios": 8,
+        "failing_scenarios": 0,
+        "duplicate_count": 1,
+        "missing_event_count": 0
+      },
+      "proof_artifacts": {
+        "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+        "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+      }
+    },
+    "status": "deterministic-harness"
   },
   "shared_queue_companion": {
     "available": true,
@@ -708,7 +1330,7 @@
     "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json",
     "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json",
     "status": "succeeded",
-    "generated_at": "2026-03-13T09:45:19Z",
+    "generated_at": "2026-03-16T15:59:45Z",
     "count": 200,
     "cross_node_completions": 99,
     "duplicate_started_tasks": 0,

--- a/bigclaw-go/docs/reports/live-validation-summary.json
+++ b/bigclaw-go/docs/reports/live-validation-summary.json
@@ -1,6 +1,6 @@
 {
   "run_id": "20260316T140138Z",
-  "generated_at": "2026-03-17T04:32:13.251910+00:00",
+  "generated_at": "2026-03-17T10:09:21.845192+00:00",
   "status": "succeeded",
   "bundle_path": "docs/reports/live-validation-runs/20260316T140138Z",
   "closeout_commands": [
@@ -692,14 +692,636 @@
     "service_log_path": "docs/reports/live-validation-runs/20260316T140138Z/ray.service.log"
   },
   "broker": {
-    "enabled": false,
-    "backend": null,
+    "enabled": true,
+    "backend": "stub",
     "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
     "canonical_summary_path": "docs/reports/broker-validation-summary.json",
     "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
-    "configuration_state": "not_configured",
-    "status": "skipped",
-    "reason": "not_configured"
+    "configuration_state": "configured",
+    "canonical_report_path": "docs/reports/broker-failover-stub-report.json",
+    "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-failover-stub-report.json",
+    "report": {
+      "generated_at": "2026-03-17T12:00:00Z",
+      "ticket": "OPE-272",
+      "title": "Deterministic broker failover stub validation report",
+      "backend": "stub_broker",
+      "status": "deterministic-harness",
+      "source_validation_pack": "bigclaw-go/docs/reports/broker-failover-fault-injection-validation-pack.md",
+      "report_schema_version": "2026-03-17",
+      "scenarios": [
+        {
+          "scenario_id": "BF-01",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "leader_before": "broker-a",
+            "leader_after": "broker-b"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:07Z",
+            "fault": "leader_restart_during_publish"
+          },
+          "published_count": 5,
+          "committed_count": 5,
+          "replayed_count": 5,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 0,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-01/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-02",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "replication_factor": 3,
+            "replica_lost": "broker-c"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "follower_loss_during_publish_and_replay"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a",
+            "publish_latency_spike_ms": 180
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-02/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-03",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "consumer_group": "group-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "consumer_crash_before_checkpoint_commit"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-03/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-04",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "consumer_group": "group-a",
+            "contenders": [
+              "consumer-a",
+              "consumer-b"
+            ]
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:03Z",
+            "end": "2026-03-17T12:00:04Z",
+            "fault": "checkpoint_leader_change_with_contention"
+          },
+          "published_count": 3,
+          "committed_count": 1,
+          "replayed_count": 1,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-b",
+            "lease_id": "lease-2",
+            "lease_epoch": 2,
+            "durable_sequence": 3
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            },
+            {
+              "owner_id": "consumer-b",
+              "lease_id": "lease-2",
+              "lease_epoch": 2
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 3,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-04/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ],
+          "stale_write_rejections": 1
+        },
+        {
+          "scenario_id": "BF-05",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "producer": "producer-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:01Z",
+            "end": "2026-03-17T12:00:02Z",
+            "fault": "producer_timeout_after_commit_ambiguity"
+          },
+          "published_count": 3,
+          "committed_count": 2,
+          "replayed_count": 2,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 0
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 1,
+            "rejected": 1,
+            "unknown_commit": 1
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 0,
+            "resumed_from_node": "broker-a"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-05/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-06",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "replay_client": "consumer-a"
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:06Z",
+            "fault": "replay_client_disconnect_and_reconnect"
+          },
+          "published_count": 5,
+          "committed_count": 2,
+          "replayed_count": 7,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 3
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-none",
+            "lease_epoch": 0,
+            "durable_sequence": 5
+          },
+          "lease_transitions": [],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 3,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-06/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        },
+        {
+          "scenario_id": "BF-07",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "retention_floor": 3
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:05Z",
+            "end": "2026-03-17T12:00:05Z",
+            "fault": "retention_boundary_intersects_stale_checkpoint"
+          },
+          "published_count": 5,
+          "committed_count": 3,
+          "replayed_count": 3,
+          "duplicate_count": 0,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 1
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "operator-reset",
+            "lease_id": "manual-reset",
+            "lease_epoch": 2,
+            "durable_sequence": 3
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 5,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-a",
+            "reset_required": true
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-07/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ],
+          "operator_guidance": "checkpoint expired behind retention floor; explicit reset to sequence 3 required"
+        },
+        {
+          "scenario_id": "BF-08",
+          "backend": "stub_broker",
+          "topology": {
+            "nodes": [
+              "broker-a",
+              "broker-b",
+              "broker-c"
+            ],
+            "duplicate_window": true
+          },
+          "fault_window": {
+            "start": "2026-03-17T12:00:04Z",
+            "end": "2026-03-17T12:00:04Z",
+            "fault": "split_brain_duplicate_delivery_window"
+          },
+          "published_count": 4,
+          "committed_count": 2,
+          "replayed_count": 3,
+          "duplicate_count": 1,
+          "missing_event_ids": [],
+          "checkpoint_before_fault": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 2
+          },
+          "checkpoint_after_recovery": {
+            "owner_id": "consumer-a",
+            "lease_id": "lease-1",
+            "lease_epoch": 1,
+            "durable_sequence": 4
+          },
+          "lease_transitions": [
+            {
+              "owner_id": "consumer-a",
+              "lease_id": "lease-1",
+              "lease_epoch": 1
+            }
+          ],
+          "publish_outcomes": {
+            "committed": 4,
+            "rejected": 0,
+            "unknown_commit": 0
+          },
+          "replay_resume_cursor": {
+            "after_sequence": 2,
+            "resumed_from_node": "broker-b"
+          },
+          "artifacts": {
+            "publish_attempt_ledger": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/publish-attempt-ledger.json",
+            "replay_capture": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/replay-capture.json",
+            "checkpoint_transition_log": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/checkpoint-transition-log.json",
+            "fault_timeline": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/fault-timeline.json",
+            "backend_health_snapshot": "bigclaw-go/docs/reports/broker-failover-stub-artifacts/BF-08/backend-health.json"
+          },
+          "result": "passed",
+          "assertions": [
+            {
+              "label": "all committed events remain replayable after recovery",
+              "passed": true
+            },
+            {
+              "label": "checkpoint sequence stays monotonic across recovery",
+              "passed": true
+            },
+            {
+              "label": "stale writers are fenced instead of regressing the checkpoint",
+              "passed": true
+            },
+            {
+              "label": "ambiguous publish outcomes resolve from replay evidence",
+              "passed": true
+            }
+          ]
+        }
+      ],
+      "summary": {
+        "scenario_count": 8,
+        "passing_scenarios": 8,
+        "failing_scenarios": 0,
+        "duplicate_count": 1,
+        "missing_event_count": 0
+      },
+      "proof_artifacts": {
+        "checkpoint_fencing_summary": "bigclaw-go/docs/reports/broker-checkpoint-fencing-proof-summary.json",
+        "retention_boundary_summary": "bigclaw-go/docs/reports/broker-retention-boundary-proof-summary.json"
+      }
+    },
+    "status": "deterministic-harness"
   },
   "shared_queue_companion": {
     "available": true,
@@ -708,7 +1330,7 @@
     "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json",
     "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json",
     "status": "succeeded",
-    "generated_at": "2026-03-13T09:45:19Z",
+    "generated_at": "2026-03-16T15:59:45Z",
     "count": 200,
     "cross_node_completions": 99,
     "duplicate_started_tasks": 0,

--- a/bigclaw-go/docs/reports/review-readiness.md
+++ b/bigclaw-go/docs/reports/review-readiness.md
@@ -47,7 +47,8 @@
 
 - Production-grade capacity certification can remain a follow-up track beyond the current rewrite closure.
 - No dedicated leader-election layer exists yet; current evidence is limited to a local two-node shared-SQLite coordination proof.
-- Higher-scale external-store validation is still pending beyond the current SQLite-backed scope.
+- Higher-scale external-store validation now has a deterministic provider-neutral harness in `docs/reports/broker-failover-stub-report.json` plus focused checkpoint and retention summaries in `docs/reports/broker-checkpoint-fencing-proof-summary.json` and `docs/reports/broker-retention-boundary-proof-summary.json`.
+- Live broker-backed durability remains pending; current external-store proof is harness-backed rather than a production service rollout.
 
 ## Parallel follow-up digests
 

--- a/bigclaw-go/docs/reports/shared-queue-companion-summary.json
+++ b/bigclaw-go/docs/reports/shared-queue-companion-summary.json
@@ -5,7 +5,7 @@
   "bundle_report_path": "docs/reports/live-validation-runs/20260316T140138Z/multi-node-shared-queue-report.json",
   "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/shared-queue-companion-summary.json",
   "status": "succeeded",
-  "generated_at": "2026-03-13T09:45:19Z",
+  "generated_at": "2026-03-16T15:59:45Z",
   "count": 200,
   "cross_node_completions": 99,
   "duplicate_started_tasks": 0,

--- a/bigclaw-go/scripts/e2e/run_all.sh
+++ b/bigclaw-go/scripts/e2e/run_all.sh
@@ -10,9 +10,9 @@ BUNDLE_DIR_REL="${ARTIFACT_ROOT_REL}/${RUN_ID}"
 RUN_LOCAL="${BIGCLAW_E2E_RUN_LOCAL:-1}"
 RUN_KUBERNETES="${BIGCLAW_E2E_RUN_KUBERNETES:-1}"
 RUN_RAY="${BIGCLAW_E2E_RUN_RAY:-1}"
-RUN_BROKER="${BIGCLAW_E2E_RUN_BROKER:-0}"
-BROKER_BACKEND="${BIGCLAW_E2E_BROKER_BACKEND:-}"
-BROKER_REPORT_PATH="${BIGCLAW_E2E_BROKER_REPORT_PATH:-}"
+RUN_BROKER="${BIGCLAW_E2E_RUN_BROKER:-1}"
+BROKER_BACKEND="${BIGCLAW_E2E_BROKER_BACKEND:-stub}"
+BROKER_REPORT_PATH="${BIGCLAW_E2E_BROKER_REPORT_PATH:-docs/reports/broker-failover-stub-report.json}"
 REFRESH_CONTINUATION="${BIGCLAW_E2E_REFRESH_CONTINUATION:-1}"
 ENFORCE_CONTINUATION_GATE="${BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE:-0}"
 CONTINUATION_GATE_MODE="${BIGCLAW_E2E_CONTINUATION_GATE_MODE:-}"
@@ -39,7 +39,9 @@ K8S_OUT="$(mktemp -t bigclaw-k8s-e2e-out.XXXXXX)"
 K8S_ERR="$(mktemp -t bigclaw-k8s-e2e-err.XXXXXX)"
 RAY_OUT="$(mktemp -t bigclaw-ray-e2e-out.XXXXXX)"
 RAY_ERR="$(mktemp -t bigclaw-ray-e2e-err.XXXXXX)"
-trap 'rm -f "$LOCAL_OUT" "$LOCAL_ERR" "$K8S_OUT" "$K8S_ERR" "$RAY_OUT" "$RAY_ERR"' EXIT
+BROKER_OUT="$(mktemp -t bigclaw-broker-e2e-out.XXXXXX)"
+BROKER_ERR="$(mktemp -t bigclaw-broker-e2e-err.XXXXXX)"
+trap 'rm -f "$LOCAL_OUT" "$LOCAL_ERR" "$K8S_OUT" "$K8S_ERR" "$RAY_OUT" "$RAY_ERR" "$BROKER_OUT" "$BROKER_ERR"' EXIT
 
 status=0
 pids=()
@@ -68,6 +70,20 @@ if [[ "$RUN_RAY" == "1" ]]; then
   BIGCLAW_RAY_SMOKE_REPORT_PATH="$RAY_REPORT_REL" \
     "$ROOT/scripts/e2e/ray_smoke.sh" >"$RAY_OUT" 2>"$RAY_ERR" &
   pids+=("$!")
+fi
+
+if [[ "$RUN_BROKER" == "1" ]]; then
+  if [[ "$BROKER_BACKEND" == "stub" ]]; then
+    (
+      python3 "$ROOT/scripts/e2e/broker_failover_stub_matrix.py" \
+        --output "$BROKER_REPORT_PATH" \
+        --pretty
+    ) >"$BROKER_OUT" 2>"$BROKER_ERR" &
+    pids+=("$!")
+  elif [[ -z "$BROKER_REPORT_PATH" ]]; then
+    printf 'BIGCLAW_E2E_RUN_BROKER=1 requires BIGCLAW_E2E_BROKER_REPORT_PATH when BIGCLAW_E2E_BROKER_BACKEND=%s\n' "$BROKER_BACKEND" >&2
+    status=1
+  fi
 fi
 
 if (( ${#pids[@]} > 0 )); then

--- a/bigclaw-go/scripts/e2e/run_all_test.py
+++ b/bigclaw-go/scripts/e2e/run_all_test.py
@@ -73,6 +73,21 @@ class RunAllTest(unittest.TestCase):
             executable=True,
         )
         self.write_file(
+            'scripts/e2e/broker_failover_stub_matrix.py',
+            """\
+            #!/usr/bin/env python3
+            import json
+            import pathlib
+            import sys
+
+            args = sys.argv[1:]
+            output = pathlib.Path(args[args.index('--output') + 1])
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(json.dumps({'status': 'deterministic-harness'}), encoding='utf-8')
+            """,
+            executable=True,
+        )
+        self.write_file(
             'scripts/e2e/validation_bundle_continuation_scorecard.py',
             """\
             #!/usr/bin/env python3
@@ -137,6 +152,36 @@ class RunAllTest(unittest.TestCase):
         self.assertEqual(len(calls), 2)
         self.assertFalse(calls[0]['gate_exists'])
         self.assertTrue(calls[1]['gate_exists'])
+        self.assertEqual(calls[0]['run_broker'], '1')
+        self.assertEqual(calls[0]['broker_backend'], 'stub')
+        self.assertEqual(calls[0]['broker_report_path'], 'docs/reports/broker-failover-stub-report.json')
+
+    def test_run_all_defaults_enable_stub_broker_lane(self) -> None:
+        self.install_stubs()
+        env = os.environ.copy()
+        env.update(
+            {
+                'BIGCLAW_E2E_RUN_KUBERNETES': '0',
+                'BIGCLAW_E2E_RUN_RAY': '0',
+                'BIGCLAW_E2E_RUN_LOCAL': '0',
+            }
+        )
+
+        result = subprocess.run(
+            [str(self.root / 'scripts' / 'e2e' / 'run_all.sh')],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        calls = [
+            json.loads(line)
+            for line in (self.root / 'calls.jsonl').read_text(encoding='utf-8').splitlines()
+            if line.strip()
+        ]
         self.assertEqual(calls[0]['run_broker'], '1')
         self.assertEqual(calls[0]['broker_backend'], 'stub')
         self.assertEqual(calls[0]['broker_report_path'], 'docs/reports/broker-failover-stub-report.json')


### PR DESCRIPTION
## Summary
- enable the broker stub validation lane by default in `scripts/e2e/run_all.sh` and refresh it when the bundle runs
- extend focused test coverage for the broker lane defaults and bundle rerender behavior
- update review and validation docs plus bundle summaries so external-store evidence is surfaced as deterministic harness coverage rather than skipped

## Validation
- `cd bigclaw-go && python3 scripts/e2e/run_all_test.py`
- `cd bigclaw-go && python3 scripts/e2e/export_validation_bundle_test.py`
- `cd bigclaw-go && python3 scripts/e2e/broker_failover_stub_matrix.py --pretty`
- `cd bigclaw-go && python3 scripts/e2e/export_validation_bundle.py --go-root . --run-id 20260316T140138Z --bundle-dir docs/reports/live-validation-runs/20260316T140138Z --summary-path docs/reports/live-validation-summary.json --index-path docs/reports/live-validation-index.md --manifest-path docs/reports/live-validation-index.json --run-local 1 --run-kubernetes 1 --run-ray 1 --run-broker 1 --broker-backend stub --broker-report-path docs/reports/broker-failover-stub-report.json --validation-status 0 --local-report-path docs/reports/live-validation-runs/20260316T140138Z/sqlite-smoke-report.json --local-stdout-path docs/reports/live-validation-runs/20260316T140138Z/local.stdout.log --local-stderr-path docs/reports/live-validation-runs/20260316T140138Z/local.stderr.log --kubernetes-report-path docs/reports/live-validation-runs/20260316T140138Z/kubernetes-live-smoke-report.json --kubernetes-stdout-path docs/reports/live-validation-runs/20260316T140138Z/kubernetes.stdout.log --kubernetes-stderr-path docs/reports/live-validation-runs/20260316T140138Z/kubernetes.stderr.log --ray-report-path docs/reports/live-validation-runs/20260316T140138Z/ray-live-smoke-report.json --ray-stdout-path docs/reports/live-validation-runs/20260316T140138Z/ray.stdout.log --ray-stderr-path docs/reports/live-validation-runs/20260316T140138Z/ray.stderr.log`