### PR TITLE
OPE-21: add broker bootstrap readiness export summary

### DIFF
--- a/bigclaw-go/docs/reports/broker-bootstrap-review-summary.json
+++ b/bigclaw-go/docs/reports/broker-bootstrap-review-summary.json
@@ -1,0 +1,26 @@
+{
+  "event_log_backend": "memory",
+  "target_backend": "broker_replicated",
+  "ready": false,
+  "runtime_posture": "contract_only",
+  "live_adapter_implemented": false,
+  "proof_boundary": "broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof",
+  "config_completeness": {
+    "driver": false,
+    "urls": false,
+    "topic": false,
+    "consumer_group": false
+  },
+  "broker_bootstrap": {
+    "publish_timeout": "5s",
+    "replay_limit": 500,
+    "checkpoint_interval": "5s",
+    "ready": false,
+    "validation_errors": [
+      "broker event log config missing driver, urls, topic"
+    ]
+  },
+  "validation_errors": [
+    "broker event log config missing driver, urls, topic"
+  ]
+}

--- a/bigclaw-go/docs/reports/broker-validation-summary.json
+++ b/bigclaw-go/docs/reports/broker-validation-summary.json
@@ -3,8 +3,49 @@
   "backend": null,
   "bundle_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json",
   "canonical_summary_path": "docs/reports/broker-validation-summary.json",
+  "bundle_bootstrap_summary_path": "docs/reports/live-validation-runs/20260316T140138Z/broker-bootstrap-review-summary.json",
+  "canonical_bootstrap_summary_path": "docs/reports/broker-bootstrap-review-summary.json",
   "validation_pack_path": "docs/reports/broker-failover-fault-injection-validation-pack.md",
   "configuration_state": "not_configured",
+  "bootstrap_summary": {
+    "event_log_backend": "memory",
+    "target_backend": "broker_replicated",
+    "ready": false,
+    "runtime_posture": "contract_only",
+    "live_adapter_implemented": false,
+    "proof_boundary": "broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof",
+    "config_completeness": {
+      "driver": false,
+      "urls": false,
+      "topic": false,
+      "consumer_group": false
+    },
+    "broker_bootstrap": {
+      "publish_timeout": "5s",
+      "replay_limit": 500,
+      "checkpoint_interval": "5s",
+      "ready": false,
+      "validation_errors": [
+        "broker event log config missing driver, urls, topic"
+      ]
+    },
+    "validation_errors": [
+      "broker event log config missing driver, urls, topic"
+    ]
+  },
+  "bootstrap_ready": false,
+  "runtime_posture": "contract_only",
+  "live_adapter_implemented": false,
+  "proof_boundary": "broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof",
+  "validation_errors": [
+    "broker event log config missing driver, urls, topic"
+  ],
+  "config_completeness": {
+    "driver": false,
+    "urls": false,
+    "topic": false,
+    "consumer_group": false
+  },
   "status": "skipped",
   "reason": "not_configured"
 }

--- a/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
+++ b/bigclaw-go/docs/reports/replicated-event-log-durability-rollout-contract.md
@@ -9,6 +9,7 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 ## Current baseline
 
 - `internal/events/durability.go` already declares `broker_replicated` as the target backend and surfaces the active durability plan through bootstrap and debug payloads, including broker bootstrap readiness derived from configured driver / URLs / topic settings.
+- `docs/reports/broker-validation-summary.json` now exports the same broker bootstrap review summary into the validation bundle path, including driver / URL / topic / consumer-group completeness, validation errors, and whether the runtime posture is `contract_only`, `stub_driver_only`, or `fail_closed_until_adapter_exists`.
 - `docs/reports/broker-durability-rollout-scorecard.json` now captures the same rollout posture as one checked-in machine-readable scorecard, including blockers, missing evidence, and broker bootstrap readiness.
 - `cmd/bigclawd/main.go` validates broker runtime config but intentionally stops before instantiating a live replicated adapter.
 - `docs/reports/event-bus-reliability-report.md` and `docs/reports/broker-failover-fault-injection-validation-pack.md` describe the portability and validation direction, but prior to this slice the rollout gate itself was not captured as one explicit contract.
