### PR TITLE
chore(tracker): record merged pr closeout

### DIFF
--- a/local-issues.json
+++ b/local-issues.json
@@ -160,6 +160,11 @@
           "author": "codex",
           "body": "Status refresh on 2026-03-21: PR #141 is merge-ready again after the latest tracker-only sync commit. GitHub now reports PR https://github.com/OpenAGIs/BigClaw/pull/141 as OPEN with merge state CLEAN, and the `test` workflow for commit 5ba7994309c5f49808dd9c86b97b70aa5bb33a34 completed successfully at 2026-03-20T16:09:11Z. No local implementation or validation work remains in this workspace; the only remaining blocker is reviewer approval and merge. Validation: gh pr view 141 --json url,title,state,mergeStateStatus,reviewDecision,statusCheckRollup -\u003e OPEN/CLEAN with successful completed test check; bash scripts/ops/bigclawctl github-sync status --json -\u003e local SHA 5ba7994309c5f49808dd9c86b97b70aa5bb33a34 matches remote SHA 5ba7994309c5f49808dd9c86b97b70aa5bb33a34 with status ok and synced true; git status --short --branch -\u003e clean branch. Commit SHA: pending tracker-note commit. PR URL: https://github.com/OpenAGIs/BigClaw/pull/141.",
           "created_at": "2026-03-20T16:10:00Z"
+        },
+        {
+          "author": "codex",
+          "body": "Final merge closeout: PR https://github.com/OpenAGIs/BigClaw/pull/141 (`BIG-GOM-304: complete BigClaw Go-mainline cutover`) merged into `main` at 2026-03-20T16:21:09Z with merge commit `669ed366cd3cea4ddf647280812021d084b87434`. No local child slices remain runnable; `bash scripts/ops/bigclawctl refill --local-issues local-issues.json` still reports no `In Progress` work and no promotion candidates. Validation: `gh pr view 141 --json url,title,state,mergedAt,mergeCommit` -\u003e `MERGED` with merge commit `669ed366cd3cea4ddf647280812021d084b87434`; `git push origin HEAD` -\u003e `Everything up-to-date`; `bash scripts/ops/bigclawctl github-sync status --json` -\u003e local SHA `b43ca5837c6fd05e56daca92d8d40263265de6ae` matches remote SHA `b43ca5837c6fd05e56daca92d8d40263265de6ae` with status `ok` and `synced: true`; `git rev-parse origin/main` -\u003e `669ed366cd3cea4ddf647280812021d084b87434`; `git log -1 --stat` -\u003e captured for commit `b43ca5837c6fd05e56daca92d8d40263265de6ae` with `local-issues.json` in the stat output. Commit SHA: pending tracker-note commit. PR URL: https://github.com/OpenAGIs/BigClaw/pull/141.",
+          "created_at": "2026-03-20T16:23:08Z"
         }
       ],
       "created_at": "2026-03-18T09:00:00Z",
@@ -175,7 +180,7 @@
       "priority": 2,
       "state": "Done",
       "title": "Observability, reporting, and weekly operations surface migration",
-      "updated_at": "2026-03-20T16:10:00Z"
+      "updated_at": "2026-03-20T16:23:08Z"
     },
     {
       "assigned_to_worker": true,


### PR DESCRIPTION
## Summary
- record the final merged-state closeout note for BIG-GOM-304 in local-issues.json
- capture the merge commit and final validation evidence on the issue branch after PR #141 merged

## Validation
- git push origin HEAD
- bash scripts/ops/bigclawctl github-sync status --json
- gh pr view 141 --json url,title,state,mergedAt,mergeCommit
- git log -1 --stat
