### PR TITLE
BIG-PAR-215: worker pool heartbeat health

### DIFF
--- a/bigclaw-go/internal/api/server.go
+++ b/bigclaw-go/internal/api/server.go
@@ -222,6 +222,11 @@ func (s *Server) Handler() http.Handler {
 		}
 		if pool := s.workerPoolSummary(); pool != nil {
 			payload["worker_pool"] = pool
+			if s.Now != nil {
+				payload["worker_pool_health"] = workerPoolHealth(s.Now(), pool)
+			} else {
+				payload["worker_pool_health"] = workerPoolHealth(time.Now(), pool)
+			}
 		}
 		if s.Control != nil {
 			payload["control"] = s.Control.Snapshot()

--- a/bigclaw-go/internal/api/server_test.go
+++ b/bigclaw-go/internal/api/server_test.go
@@ -1511,7 +1511,7 @@ func TestDebugStatusIncludesWorkerPoolSummary(t *testing.T) {
 		t.Fatalf("expected status 200, got %d", response.Code)
 	}
 	body := response.Body.String()
-	for _, want := range []string{"worker_pool", "total_workers", "3", "active_workers", "2", "idle_workers", "1", "worker-b", "leased", "preemption_active", "last_preempted_task_id", "task-low"} {
+	for _, want := range []string{"worker_pool", "worker_pool_health", "workers_missing_heartbeat", "total_workers", "3", "active_workers", "2", "idle_workers", "1", "worker-b", "leased", "preemption_active", "last_preempted_task_id", "task-low"} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("expected %q in debug payload, got %s", want, body)
 		}
@@ -2801,7 +2801,7 @@ func TestV2ControlCenterIncludesMultiWorkerPoolSummary(t *testing.T) {
 		t.Fatalf("expected control center 200, got %d", centerResponse.Code)
 	}
 	bodyText := centerResponse.Body.String()
-	for _, want := range []string{"worker_pool", "total_workers", "3", "active_workers", "2", "idle_workers", "1", "worker-c", "idle", "preemption_active", "task-low"} {
+	for _, want := range []string{"worker_pool", "worker_pool_health", "workers_missing_heartbeat", "total_workers", "3", "active_workers", "2", "idle_workers", "1", "worker-c", "idle", "preemption_active", "task-low"} {
 		if !strings.Contains(bodyText, want) {
 			t.Fatalf("expected %q in control center payload, got %s", want, bodyText)
 		}

--- a/bigclaw-go/internal/api/v2.go
+++ b/bigclaw-go/internal/api/v2.go
@@ -204,6 +204,17 @@ type workerPoolSummary struct {
 	Workers       []worker.Status `json:"workers"`
 }
 
+type workerPoolHealthSummary struct {
+	StaleAfterSeconds          int64    `json:"stale_after_seconds"`
+	WorkersWithHeartbeat       int      `json:"workers_with_heartbeat"`
+	WorkersMissingHeartbeat    int      `json:"workers_missing_heartbeat"`
+	StaleWorkers               int      `json:"stale_workers"`
+	StaleWorkerIDs             []string `json:"stale_worker_ids,omitempty"`
+	MissingHeartbeatWorkerIDs  []string `json:"missing_heartbeat_worker_ids,omitempty"`
+	OldestHeartbeatAgeSeconds  *int64   `json:"oldest_heartbeat_age_seconds,omitempty"`
+	NewestHeartbeatAgeSeconds  *int64   `json:"newest_heartbeat_age_seconds,omitempty"`
+}
+
 type controlActionAuditEntry struct {
 	OperationID      string       `json:"operation_id,omitempty"`
 	Action           string       `json:"action"`
@@ -1233,6 +1244,7 @@ func (s *Server) handleV2ControlCenter(w http.ResponseWriter, r *http.Request) {
 	}
 	if pool := s.workerPoolSummary(); pool != nil {
 		response["worker_pool"] = pool
+		response["worker_pool_health"] = workerPoolHealth(s.Now(), pool)
 	}
 	if checkpointResets := s.checkpointResetAuditSnapshot(filters.AuditLimit); checkpointResets != nil {
 		response["checkpoint_resets"] = checkpointResets
@@ -2786,5 +2798,60 @@ func (s *Server) workerPoolSummary() *workerPoolSummary {
 		ActiveWorkers: active,
 		IdleWorkers:   idle,
 		Workers:       snapshots,
+	}
+}
+
+func workerPoolHealth(now time.Time, pool *workerPoolSummary) *workerPoolHealthSummary {
+	if pool == nil {
+		return nil
+	}
+	// Default threshold: if a worker hasn't heartbeat in 5 minutes, surface it as stale in operator payloads.
+	staleAfter := 5 * time.Minute
+
+	withHeartbeat := 0
+	missingIDs := make([]string, 0)
+	staleIDs := make([]string, 0)
+	var oldestSeconds *int64
+	var newestSeconds *int64
+
+	for _, status := range pool.Workers {
+		if status.WorkerID == "" {
+			continue
+		}
+		if status.LastHeartbeatAt.IsZero() {
+			missingIDs = append(missingIDs, status.WorkerID)
+			continue
+		}
+		withHeartbeat++
+		age := now.Sub(status.LastHeartbeatAt)
+		if age < 0 {
+			age = 0
+		}
+		seconds := int64(age.Seconds())
+		if oldestSeconds == nil || seconds > *oldestSeconds {
+			value := seconds
+			oldestSeconds = &value
+		}
+		if newestSeconds == nil || seconds < *newestSeconds {
+			value := seconds
+			newestSeconds = &value
+		}
+		if age >= staleAfter {
+			staleIDs = append(staleIDs, status.WorkerID)
+		}
+	}
+
+	sort.Strings(staleIDs)
+	sort.Strings(missingIDs)
+
+	return &workerPoolHealthSummary{
+		StaleAfterSeconds:         int64(staleAfter.Seconds()),
+		WorkersWithHeartbeat:      withHeartbeat,
+		WorkersMissingHeartbeat:   len(missingIDs),
+		StaleWorkers:              len(staleIDs),
+		StaleWorkerIDs:            staleIDs,
+		MissingHeartbeatWorkerIDs: missingIDs,
+		OldestHeartbeatAgeSeconds: oldestSeconds,
+		NewestHeartbeatAgeSeconds: newestSeconds,
 	}
 }


### PR DESCRIPTION
Adds a `worker_pool_health` summary to `/debug/status` and `/v2/control-center` so multi-worker deployments can surface missing/stale heartbeats without digging through per-worker timestamps.

Follow-ups queued in local tracker:
- BIG-PAR-216: export worker heartbeat health metrics
- BIG-PAR-217: warn on stale/missing heartbeats in distributed diagnostics
- BIG-PAR-218: distributed validation matrix brief