@@ -71,6 +72,8 @@ It builds on the provider-neutral adapter boundary in `docs/reports/broker-event
 - references to the supporting validation pack and rollout contract documents
 
 The current repo-native sources for these signals are the `event_durability` payload and its nested `rollout_scorecard`, plus the top-level `event_durability_rollout` alias exposed through `GET /debug/status` and `/metrics`. Checked-in reviewer artifacts live at `docs/reports/broker-durability-rollout-scorecard.json`, `docs/reports/durability-rollout-scorecard.json`, `docs/reports/broker-checkpoint-fencing-proof-summary.json`, and `docs/reports/broker-retention-boundary-proof-summary.json`.
+
+`docs/reports/broker-validation-summary.json` is a reviewer-facing readiness surface, not evidence of a live broker adapter. A `ready` bootstrap summary only means the configured driver / URLs / topic / consumer group satisfy the pre-adapter contract; it does not prove replicated publish durability, live replay correctness, or a non-stub broker implementation.
 
 
 ## Validation evidence required before a live adapter lands

--- a/bigclaw-go/internal/events/durability.go
+++ b/bigclaw-go/internal/events/durability.go
@@ -50,6 +50,25 @@ type BrokerBootstrapStatus struct {
 	ValidationErrors   []string `json:"validation_errors,omitempty"`
 }
 
+type BrokerBootstrapCompleteness struct {
+	Driver        bool `json:"driver"`
+	URLs          bool `json:"urls"`
+	Topic         bool `json:"topic"`
+	ConsumerGroup bool `json:"consumer_group"`
+}
+
+type BrokerBootstrapReviewSummary struct {
+	EventLogBackend        DurabilityBackend           `json:"event_log_backend"`
+	TargetBackend          DurabilityBackend           `json:"target_backend"`
+	Ready                  bool                        `json:"ready"`
+	RuntimePosture         string                      `json:"runtime_posture"`
+	LiveAdapterImplemented bool                        `json:"live_adapter_implemented"`
+	ProofBoundary          string                      `json:"proof_boundary"`
+	ConfigCompleteness     BrokerBootstrapCompleteness `json:"config_completeness"`
+	BrokerBootstrap        *BrokerBootstrapStatus      `json:"broker_bootstrap,omitempty"`
+	ValidationErrors       []string                    `json:"validation_errors,omitempty"`
+}
+
 type RolloutEvidenceStatus struct {
 	Name      string   `json:"name"`
 	Status    string   `json:"status"`
@@ -457,4 +476,40 @@ func BrokerBootstrapStatusFromConfig(cfg BrokerRuntimeConfig) *BrokerBootstrapSt
 	}
 	status.Ready = true
 	return status
+}
+
+func BrokerBootstrapReviewSummaryFromConfig(eventBackend, targetBackend string, cfg BrokerRuntimeConfig) BrokerBootstrapReviewSummary {
+	current := NormalizeDurabilityBackend(eventBackend)
+	target := NormalizeDurabilityBackend(targetBackend)
+	bootstrap := BrokerBootstrapStatusFromConfig(cfg)
+	summary := BrokerBootstrapReviewSummary{
+		EventLogBackend:        current,
+		TargetBackend:          target,
+		Ready:                  bootstrap.Ready,
+		LiveAdapterImplemented: false,
+		ProofBoundary:          "broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof",
+		ConfigCompleteness: BrokerBootstrapCompleteness{
+			Driver:        strings.TrimSpace(cfg.Driver) != "",
+			URLs:          len(cfg.URLs) > 0,
+			Topic:         strings.TrimSpace(cfg.Topic) != "",
+			ConsumerGroup: strings.TrimSpace(cfg.ConsumerGroup) != "",
+		},
+		BrokerBootstrap: bootstrap,
+	}
+	if len(bootstrap.ValidationErrors) > 0 {
+		summary.ValidationErrors = append([]string(nil), bootstrap.ValidationErrors...)
+	}
+	switch {
+	case current == DurabilityBackendBrokerReplicated && strings.EqualFold(strings.TrimSpace(cfg.Driver), BrokerDriverStub):
+		summary.RuntimePosture = "stub_driver_only"
+		summary.ProofBoundary = "runtime can exercise the local stub driver, but that path remains deterministic scaffolding rather than a live broker adapter"
+	case current == DurabilityBackendBrokerReplicated:
+		summary.RuntimePosture = "fail_closed_until_adapter_exists"
+		summary.ProofBoundary = "runtime validates broker bootstrap config and then fails closed instead of claiming a live broker adapter"
+	case target == DurabilityBackendBrokerReplicated:
+		summary.RuntimePosture = "contract_only"
+	default:
+		summary.RuntimePosture = "not_requested"
+	}
+	return summary
 }

--- a/bigclaw-go/internal/events/durability_test.go
+++ b/bigclaw-go/internal/events/durability_test.go
@@ -130,3 +130,52 @@ func TestDurabilityPlanRolloutScorecardKeepsFailoverGateVisibleWhenBootstrapRead
 		t.Fatalf("expected no blockers with ready bootstrap and repo-native failover evidence, got %+v", scorecard.Blockers)
 	}
 }
+
+func TestBrokerBootstrapReviewSummaryFlagsContractOnlyReadiness(t *testing.T) {
+	summary := BrokerBootstrapReviewSummaryFromConfig("memory", "broker_replicated", BrokerRuntimeConfig{
+		PublishTimeout:     5 * time.Second,
+		ReplayLimit:        500,
+		CheckpointInterval: 5 * time.Second,
+	})
+
+	if summary.RuntimePosture != "contract_only" {
+		t.Fatalf("expected contract_only posture, got %+v", summary)
+	}
+	if summary.LiveAdapterImplemented {
+		t.Fatalf("expected no live adapter claim, got %+v", summary)
+	}
+	if summary.Ready {
+		t.Fatalf("expected bootstrap summary to stay not ready, got %+v", summary)
+	}
+	if summary.ConfigCompleteness.ConsumerGroup {
+		t.Fatalf("consumer group should not be marked complete when unset, got %+v", summary.ConfigCompleteness)
+	}
+	if len(summary.ValidationErrors) != 1 || summary.ValidationErrors[0] != "broker event log config missing driver, urls, topic" {
+		t.Fatalf("unexpected validation errors: %+v", summary.ValidationErrors)
+	}
+}
+
+func TestBrokerBootstrapReviewSummaryFlagsStubDriverAsScaffolding(t *testing.T) {
+	summary := BrokerBootstrapReviewSummaryFromConfig("broker", "broker_replicated", BrokerRuntimeConfig{
+		Driver:             BrokerDriverStub,
+		URLs:               []string{"stub://broker"},
+		Topic:              "bigclaw.events",
+		ConsumerGroup:      "bigclaw-consumers",
+		PublishTimeout:     7 * time.Second,
+		ReplayLimit:        2048,
+		CheckpointInterval: 15 * time.Second,
+	})
+
+	if summary.RuntimePosture != "stub_driver_only" {
+		t.Fatalf("expected stub posture, got %+v", summary)
+	}
+	if !summary.Ready {
+		t.Fatalf("expected ready bootstrap summary for configured stub driver, got %+v", summary)
+	}
+	if summary.LiveAdapterImplemented {
+		t.Fatalf("stub driver must not claim a live adapter, got %+v", summary)
+	}
+	if !summary.ConfigCompleteness.ConsumerGroup {
+		t.Fatalf("expected consumer group completeness, got %+v", summary.ConfigCompleteness)
+	}
+}

--- a/bigclaw-go/scripts/e2e/broker_bootstrap_summary.go
+++ b/bigclaw-go/scripts/e2e/broker_bootstrap_summary.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path/filepath"
+
+	"bigclaw-go/internal/config"
+	"bigclaw-go/internal/events"
+)
+
+func main() {
+	output := flag.String("output", "docs/reports/broker-bootstrap-review-summary.json", "output path for the broker bootstrap review summary")
+	flag.Parse()
+
+	cfg := config.LoadFromEnv()
+	summary := events.BrokerBootstrapReviewSummaryFromConfig(
+		cfg.EventLogBackend,
+		cfg.EventLogTargetBackend,
+		events.BrokerRuntimeConfig{
+			Driver:             cfg.EventLogBrokerDriver,
+			URLs:               cfg.EventLogBrokerURLs,
+			Topic:              cfg.EventLogBrokerTopic,
+			ConsumerGroup:      cfg.EventLogConsumerGroup,
+			PublishTimeout:     cfg.EventLogPublishTimeout,
+			ReplayLimit:        cfg.EventLogReplayLimit,
+			CheckpointInterval: cfg.EventLogCheckpointInterval,
+		},
+	)
+
+	if err := os.MkdirAll(filepath.Dir(*output), 0o755); err != nil {
+		panic(err)
+	}
+	body, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(*output, append(body, '\n'), 0o644); err != nil {
+		panic(err)
+	}
+}

--- a/bigclaw-go/scripts/e2e/export_validation_bundle.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle.py
@@ -13,6 +13,7 @@ LATEST_REPORTS = {
     'ray': 'docs/reports/ray-live-smoke-report.json',
 }
 BROKER_SUMMARY = 'docs/reports/broker-validation-summary.json'
+BROKER_BOOTSTRAP_SUMMARY = 'docs/reports/broker-bootstrap-review-summary.json'
 BROKER_VALIDATION_PACK = 'docs/reports/broker-failover-fault-injection-validation-pack.md'
 SHARED_QUEUE_REPORT = 'docs/reports/multi-node-shared-queue-report.json'
 SHARED_QUEUE_SUMMARY = 'docs/reports/shared-queue-companion-summary.json'
@@ -216,18 +217,41 @@ def build_broker_section(
     backend: str,
     root: Path,
     bundle_dir: Path,
+    bootstrap_summary_path: Path | None,
     report_path: Path | None,
 ) -> dict[str, Any]:
     bundle_summary_path = bundle_dir / 'broker-validation-summary.json'
+    bundle_bootstrap_summary_path = bundle_dir / 'broker-bootstrap-review-summary.json'
     section: dict[str, Any] = {
         'enabled': enabled,
         'backend': backend or None,
         'bundle_summary_path': relpath(bundle_summary_path, root),
         'canonical_summary_path': BROKER_SUMMARY,
+        'bundle_bootstrap_summary_path': relpath(bundle_bootstrap_summary_path, root),
+        'canonical_bootstrap_summary_path': BROKER_BOOTSTRAP_SUMMARY,
         'validation_pack_path': BROKER_VALIDATION_PACK,
     }
     configuration_state = 'configured' if enabled and backend else 'not_configured'
     section['configuration_state'] = configuration_state
+    bootstrap_summary = read_json(bootstrap_summary_path) if bootstrap_summary_path else None
+    if isinstance(bootstrap_summary, dict):
+        copied_bootstrap = copy_json_artifact(bootstrap_summary_path, bundle_bootstrap_summary_path)
+        if copied_bootstrap:
+            section['bundle_bootstrap_summary_path'] = relpath(Path(copied_bootstrap), root)
+        canonical_bootstrap = copy_json_artifact(bootstrap_summary_path, root / BROKER_BOOTSTRAP_SUMMARY)
+        if canonical_bootstrap:
+            section['canonical_bootstrap_summary_path'] = relpath(Path(canonical_bootstrap), root)
+        section['bootstrap_summary'] = bootstrap_summary
+        section['bootstrap_ready'] = bool(bootstrap_summary.get('ready'))
+        section['runtime_posture'] = bootstrap_summary.get('runtime_posture')
+        section['live_adapter_implemented'] = bool(bootstrap_summary.get('live_adapter_implemented'))
+        section['proof_boundary'] = bootstrap_summary.get('proof_boundary')
+        validation_errors = bootstrap_summary.get('validation_errors')
+        if isinstance(validation_errors, list):
+            section['validation_errors'] = validation_errors
+        completeness = bootstrap_summary.get('config_completeness')
+        if isinstance(completeness, dict):
+            section['config_completeness'] = completeness
 
     if not enabled or not backend:
         section['status'] = 'skipped'
@@ -353,9 +377,30 @@ def render_index(
         lines.append(f"- Configuration state: `{broker['configuration_state']}`")
         lines.append(f"- Bundle summary: `{broker['bundle_summary_path']}`")
         lines.append(f"- Canonical summary: `{broker['canonical_summary_path']}`")
+        lines.append(f"- Bundle bootstrap summary: `{broker['bundle_bootstrap_summary_path']}`")
+        lines.append(f"- Canonical bootstrap summary: `{broker['canonical_bootstrap_summary_path']}`")
         lines.append(f"- Validation pack: `{broker['validation_pack_path']}`")
         if broker.get('backend'):
             lines.append(f"- Backend: `{broker['backend']}`")
+        if broker.get('bootstrap_ready') is not None:
+            lines.append(f"- Bootstrap ready: `{broker['bootstrap_ready']}`")
+        if broker.get('runtime_posture'):
+            lines.append(f"- Runtime posture: `{broker['runtime_posture']}`")
+        if broker.get('live_adapter_implemented') is not None:
+            lines.append(f"- Live adapter implemented: `{broker['live_adapter_implemented']}`")
+        completeness = broker.get('config_completeness')
+        if isinstance(completeness, dict):
+            lines.append(
+                "- Config completeness: "
+                f"driver=`{completeness.get('driver', False)}` "
+                f"urls=`{completeness.get('urls', False)}` "
+                f"topic=`{completeness.get('topic', False)}` "
+                f"consumer_group=`{completeness.get('consumer_group', False)}`"
+            )
+        if broker.get('proof_boundary'):
+            lines.append(f"- Proof boundary: `{broker['proof_boundary']}`")
+        for error in broker.get('validation_errors', []):
+            lines.append(f"- Validation error: `{error}`")
         if broker.get('bundle_report_path'):
             lines.append(f"- Bundle report: `{broker['bundle_report_path']}`")
         if broker.get('canonical_report_path'):
@@ -449,6 +494,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument('--run-broker', default='0')
     parser.add_argument('--broker-backend', default='')
     parser.add_argument('--broker-report-path', default='')
+    parser.add_argument('--broker-bootstrap-summary-path', default='')
     parser.add_argument('--local-report-path', required=True)
     parser.add_argument('--local-stdout-path', required=True)
     parser.add_argument('--local-stderr-path', required=True)
@@ -510,6 +556,7 @@ def main() -> int:
         backend=args.broker_backend.strip(),
         root=root,
         bundle_dir=bundle_dir,
+        bootstrap_summary_path=(root / args.broker_bootstrap_summary_path) if args.broker_bootstrap_summary_path else None,
         report_path=(root / args.broker_report_path) if args.broker_report_path else None,
     )
     summary['shared_queue_companion'] = build_shared_queue_companion(root, bundle_dir)

--- a/bigclaw-go/scripts/e2e/export_validation_bundle_test.py
+++ b/bigclaw-go/scripts/e2e/export_validation_bundle_test.py
@@ -47,8 +47,21 @@ class ExportValidationBundleTest(unittest.TestCase):
                 'reason': 'not_configured',
                 'bundle_summary_path': 'docs/reports/live-validation-runs/20260316T140138Z/broker-validation-summary.json',
                 'canonical_summary_path': 'docs/reports/broker-validation-summary.json',
+                'bundle_bootstrap_summary_path': 'docs/reports/live-validation-runs/20260316T140138Z/broker-bootstrap-review-summary.json',
+                'canonical_bootstrap_summary_path': 'docs/reports/broker-bootstrap-review-summary.json',
                 'validation_pack_path': 'docs/reports/broker-failover-fault-injection-validation-pack.md',
                 'backend': None,
+                'bootstrap_ready': False,
+                'runtime_posture': 'contract_only',
+                'live_adapter_implemented': False,
+                'proof_boundary': 'broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof',
+                'config_completeness': {
+                    'driver': False,
+                    'urls': False,
+                    'topic': False,
+                    'consumer_group': False,
+                },
+                'validation_errors': ['broker event log config missing driver, urls, topic'],
             },
         }
         continuation_gate = {
@@ -68,6 +81,9 @@ class ExportValidationBundleTest(unittest.TestCase):
         self.assertIn('- Workflow exit code on current evidence: `2`', index_text)
         self.assertIn('### broker', index_text)
         self.assertIn('- Configuration state: `not_configured`', index_text)
+        self.assertIn('- Runtime posture: `contract_only`', index_text)
+        self.assertIn('- Live adapter implemented: `False`', index_text)
+        self.assertIn('- Validation error: `broker event log config missing driver, urls, topic`', index_text)
         self.assertIn('- Reason: `not_configured`', index_text)
 
     def test_build_broker_section_writes_not_configured_summary_when_disabled(self) -> None:
@@ -75,12 +91,22 @@ class ExportValidationBundleTest(unittest.TestCase):
             tmp_root = Path(tmpdir)
             bundle_dir = tmp_root / 'docs' / 'reports' / 'live-validation-runs' / 'run-1'
             bundle_dir.mkdir(parents=True, exist_ok=True)
+            bootstrap_summary_path = tmp_root / 'docs' / 'reports' / 'broker-bootstrap-review-summary-source.json'
+            bootstrap_summary_path.parent.mkdir(parents=True, exist_ok=True)
+            bootstrap_summary_path.write_text(
+                '{"ready": false, "runtime_posture": "contract_only", "live_adapter_implemented": false, '
+                '"proof_boundary": "broker bootstrap readiness is a pre-adapter contract surface, not live broker durability proof", '
+                '"config_completeness": {"driver": false, "urls": false, "topic": false, "consumer_group": false}, '
+                '"validation_errors": ["broker event log config missing driver, urls, topic"]}',
+                encoding='utf-8',
+            )
 
             section = MODULE.build_broker_section(
                 enabled=False,
                 backend='',
                 root=tmp_root,
                 bundle_dir=bundle_dir,
+                bootstrap_summary_path=bootstrap_summary_path,
                 report_path=None,
             )
 
@@ -91,8 +117,13 @@ class ExportValidationBundleTest(unittest.TestCase):
                 section['bundle_summary_path'],
                 'docs/reports/live-validation-runs/run-1/broker-validation-summary.json',
             )
+            self.assertEqual(section['runtime_posture'], 'contract_only')
+            self.assertFalse(section['live_adapter_implemented'])
+            self.assertFalse(section['config_completeness']['driver'])
             self.assertTrue((bundle_dir / 'broker-validation-summary.json').exists())
             self.assertTrue((tmp_root / 'docs/reports/broker-validation-summary.json').exists())
+            self.assertTrue((bundle_dir / 'broker-bootstrap-review-summary.json').exists())
+            self.assertTrue((tmp_root / 'docs/reports/broker-bootstrap-review-summary.json').exists())
 
 
 if __name__ == '__main__':

--- a/bigclaw-go/scripts/e2e/run_all.sh
+++ b/bigclaw-go/scripts/e2e/run_all.sh
@@ -13,6 +13,7 @@ RUN_RAY="${BIGCLAW_E2E_RUN_RAY:-1}"
 RUN_BROKER="${BIGCLAW_E2E_RUN_BROKER:-0}"
 BROKER_BACKEND="${BIGCLAW_E2E_BROKER_BACKEND:-}"
 BROKER_REPORT_PATH="${BIGCLAW_E2E_BROKER_REPORT_PATH:-}"
+BROKER_BOOTSTRAP_SUMMARY_PATH="${BIGCLAW_E2E_BROKER_BOOTSTRAP_SUMMARY_PATH:-docs/reports/broker-bootstrap-review-summary.json}"
 REFRESH_CONTINUATION="${BIGCLAW_E2E_REFRESH_CONTINUATION:-1}"
 ENFORCE_CONTINUATION_GATE="${BIGCLAW_E2E_ENFORCE_CONTINUATION_GATE:-0}"
 CONTINUATION_GATE_MODE="${BIGCLAW_E2E_CONTINUATION_GATE_MODE:-}"
@@ -79,6 +80,8 @@ if (( ${#pids[@]} > 0 )); then
 fi
 
 export_bundle() {
+  go run "$ROOT/scripts/e2e/broker_bootstrap_summary.go" \
+    --output "$ROOT/$BROKER_BOOTSTRAP_SUMMARY_PATH"
   python3 "$ROOT/scripts/e2e/export_validation_bundle.py" \
     --go-root "$ROOT" \
     --run-id "$RUN_ID" \
@@ -92,6 +95,7 @@ export_bundle() {
     --run-broker "$RUN_BROKER" \
     --broker-backend "$BROKER_BACKEND" \
     --broker-report-path "$BROKER_REPORT_PATH" \
+    --broker-bootstrap-summary-path "$BROKER_BOOTSTRAP_SUMMARY_PATH" \
     --validation-status "$status" \
     --local-report-path "$LOCAL_REPORT_REL" \
     --local-stdout-path "$LOCAL_OUT" \

--- a/bigclaw-go/scripts/e2e/run_all_test.py
+++ b/bigclaw-go/scripts/e2e/run_all_test.py
@@ -48,6 +48,25 @@ class RunAllTest(unittest.TestCase):
             executable=True,
         )
         self.write_file(
+            'scripts/e2e/broker_bootstrap_summary.go',
+            """\
+            package main
+
+            import (
+                "flag"
+                "os"
+            )
+
+            func main() {
+                output := flag.String("output", "", "output")
+                flag.Parse()
+                if err := os.WriteFile(*output, []byte("{\\"ready\\":false,\\"runtime_posture\\":\\"contract_only\\",\\"live_adapter_implemented\\":false}\\n"), 0o644); err != nil {
+                    panic(err)
+                }
+            }
+            """,
+        )
+        self.write_file(
             'scripts/e2e/export_validation_bundle.py',
             """\
             #!/usr/bin/env python3
@@ -66,6 +85,7 @@ class RunAllTest(unittest.TestCase):
                 'run_broker': args[args.index('--run-broker') + 1],
                 'broker_backend': args[args.index('--broker-backend') + 1],
                 'broker_report_path': args[args.index('--broker-report-path') + 1],
+                'broker_bootstrap_summary_path': args[args.index('--broker-bootstrap-summary-path') + 1],
             }
             with calls_path.open('a', encoding='utf-8') as handle:
                 handle.write(json.dumps(payload) + '\\n')
@@ -140,6 +160,7 @@ class RunAllTest(unittest.TestCase):
         self.assertEqual(calls[0]['run_broker'], '1')
         self.assertEqual(calls[0]['broker_backend'], 'stub')
         self.assertEqual(calls[0]['broker_report_path'], 'docs/reports/broker-failover-stub-report.json')
+        self.assertEqual(calls[0]['broker_bootstrap_summary_path'], 'docs/reports/broker-bootstrap-review-summary.json')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a Go-generated broker bootstrap review summary that reuses the runtime broker bootstrap contract
- thread the summary into validation bundle exports and reviewer index output with completeness, validation errors, and runtime posture
- document the surface as pre-adapter readiness only and cover it with Go/Python regression tests

## Validation
- go test ./internal/events
- python3 -m unittest scripts.e2e.export_validation_bundle_test scripts.e2e.run_all_test
