### PR TITLE
OPE-1: add explicit coordinator leader election

### DIFF
--- a/bigclaw-go/cmd/bigclawd/main.go
+++ b/bigclaw-go/cmd/bigclawd/main.go
@@ -6,12 +6,14 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
 	"bigclaw-go/internal/api"
 	"bigclaw-go/internal/config"
 	"bigclaw-go/internal/control"
+	"bigclaw-go/internal/coordination"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
 	"bigclaw-go/internal/executor"
@@ -92,6 +94,12 @@ func main() {
 		panic(err)
 	}
 	defer closeSubscriberLeaseStore(subscriberLeases)
+	leaderElection, err := buildCoordinatorLeaderElection(cfg)
+	if err != nil {
+		panic(err)
+	}
+	defer closeCoordinatorLeaderElection(leaderElection)
+	coordinatorID := coordinatorID(cfg)
 	schedulerRuntime := scheduler.NewWithStores(policyStore, fairnessStore)
 	runtime := &worker.Runtime{
 		WorkerID:    "bootstrap-worker",
@@ -104,23 +112,34 @@ func main() {
 		LeaseTTL:    cfg.LeaseTTL,
 		TaskTimeout: cfg.TaskTimeout,
 	}
-	loop := &orchestrator.Loop{Runtime: runtime, Quota: scheduler.QuotaSnapshot{ConcurrentLimit: cfg.MaxConcurrentRuns, BudgetRemaining: cfg.DefaultBudgetCents}, PollInterval: cfg.PollInterval}
+	loop := &orchestrator.Loop{
+		Runtime:         runtime,
+		Quota:           scheduler.QuotaSnapshot{ConcurrentLimit: cfg.MaxConcurrentRuns, BudgetRemaining: cfg.DefaultBudgetCents},
+		PollInterval:    cfg.PollInterval,
+		LeaderElection:  leaderElection,
+		LeaderScope:     cfg.CoordinatorScope,
+		LeaderCandidate: coordinatorID,
+		LeaderTTL:       cfg.CoordinatorLeaseTTL,
+	}
 
 	if cfg.BootstrapTasks {
 		seed(context.Background(), q)
 	}
 	server := &api.Server{
-		Recorder:         recorder,
-		Queue:            q,
-		Executors:        registry.Kinds(),
-		Bus:              bus,
-		EventPlan:        events.NewDurabilityPlanWithBrokerConfig(eventPlanBackend, cfg.EventLogTargetBackend, cfg.EventLogReplicationFactor, brokerRuntimeConfig(cfg)),
-		EventLog:         eventLog,
-		SubscriberLeases: subscriberLeases,
-		Worker:           runtime,
-		Control:          controller,
-		SchedulerPolicy:  policyStore,
-		SchedulerRuntime: schedulerRuntime,
+		Recorder:          recorder,
+		Queue:             q,
+		Executors:         registry.Kinds(),
+		Bus:               bus,
+		EventPlan:         events.NewDurabilityPlanWithBrokerConfig(eventPlanBackend, cfg.EventLogTargetBackend, cfg.EventLogReplicationFactor, brokerRuntimeConfig(cfg)),
+		EventLog:          eventLog,
+		SubscriberLeases:  subscriberLeases,
+		CoordinatorLeases: leaderElection,
+		CoordinatorScope:  cfg.CoordinatorScope,
+		CoordinatorID:     coordinatorID,
+		Worker:            runtime,
+		Control:           controller,
+		SchedulerPolicy:   policyStore,
+		SchedulerRuntime:  schedulerRuntime,
 	}
 	httpServer := &http.Server{Addr: cfg.HTTPAddr, Handler: server.Handler()}
 	go func() {
@@ -145,6 +164,31 @@ func buildSubscriberLeaseStore(cfg config.Config) (events.SubscriberLeaseStore, 
 		return events.NewSubscriberLeaseCoordinator(), nil
 	}
 	return events.NewSQLiteSubscriberLeaseStore(cfg.SubscriberLeaseSQLitePath)
+}
+
+func buildCoordinatorLeaderElection(cfg config.Config) (coordination.LeaderElection, error) {
+	if cfg.CoordinatorLeaseSQLitePath == "" {
+		return coordination.NewLeaderElection(), nil
+	}
+	return coordination.NewSQLiteLeaderElection(cfg.CoordinatorLeaseSQLitePath)
+}
+
+func closeCoordinatorLeaderElection(store coordination.LeaderElection) {
+	type closer interface{ Close() error }
+	if closable, ok := store.(closer); ok {
+		_ = closable.Close()
+	}
+}
+
+func coordinatorID(cfg config.Config) string {
+	if strings.TrimSpace(cfg.CoordinatorID) != "" {
+		return strings.TrimSpace(cfg.CoordinatorID)
+	}
+	host, err := os.Hostname()
+	if err != nil || strings.TrimSpace(host) == "" {
+		host = "unknown-host"
+	}
+	return fmt.Sprintf("%s@%s", cfg.ServiceName, host)
 }
 
 func closeSubscriberLeaseStore(store events.SubscriberLeaseStore) {

--- a/bigclaw-go/docs/reports/multi-node-coordination-report.md
+++ b/bigclaw-go/docs/reports/multi-node-coordination-report.md
@@ -20,9 +20,13 @@
 
 ## Meaning
 
-This run proves that two independent `bigclawd` processes can share the same SQLite-backed queue and coordinate task consumption without duplicate terminal execution in the current local topology. It is not a full leader-election system, but it gives the epic a concrete multi-node coordination proof instead of relying only on single-process evidence.
+This run proves that two independent `bigclawd` processes can share the same SQLite-backed queue and coordinate task consumption without duplicate terminal execution in the current local topology. It is not a full distributed durability proof, but it gives the epic a concrete multi-node coordination baseline instead of relying only on single-process evidence.
 
-In the runtime capability matrix, this shared-queue result is the current `live_proven` shared-queue proof. Subscriber takeover, stale-writer fencing, and replay coordination remain `harness_proven` or `contract_only` until the same semantics are emitted by a live multi-node run.
+In the runtime capability matrix, this shared-queue result is the current `live_proven` shared-queue proof. Subscriber takeover, stale-writer fencing, and replay coordination remain `harness_proven` or `contract_only` until the same semantics are emitted by a live multi-node run. The runtime now carries a dedicated coordinator leader-election lease for scheduler authority and failover visibility, but that lease still uses the same local SQLite durability boundary as the rest of the current proof.
+
+## Leader Election Boundary
+
+The coordinator lease makes scheduler ownership explicit through `scope`, `leader_id`, `lease_token`, `lease_epoch`, and expiry metadata surfaced in `/debug/status` and `/v2/reports/distributed`. That hardens failover and stale-owner fencing beyond implicit writer behavior, while still remaining a local SQLite-backed coordination mechanism rather than a broker-backed or quorum-backed control plane.
 
 ## Artifact
 

--- a/bigclaw-go/internal/api/distributed.go
+++ b/bigclaw-go/internal/api/distributed.go
@@ -103,6 +103,7 @@ type traceExportBundleTrace struct {
 
 type distributedDiagnostics struct {
 	Summary               distributedDiagnosticsSummary         `json:"summary"`
+	CoordinatorLeadership coordinatorLeadershipStatus           `json:"coordinator_leadership"`
 	RoutingReasons        []routingReasonSummary                `json:"routing_reasons"`
 	ExecutorCapacity      []executorCapacityView                `json:"executor_capacity"`
 	ClusterHealth         clusterHealthRollup                   `json:"cluster_health"`
@@ -157,6 +158,7 @@ func (s *Server) handleV2DistributedReport(w http.ResponseWriter, r *http.Reques
 		},
 		"event_durability":             s.EventPlan,
 		"summary":                      diagnostics.Summary,
+		"coordinator_leadership":       diagnostics.CoordinatorLeadership,
 		"routing_reasons":              diagnostics.RoutingReasons,
 		"executor_capacity":            diagnostics.ExecutorCapacity,
 		"cluster_health":               diagnostics.ClusterHealth,
@@ -385,6 +387,7 @@ func (s *Server) buildDistributedDiagnostics(filters controlCenterFilters) distr
 	}
 	diagnostics := distributedDiagnostics{
 		Summary:               summary,
+		CoordinatorLeadership: s.coordinatorLeadershipStatus(),
 		RoutingReasons:        routingReasons,
 		ExecutorCapacity:      executorCapacity,
 		ClusterHealth:         clusterHealth,

--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"bigclaw-go/internal/control"
+	"bigclaw-go/internal/coordination"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
 	"bigclaw-go/internal/flow"
@@ -31,19 +32,22 @@ type WorkerPoolStatusProvider interface {
 }
 
 type Server struct {
-	Recorder         *observability.Recorder
-	Queue            queue.Queue
-	Executors        []domain.ExecutorKind
-	Bus              *events.Bus
-	EventPlan        events.DurabilityPlan
-	EventLog         events.EventLog
-	SubscriberLeases events.SubscriberLeaseStore
-	Now              func() time.Time
-	Worker           WorkerStatusProvider
-	Control          *control.Controller
-	FlowStore        *flow.Store
-	SchedulerPolicy  *scheduler.PolicyStore
-	SchedulerRuntime *scheduler.Scheduler
+	Recorder          *observability.Recorder
+	Queue             queue.Queue
+	Executors         []domain.ExecutorKind
+	Bus               *events.Bus
+	EventPlan         events.DurabilityPlan
+	EventLog          events.EventLog
+	SubscriberLeases  events.SubscriberLeaseStore
+	CoordinatorLeases coordination.LeaderElection
+	CoordinatorScope  string
+	CoordinatorID     string
+	Now               func() time.Time
+	Worker            WorkerStatusProvider
+	Control           *control.Controller
+	FlowStore         *flow.Store
+	SchedulerPolicy   *scheduler.PolicyStore
+	SchedulerRuntime  *scheduler.Scheduler
 }
 
 type checkpointDiagnostics struct {
@@ -69,6 +73,16 @@ type checkpointResetSnapshot struct {
 
 type checkpointExpiredError struct {
 	Diagnostics checkpointDiagnostics
+}
+
+type coordinatorLeadershipStatus struct {
+	Scope        string                    `json:"scope"`
+	CandidateID  string                    `json:"candidate_id,omitempty"`
+	HasLeader    bool                      `json:"has_leader"`
+	IsLeader     bool                      `json:"is_leader"`
+	Authority    string                    `json:"authority"`
+	LeaseBackend string                    `json:"lease_backend"`
+	Lease        *coordination.LeaderLease `json:"lease,omitempty"`
 }
 
 func (e checkpointExpiredError) Error() string {
@@ -201,6 +215,7 @@ func (s *Server) Handler() http.Handler {
 			"event_durability_rollout":        rolloutScorecard,
 			"event_log":                       s.eventLogCapabilities(r.Context()),
 			"coordination_capability_surface": coordinationCapabilitySurfacePayload(),
+			"coordinator_leadership":          s.coordinatorLeadershipStatus(),
 			"delivery_ack_readiness":          deliveryAckReadinessPayload(),
 			"live_shadow_mirror_scorecard":    liveShadowMirrorPayload(),
 			"rollback_trigger_surface":        rollbackTriggerSurfacePayload(),
@@ -320,6 +335,47 @@ func (s *Server) publishSubscriberLeaseEvent(eventType domain.EventType, now tim
 		Timestamp: now,
 		Payload:   payload,
 	})
+}
+
+func (s *Server) coordinatorLeadershipStatus() coordinatorLeadershipStatus {
+	scope := strings.TrimSpace(s.CoordinatorScope)
+	if scope == "" {
+		scope = "scheduler"
+	}
+	status := coordinatorLeadershipStatus{
+		Scope:        scope,
+		CandidateID:  strings.TrimSpace(s.CoordinatorID),
+		HasLeader:    false,
+		IsLeader:     false,
+		Authority:    "implicit_single_node",
+		LeaseBackend: "memory",
+	}
+	if s.CoordinatorLeases == nil {
+		return status
+	}
+	status.Authority = "standby"
+	type stringer interface{ String() string }
+	if named, ok := s.CoordinatorLeases.(stringer); ok {
+		status.LeaseBackend = named.String()
+	}
+	now := s.Now().UTC()
+	lease, ok := s.CoordinatorLeases.Get(scope)
+	if !ok {
+		return status
+	}
+	status.Lease = &lease
+	status.HasLeader = coordination.IsLeaderActive(lease, now)
+	if !status.HasLeader {
+		status.Authority = "expired"
+		return status
+	}
+	if lease.LeaderID == status.CandidateID {
+		status.IsLeader = true
+		status.Authority = "leader"
+		return status
+	}
+	status.Authority = "follower"
+	return status
 }
 
 func subscriberLeaseEventKeyPart(groupID string, subscriberID string) string {

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"bigclaw-go/internal/control"
+	"bigclaw-go/internal/coordination"
 	"bigclaw-go/internal/domain"
 	"bigclaw-go/internal/events"
 	"bigclaw-go/internal/observability"
@@ -380,6 +381,59 @@ func TestDebugStatusIncludesCoordinationCapabilitySurface(t *testing.T) {
 	first := decoded.Coordination.Capabilities[0]
 	if first.Name != "shared_queue_task_coordination" || first.CurrentState != "implemented" || first.RuntimeReadiness != "live_proven" || first.ContractOnly || !first.LiveProven || len(first.SourceReportLinks) == 0 {
 		t.Fatalf("unexpected first capability payload: %+v", first)
+	}
+}
+
+func TestDebugStatusIncludesCoordinatorLeadership(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+	election := coordination.NewLeaderElection()
+	lease, err := election.Campaign(coordination.CampaignRequest{
+		Scope:     "scheduler",
+		Candidate: "node-a",
+		TTL:       5 * time.Second,
+		Now:       now,
+	})
+	if err != nil {
+		t.Fatalf("seed coordinator leadership: %v", err)
+	}
+	server := &Server{
+		Recorder:          observability.NewRecorder(),
+		Queue:             queue.NewMemoryQueue(),
+		Bus:               events.NewBus(),
+		CoordinatorLeases: election,
+		CoordinatorScope:  "scheduler",
+		CoordinatorID:     "node-a",
+		Now:               func() time.Time { return now.Add(time.Second) },
+	}
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/debug/status", nil)
+
+	server.Handler().ServeHTTP(response, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", response.Code)
+	}
+	var decoded struct {
+		Leadership struct {
+			Scope       string `json:"scope"`
+			CandidateID string `json:"candidate_id"`
+			HasLeader   bool   `json:"has_leader"`
+			IsLeader    bool   `json:"is_leader"`
+			Authority   string `json:"authority"`
+			Lease       struct {
+				LeaderID   string `json:"leader_id"`
+				LeaseToken string `json:"lease_token"`
+				LeaseEpoch int64  `json:"lease_epoch"`
+			} `json:"lease"`
+		} `json:"coordinator_leadership"`
+	}
+	if err := json.Unmarshal(response.Body.Bytes(), &decoded); err != nil {
+		t.Fatalf("decode debug coordinator leadership payload: %v", err)
+	}
+	if decoded.Leadership.Scope != "scheduler" || decoded.Leadership.CandidateID != "node-a" || !decoded.Leadership.HasLeader || !decoded.Leadership.IsLeader || decoded.Leadership.Authority != "leader" {
+		t.Fatalf("unexpected coordinator leadership status: %+v", decoded.Leadership)
+	}
+	if decoded.Leadership.Lease.LeaderID != "node-a" || decoded.Leadership.Lease.LeaseToken != lease.LeaseToken || decoded.Leadership.Lease.LeaseEpoch != lease.LeaseEpoch {
+		t.Fatalf("unexpected coordinator leadership lease payload: %+v", decoded.Leadership.Lease)
 	}
 }
 
@@ -2159,6 +2213,7 @@ func TestV2ControlCenterIncludesMultiWorkerPoolSummary(t *testing.T) {
 func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	recorder := observability.NewRecorder()
 	controller := control.New()
+	election := coordination.NewLeaderElection()
 	server := &Server{
 		Recorder:  recorder,
 		Queue:     queue.NewMemoryQueue(),
@@ -2172,12 +2227,23 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 			ReplayLimit:        1024,
 			CheckpointInterval: 10 * time.Second,
 		}),
-		Control: controller,
-		Worker:  fakeWorkerPoolStatus{},
-		Now:     func() time.Time { return time.Unix(1700007200, 0) },
+		CoordinatorLeases: election,
+		CoordinatorScope:  "scheduler",
+		CoordinatorID:     "node-a",
+		Control:           controller,
+		Worker:            fakeWorkerPoolStatus{},
+		Now:               func() time.Time { return time.Unix(1700007200, 0) },
 	}
 	handler := server.Handler()
 	base := time.Unix(1700000000, 0)
+	if _, err := election.Campaign(coordination.CampaignRequest{
+		Scope:     "scheduler",
+		Candidate: "node-a",
+		TTL:       24 * time.Hour,
+		Now:       server.Now(),
+	}); err != nil {
+		t.Fatalf("seed coordinator lease: %v", err)
+	}
 	for _, task := range []domain.Task{
 		{ID: "diag-local", TraceID: "trace-local", Title: "Local diag", State: domain.TaskSucceeded, Metadata: map[string]string{"team": "platform", "project": "alpha"}, UpdatedAt: base.Add(time.Minute)},
 		{ID: "diag-k8s", TraceID: "trace-k8s", Title: "K8s diag", State: domain.TaskSucceeded, RequiredTools: []string{"browser"}, Metadata: map[string]string{"team": "platform", "project": "alpha"}, UpdatedAt: base.Add(2 * time.Minute)},
@@ -2216,6 +2282,17 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 				ActiveWorkers        int `json:"active_workers"`
 				ActiveTakeovers      int `json:"active_takeovers"`
 			} `json:"summary"`
+			CoordinatorLeadership struct {
+				Scope       string `json:"scope"`
+				CandidateID string `json:"candidate_id"`
+				HasLeader   bool   `json:"has_leader"`
+				IsLeader    bool   `json:"is_leader"`
+				Authority   string `json:"authority"`
+				Lease       struct {
+					LeaderID   string `json:"leader_id"`
+					LeaseToken string `json:"lease_token"`
+				} `json:"lease"`
+			} `json:"coordinator_leadership"`
 			RoutingReasons []struct {
 				Executor string `json:"executor"`
 				Reason   string `json:"reason"`
@@ -2367,6 +2444,12 @@ func TestV2ControlCenterIncludesDistributedDiagnostics(t *testing.T) {
 	}
 	if decoded.Diagnostics.Summary.ActiveWorkers != 2 || decoded.Diagnostics.Summary.ActiveTakeovers != 1 {
 		t.Fatalf("unexpected worker/takeover summary: %+v", decoded.Diagnostics.Summary)
+	}
+	if decoded.Diagnostics.CoordinatorLeadership.Scope != "scheduler" || decoded.Diagnostics.CoordinatorLeadership.CandidateID != "node-a" || !decoded.Diagnostics.CoordinatorLeadership.HasLeader || !decoded.Diagnostics.CoordinatorLeadership.IsLeader || decoded.Diagnostics.CoordinatorLeadership.Authority != "leader" {
+		t.Fatalf("unexpected coordinator leadership payload: %+v", decoded.Diagnostics.CoordinatorLeadership)
+	}
+	if decoded.Diagnostics.CoordinatorLeadership.Lease.LeaderID != "node-a" || decoded.Diagnostics.CoordinatorLeadership.Lease.LeaseToken == "" {
+		t.Fatalf("expected active coordinator lease metadata, got %+v", decoded.Diagnostics.CoordinatorLeadership.Lease)
 	}
 	if len(decoded.Diagnostics.RoutingReasons) != 3 {
 		t.Fatalf("expected 3 routing reasons, got %+v", decoded.Diagnostics.RoutingReasons)

--- a/bigclaw-go/internal/config/config.go
+++ b/bigclaw-go/internal/config/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	EventLogRemoteBearer          string
 	QueueSQLitePath               string
 	SubscriberLeaseSQLitePath     string
+	CoordinatorLeaseSQLitePath    string
+	CoordinatorScope              string
+	CoordinatorID                 string
+	CoordinatorLeaseTTL           time.Duration
 	AuditLogPath                  string
 	ServiceName                   string
 	LeaseTTL                      time.Duration
@@ -85,6 +89,10 @@ func Default() Config {
 		EventLogRemoteBearer:          "",
 		QueueSQLitePath:               "./state/queue.db",
 		SubscriberLeaseSQLitePath:     "",
+		CoordinatorLeaseSQLitePath:    "",
+		CoordinatorScope:              "scheduler",
+		CoordinatorID:                 "",
+		CoordinatorLeaseTTL:           5 * time.Second,
 		AuditLogPath:                  "./state/audit.jsonl",
 		ServiceName:                   "bigclawd",
 		LeaseTTL:                      2 * time.Minute,
@@ -142,6 +150,9 @@ func LoadFromEnv() Config {
 	cfg.EventLogRemoteBearer = getString("BIGCLAW_EVENT_LOG_REMOTE_BEARER_TOKEN", cfg.EventLogRemoteBearer)
 	cfg.QueueSQLitePath = getString("BIGCLAW_QUEUE_SQLITE_PATH", cfg.QueueSQLitePath)
 	cfg.SubscriberLeaseSQLitePath = getString("BIGCLAW_SUBSCRIBER_LEASE_SQLITE_PATH", cfg.SubscriberLeaseSQLitePath)
+	cfg.CoordinatorLeaseSQLitePath = getString("BIGCLAW_COORDINATOR_LEASE_SQLITE_PATH", cfg.CoordinatorLeaseSQLitePath)
+	cfg.CoordinatorScope = getString("BIGCLAW_COORDINATOR_SCOPE", cfg.CoordinatorScope)
+	cfg.CoordinatorID = getString("BIGCLAW_COORDINATOR_ID", cfg.CoordinatorID)
 	cfg.AuditLogPath = getString("BIGCLAW_AUDIT_LOG_PATH", cfg.AuditLogPath)
 	cfg.ServiceName = getString("BIGCLAW_SERVICE_NAME", cfg.ServiceName)
 	cfg.QueueFilePath = getString("BIGCLAW_QUEUE_FILE", cfg.QueueFilePath)
@@ -164,6 +175,7 @@ func LoadFromEnv() Config {
 	cfg.KubernetesPollInterval = getDuration("BIGCLAW_KUBERNETES_POLL_INTERVAL", cfg.KubernetesPollInterval)
 	cfg.RayPollInterval = getDuration("BIGCLAW_RAY_POLL_INTERVAL", cfg.RayPollInterval)
 	cfg.RayHTTPTimeout = getDuration("BIGCLAW_RAY_HTTP_TIMEOUT", cfg.RayHTTPTimeout)
+	cfg.CoordinatorLeaseTTL = getDuration("BIGCLAW_COORDINATOR_LEASE_TTL", cfg.CoordinatorLeaseTTL)
 	cfg.MaxConcurrentRuns = getInt("BIGCLAW_MAX_CONCURRENT_RUNS", cfg.MaxConcurrentRuns)
 	cfg.DefaultBudgetCents = getInt64("BIGCLAW_DEFAULT_BUDGET_CENTS", cfg.DefaultBudgetCents)
 	cfg.KubernetesCleanupFinishedJobs = getBool("BIGCLAW_KUBERNETES_CLEANUP", cfg.KubernetesCleanupFinishedJobs)

--- a/bigclaw-go/internal/config/config_test.go
+++ b/bigclaw-go/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestLoadFromEnvIncludesEventLogBrokerSettings(t *testing.T) {
 	t.Setenv("BIGCLAW_EVENT_LOG_BACKEND", "broker")
@@ -41,9 +44,19 @@ func TestLoadFromEnvIncludesEventLogBrokerSettings(t *testing.T) {
 
 func TestLoadFromEnvIncludesSubscriberLeaseSQLitePath(t *testing.T) {
 	t.Setenv("BIGCLAW_SUBSCRIBER_LEASE_SQLITE_PATH", "/tmp/shared-subscriber-leases.db")
+	t.Setenv("BIGCLAW_COORDINATOR_LEASE_SQLITE_PATH", "/tmp/shared-coordinator-leases.db")
+	t.Setenv("BIGCLAW_COORDINATOR_SCOPE", "scheduler")
+	t.Setenv("BIGCLAW_COORDINATOR_ID", "node-a")
+	t.Setenv("BIGCLAW_COORDINATOR_LEASE_TTL", "9s")
 
 	cfg := LoadFromEnv()
 	if cfg.SubscriberLeaseSQLitePath != "/tmp/shared-subscriber-leases.db" {
 		t.Fatalf("expected subscriber lease sqlite path, got %q", cfg.SubscriberLeaseSQLitePath)
+	}
+	if cfg.CoordinatorLeaseSQLitePath != "/tmp/shared-coordinator-leases.db" {
+		t.Fatalf("expected coordinator lease sqlite path, got %q", cfg.CoordinatorLeaseSQLitePath)
+	}
+	if cfg.CoordinatorScope != "scheduler" || cfg.CoordinatorID != "node-a" || cfg.CoordinatorLeaseTTL != 9*time.Second {
+		t.Fatalf("unexpected coordinator lease config: %+v", cfg)
 	}
 }

--- a/bigclaw-go/internal/coordination/leader_election.go
+++ b/bigclaw-go/internal/coordination/leader_election.go
@@ -1,0 +1,119 @@
+package coordination
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+var (
+	ErrLeaderHeld    = errors.New("coordinator leader lease held by another candidate")
+	ErrLeaderExpired = errors.New("coordinator leader lease expired")
+	ErrLeaderFence   = errors.New("coordinator leader lease fenced")
+)
+
+type LeaderLease struct {
+	Scope      string    `json:"scope"`
+	LeaderID   string    `json:"leader_id"`
+	LeaseToken string    `json:"lease_token"`
+	LeaseEpoch int64     `json:"lease_epoch"`
+	ExpiresAt  time.Time `json:"expires_at"`
+	AcquiredAt time.Time `json:"acquired_at"`
+	RenewedAt  time.Time `json:"renewed_at"`
+}
+
+type CampaignRequest struct {
+	Scope     string
+	Candidate string
+	TTL       time.Duration
+	Now       time.Time
+}
+
+type LeaderElection interface {
+	Campaign(request CampaignRequest) (LeaderLease, error)
+	Get(scope string) (LeaderLease, bool)
+	Resign(scope string, candidate string, leaseToken string, leaseEpoch int64) error
+}
+
+func IsLeaderActive(lease LeaderLease, now time.Time) bool {
+	if lease.Scope == "" || lease.LeaderID == "" || lease.LeaseToken == "" || lease.ExpiresAt.IsZero() {
+		return false
+	}
+	return now.Before(lease.ExpiresAt)
+}
+
+type memoryLeaderElection struct {
+	mu      sync.Mutex
+	leases  map[string]LeaderLease
+	counter uint64
+}
+
+func NewLeaderElection() LeaderElection {
+	return &memoryLeaderElection{leases: make(map[string]LeaderLease)}
+}
+
+func (e *memoryLeaderElection) Campaign(request CampaignRequest) (LeaderLease, error) {
+	if request.Scope == "" || request.Candidate == "" {
+		return LeaderLease{}, fmt.Errorf("scope and candidate are required")
+	}
+	if request.TTL <= 0 {
+		return LeaderLease{}, fmt.Errorf("ttl must be positive")
+	}
+	if request.Now.IsZero() {
+		request.Now = time.Now().UTC()
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	current, ok := e.leases[request.Scope]
+	if ok && IsLeaderActive(current, request.Now) && current.LeaderID != request.Candidate {
+		return current, ErrLeaderHeld
+	}
+	if ok && IsLeaderActive(current, request.Now) && current.LeaderID == request.Candidate {
+		current.ExpiresAt = request.Now.Add(request.TTL)
+		current.RenewedAt = request.Now
+		e.leases[request.Scope] = current
+		return current, nil
+	}
+
+	next := LeaderLease{
+		Scope:      request.Scope,
+		LeaderID:   request.Candidate,
+		LeaseToken: e.nextToken(),
+		LeaseEpoch: current.LeaseEpoch + 1,
+		ExpiresAt:  request.Now.Add(request.TTL),
+		AcquiredAt: request.Now,
+		RenewedAt:  request.Now,
+	}
+	e.leases[request.Scope] = next
+	return next, nil
+}
+
+func (e *memoryLeaderElection) Get(scope string) (LeaderLease, bool) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	lease, ok := e.leases[scope]
+	return lease, ok
+}
+
+func (e *memoryLeaderElection) Resign(scope string, candidate string, leaseToken string, leaseEpoch int64) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	current, ok := e.leases[scope]
+	if !ok {
+		return ErrLeaderExpired
+	}
+	if current.LeaderID != candidate || current.LeaseToken != leaseToken || current.LeaseEpoch != leaseEpoch {
+		return ErrLeaderFence
+	}
+	delete(e.leases, scope)
+	return nil
+}
+
+func (e *memoryLeaderElection) nextToken() string {
+	e.counter++
+	return fmt.Sprintf("leader-%d", e.counter)
+}

--- a/bigclaw-go/internal/coordination/leader_election_test.go
+++ b/bigclaw-go/internal/coordination/leader_election_test.go
@@ -1,0 +1,74 @@
+package coordination
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMemoryLeaderElectionFailoverAndFence(t *testing.T) {
+	election := NewLeaderElection()
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	leaseA, err := election.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-a", TTL: 5 * time.Second, Now: now})
+	if err != nil {
+		t.Fatalf("campaign node-a: %v", err)
+	}
+
+	conflict, err := election.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-b", TTL: 5 * time.Second, Now: now.Add(time.Second)})
+	if !errors.Is(err, ErrLeaderHeld) {
+		t.Fatalf("expected leader held conflict, got lease=%+v err=%v", conflict, err)
+	}
+	if conflict.LeaderID != "node-a" {
+		t.Fatalf("expected conflict to expose node-a, got %+v", conflict)
+	}
+
+	leaseB, err := election.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-b", TTL: 5 * time.Second, Now: now.Add(6 * time.Second)})
+	if err != nil {
+		t.Fatalf("campaign node-b after expiry: %v", err)
+	}
+	if leaseB.LeaseEpoch != leaseA.LeaseEpoch+1 {
+		t.Fatalf("expected lease epoch advance from %d to %d, got %+v", leaseA.LeaseEpoch, leaseA.LeaseEpoch+1, leaseB)
+	}
+	if err := election.Resign("scheduler", "node-a", leaseA.LeaseToken, leaseA.LeaseEpoch); !errors.Is(err, ErrLeaderFence) {
+		t.Fatalf("expected stale resign fence, got %v", err)
+	}
+	if err := election.Resign("scheduler", "node-b", leaseB.LeaseToken, leaseB.LeaseEpoch); err != nil {
+		t.Fatalf("resign active leader: %v", err)
+	}
+}
+
+func TestSQLiteLeaderElectionSharedStoreFailover(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "leader-election.db")
+	primary, err := NewSQLiteLeaderElection(path)
+	if err != nil {
+		t.Fatalf("new sqlite election primary: %v", err)
+	}
+	defer func() { _ = primary.Close() }()
+	secondary, err := NewSQLiteLeaderElection(path)
+	if err != nil {
+		t.Fatalf("new sqlite election secondary: %v", err)
+	}
+	defer func() { _ = secondary.Close() }()
+
+	now := time.Unix(1_700_000_000, 0).UTC()
+	leaseA, err := primary.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-a", TTL: 5 * time.Second, Now: now})
+	if err != nil {
+		t.Fatalf("campaign node-a: %v", err)
+	}
+	conflict, err := secondary.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-b", TTL: 5 * time.Second, Now: now.Add(time.Second)})
+	if !errors.Is(err, ErrLeaderHeld) {
+		t.Fatalf("expected leader held conflict, got lease=%+v err=%v", conflict, err)
+	}
+	leaseB, err := secondary.Campaign(CampaignRequest{Scope: "scheduler", Candidate: "node-b", TTL: 5 * time.Second, Now: now.Add(6 * time.Second)})
+	if err != nil {
+		t.Fatalf("campaign node-b after expiry: %v", err)
+	}
+	if leaseB.LeaseEpoch != leaseA.LeaseEpoch+1 {
+		t.Fatalf("expected epoch advance, got lease-a=%+v lease-b=%+v", leaseA, leaseB)
+	}
+	if err := primary.Resign("scheduler", "node-a", leaseA.LeaseToken, leaseA.LeaseEpoch); !errors.Is(err, ErrLeaderFence) {
+		t.Fatalf("expected stale resign fence, got %v", err)
+	}
+}

--- a/bigclaw-go/internal/coordination/sqlite_leader_election.go
+++ b/bigclaw-go/internal/coordination/sqlite_leader_election.go
@@ -1,0 +1,236 @@
+package coordination
+
+import (
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+type SQLiteLeaderElection struct {
+	db   *sql.DB
+	path string
+	mu   sync.Mutex
+}
+
+func NewSQLiteLeaderElection(path string) (*SQLiteLeaderElection, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	store := &SQLiteLeaderElection{db: db, path: path}
+	if err := store.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return store, nil
+}
+
+func (s *SQLiteLeaderElection) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+	return s.db.Close()
+}
+
+func (s *SQLiteLeaderElection) Campaign(request CampaignRequest) (lease LeaderLease, err error) {
+	if request.Scope == "" || request.Candidate == "" {
+		return LeaderLease{}, fmt.Errorf("scope and candidate are required")
+	}
+	if request.TTL <= 0 {
+		return LeaderLease{}, fmt.Errorf("ttl must be positive")
+	}
+	if request.Now.IsZero() {
+		request.Now = time.Now().UTC()
+	}
+
+	err = s.withImmediateTx(func() error {
+		current, ok, err := s.get(request.Scope)
+		if err != nil {
+			return err
+		}
+		if ok && IsLeaderActive(current, request.Now) && current.LeaderID != request.Candidate {
+			lease = current
+			return ErrLeaderHeld
+		}
+		if ok && IsLeaderActive(current, request.Now) && current.LeaderID == request.Candidate {
+			current.ExpiresAt = request.Now.Add(request.TTL)
+			current.RenewedAt = request.Now
+			if err := s.save(current); err != nil {
+				return err
+			}
+			lease = current
+			return nil
+		}
+
+		token, err := s.nextToken()
+		if err != nil {
+			return err
+		}
+		next := LeaderLease{
+			Scope:      request.Scope,
+			LeaderID:   request.Candidate,
+			LeaseToken: token,
+			LeaseEpoch: current.LeaseEpoch + 1,
+			ExpiresAt:  request.Now.Add(request.TTL),
+			AcquiredAt: request.Now,
+			RenewedAt:  request.Now,
+		}
+		if err := s.save(next); err != nil {
+			return err
+		}
+		lease = next
+		return nil
+	})
+	return lease, err
+}
+
+func (s *SQLiteLeaderElection) Get(scope string) (LeaderLease, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	lease, ok, err := s.get(scope)
+	if err != nil {
+		return LeaderLease{}, false
+	}
+	return lease, ok
+}
+
+func (s *SQLiteLeaderElection) Resign(scope string, candidate string, leaseToken string, leaseEpoch int64) error {
+	return s.withImmediateTx(func() error {
+		current, ok, err := s.get(scope)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return ErrLeaderExpired
+		}
+		if current.LeaderID != candidate || current.LeaseToken != leaseToken || current.LeaseEpoch != leaseEpoch {
+			return ErrLeaderFence
+		}
+		_, err = s.db.Exec(`DELETE FROM coordinator_leader_lease WHERE scope = ?`, scope)
+		return err
+	})
+}
+
+func (s *SQLiteLeaderElection) String() string {
+	return fmt.Sprintf("sqlite:%s", s.path)
+}
+
+func (s *SQLiteLeaderElection) init() error {
+	stmts := []string{
+		`PRAGMA journal_mode=WAL;`,
+		`PRAGMA busy_timeout=5000;`,
+		`CREATE TABLE IF NOT EXISTS coordinator_leader_lease (
+			scope TEXT PRIMARY KEY,
+			leader_id TEXT NOT NULL,
+			lease_token TEXT NOT NULL,
+			lease_epoch INTEGER NOT NULL,
+			expires_at_ns INTEGER NOT NULL,
+			acquired_at_ns INTEGER NOT NULL,
+			renewed_at_ns INTEGER NOT NULL
+		);`,
+		`CREATE TABLE IF NOT EXISTS coordinator_leader_token_seq (
+			id INTEGER PRIMARY KEY AUTOINCREMENT
+		);`,
+	}
+	for _, stmt := range stmts {
+		if _, err := s.db.Exec(stmt); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *SQLiteLeaderElection) withImmediateTx(fn func() error) (err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, err = s.db.Exec(`BEGIN IMMEDIATE`); err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_, _ = s.db.Exec(`ROLLBACK`)
+		}
+	}()
+	if err = fn(); err != nil {
+		return err
+	}
+	_, err = s.db.Exec(`COMMIT`)
+	return err
+}
+
+func (s *SQLiteLeaderElection) get(scope string) (LeaderLease, bool, error) {
+	row := s.db.QueryRow(`SELECT scope, leader_id, lease_token, lease_epoch, expires_at_ns, acquired_at_ns, renewed_at_ns
+		FROM coordinator_leader_lease WHERE scope = ?`, scope)
+	var lease LeaderLease
+	var expiresAtNS int64
+	var acquiredAtNS int64
+	var renewedAtNS int64
+	if err := row.Scan(
+		&lease.Scope,
+		&lease.LeaderID,
+		&lease.LeaseToken,
+		&lease.LeaseEpoch,
+		&expiresAtNS,
+		&acquiredAtNS,
+		&renewedAtNS,
+	); err != nil {
+		if err == sql.ErrNoRows {
+			return LeaderLease{}, false, nil
+		}
+		return LeaderLease{}, false, err
+	}
+	lease.ExpiresAt = time.Unix(0, expiresAtNS).UTC()
+	lease.AcquiredAt = time.Unix(0, acquiredAtNS).UTC()
+	lease.RenewedAt = time.Unix(0, renewedAtNS).UTC()
+	return lease, true, nil
+}
+
+func (s *SQLiteLeaderElection) save(lease LeaderLease) error {
+	_, err := s.db.Exec(`INSERT INTO coordinator_leader_lease(
+			scope, leader_id, lease_token, lease_epoch, expires_at_ns, acquired_at_ns, renewed_at_ns
+		) VALUES(?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT(scope) DO UPDATE SET
+			leader_id = excluded.leader_id,
+			lease_token = excluded.lease_token,
+			lease_epoch = excluded.lease_epoch,
+			expires_at_ns = excluded.expires_at_ns,
+			acquired_at_ns = excluded.acquired_at_ns,
+			renewed_at_ns = excluded.renewed_at_ns`,
+		lease.Scope,
+		lease.LeaderID,
+		lease.LeaseToken,
+		lease.LeaseEpoch,
+		lease.ExpiresAt.UTC().UnixNano(),
+		lease.AcquiredAt.UTC().UnixNano(),
+		lease.RenewedAt.UTC().UnixNano(),
+	)
+	return err
+}
+
+func (s *SQLiteLeaderElection) nextToken() (string, error) {
+	result, err := s.db.Exec(`INSERT INTO coordinator_leader_token_seq DEFAULT VALUES`)
+	if err != nil {
+		return "", err
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("leader-%d", id), nil
+}
+
+func isSQLiteBusy(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "database is locked")
+}

--- a/bigclaw-go/internal/orchestrator/loop.go
+++ b/bigclaw-go/internal/orchestrator/loop.go
@@ -4,14 +4,23 @@ import (
 	"context"
 	"time"
 
+	"bigclaw-go/internal/coordination"
 	"bigclaw-go/internal/scheduler"
-	"bigclaw-go/internal/worker"
 )
 
+type Runner interface {
+	RunOnce(context.Context, scheduler.QuotaSnapshot) bool
+}
+
 type Loop struct {
-	Runtime      *worker.Runtime
-	Quota        scheduler.QuotaSnapshot
-	PollInterval time.Duration
+	Runtime         Runner
+	Quota           scheduler.QuotaSnapshot
+	PollInterval    time.Duration
+	LeaderElection  coordination.LeaderElection
+	LeaderScope     string
+	LeaderCandidate string
+	LeaderTTL       time.Duration
+	Now             func() time.Time
 }
 
 func (l *Loop) Run(ctx context.Context) {
@@ -23,7 +32,37 @@ func (l *Loop) Run(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			_ = l.Runtime.RunOnce(ctx, l.Quota)
+			l.runStep(ctx)
 		}
 	}
+}
+
+func (l *Loop) runStep(ctx context.Context) {
+	if l.Runtime == nil {
+		return
+	}
+	if !l.shouldRun(ctx) {
+		return
+	}
+	_ = l.Runtime.RunOnce(ctx, l.Quota)
+}
+
+func (l *Loop) shouldRun(_ context.Context) bool {
+	if l.LeaderElection == nil {
+		return true
+	}
+	now := time.Now().UTC()
+	if l.Now != nil {
+		now = l.Now().UTC()
+	}
+	lease, err := l.LeaderElection.Campaign(coordination.CampaignRequest{
+		Scope:     l.LeaderScope,
+		Candidate: l.LeaderCandidate,
+		TTL:       l.LeaderTTL,
+		Now:       now,
+	})
+	if err != nil {
+		return false
+	}
+	return lease.LeaderID == l.LeaderCandidate && coordination.IsLeaderActive(lease, now)
 }

--- a/bigclaw-go/internal/orchestrator/loop_test.go
+++ b/bigclaw-go/internal/orchestrator/loop_test.go
@@ -1,0 +1,89 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"bigclaw-go/internal/coordination"
+	"bigclaw-go/internal/scheduler"
+)
+
+type spyRunner struct {
+	calls int
+}
+
+func (r *spyRunner) RunOnce(_ context.Context, _ scheduler.QuotaSnapshot) bool {
+	r.calls++
+	return true
+}
+
+type stubElection struct {
+	lease coordination.LeaderLease
+	err   error
+}
+
+func (e stubElection) Campaign(_ coordination.CampaignRequest) (coordination.LeaderLease, error) {
+	return e.lease, e.err
+}
+
+func (e stubElection) Get(_ string) (coordination.LeaderLease, bool) {
+	return e.lease, e.lease.Scope != ""
+}
+
+func (e stubElection) Resign(_ string, _ string, _ string, _ int64) error {
+	return nil
+}
+
+func TestLoopRunStepRequiresCoordinatorLeadership(t *testing.T) {
+	now := time.Unix(1_700_000_000, 0).UTC()
+
+	t.Run("runs when candidate holds active lease", func(t *testing.T) {
+		runner := &spyRunner{}
+		loop := &Loop{
+			Runtime:         runner,
+			LeaderElection:  stubElection{lease: coordination.LeaderLease{Scope: "scheduler", LeaderID: "node-a", LeaseToken: "leader-1", ExpiresAt: now.Add(5 * time.Second)}},
+			LeaderScope:     "scheduler",
+			LeaderCandidate: "node-a",
+			LeaderTTL:       5 * time.Second,
+			Now:             func() time.Time { return now },
+		}
+		loop.runStep(context.Background())
+		if runner.calls != 1 {
+			t.Fatalf("expected runner to execute once, got %d", runner.calls)
+		}
+	})
+
+	t.Run("skips when lease is held by another node", func(t *testing.T) {
+		runner := &spyRunner{}
+		loop := &Loop{
+			Runtime:         runner,
+			LeaderElection:  stubElection{lease: coordination.LeaderLease{Scope: "scheduler", LeaderID: "node-b", LeaseToken: "leader-2", ExpiresAt: now.Add(5 * time.Second)}, err: coordination.ErrLeaderHeld},
+			LeaderScope:     "scheduler",
+			LeaderCandidate: "node-a",
+			LeaderTTL:       5 * time.Second,
+			Now:             func() time.Time { return now },
+		}
+		loop.runStep(context.Background())
+		if runner.calls != 0 {
+			t.Fatalf("expected runner to be skipped, got %d", runner.calls)
+		}
+	})
+
+	t.Run("skips on election errors", func(t *testing.T) {
+		runner := &spyRunner{}
+		loop := &Loop{
+			Runtime:         runner,
+			LeaderElection:  stubElection{err: errors.New("sqlite unavailable")},
+			LeaderScope:     "scheduler",
+			LeaderCandidate: "node-a",
+			LeaderTTL:       5 * time.Second,
+			Now:             func() time.Time { return now },
+		}
+		loop.runStep(context.Background())
+		if runner.calls != 0 {
+			t.Fatalf("expected runner to be skipped on election error, got %d", runner.calls)
+		}
+	})
+}

--- a/bigclaw-go/internal/regression/cross_process_coordination_docs_test.go
+++ b/bigclaw-go/internal/regression/cross_process_coordination_docs_test.go
@@ -101,6 +101,8 @@ func TestCrossProcessCoordinationReadinessDocsStayAligned(t *testing.T) {
 			substrings: []string{
 				"runtime capability matrix",
 				"`live_proven` shared-queue proof",
+				"dedicated coordinator leader-election lease",
+				"`lease_token`",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- add a dedicated coordinator leader-election layer with memory and SQLite-backed leases
- gate orchestrator scheduling on the active coordinator lease and surface leadership metadata in debug/distributed diagnostics
- add regression coverage plus docs clarifying the current SQLite proof boundary vs explicit leader-election hardening

## Validation
- go test ./internal/coordination ./internal/orchestrator ./internal/config ./internal/api ./internal/regression
- go test ./...
