### PR TITLE
BIG-PAR-224: record stale branch deletion

### DIFF
--- a/local-issues.json
+++ b/local-issues.json
@@ -1412,6 +1412,11 @@
           "author": "codex",
           "body": "Recovery note: landed the missing post-merge tracker comment onto `main` via PR #162.\n\nContext:\n- The \"PR merged\" tracker note above existed on branch `symphony/BIG-PAR-224` (commit `5065cf9fdb8812f4317cefc9a5b47d4dcbed7c33`) but was not part of `main` after PR #159 merged.\n\nWhat changed:\n- Opened and merged PR #162 to bring that tracker-only commit onto `main`.\n\nValidation:\n- `gh pr view 162 --repo OpenAGIs/BigClaw --json url,state,mergedAt,mergeCommit` -> MERGED at `2026-03-22T12:06:06Z` with merge commit `d1452673f1848de388447dfb8d0ecc24ab4e606c`\n- `git rev-parse HEAD origin/main` -> both `d1452673f1848de388447dfb8d0ecc24ab4e606c`\n- `bash scripts/ops/bigclawctl refill --local-issues local-issues.json` -> `active_in_progress: []`, `candidates: []`\n\nPR URL: https://github.com/OpenAGIs/BigClaw/pull/162.",
           "created_at": "2026-03-22T12:06:06Z"
+        },
+        {
+          "author": "codex",
+          "body": "Final cleanup: deleted the stale remote branch `symphony/BIG-PAR-224` after PR #159 merged (no open PRs remained for that head).\n\nValidation:\n- `gh pr list --repo OpenAGIs/BigClaw --head symphony/BIG-PAR-224 --json url,state` -> `[]`\n- `git ls-remote --heads origin symphony/BIG-PAR-224` -> no output (branch deleted)\n\nTimestamp: 2026-03-22T12:31:14Z.",
+          "created_at": "2026-03-22T12:31:14Z"
         }
       ],
       "created_at": "2026-03-22T09:40:00Z",
@@ -1426,7 +1431,7 @@
       "priority": 3,
       "state": "Done",
       "title": "Reconcile tracker and refill queue follow-up state",
-      "updated_at": "2026-03-22T12:06:06Z"
+      "updated_at": "2026-03-22T12:31:14Z"
     },
     {
       "assigned_to_worker": true,


### PR DESCRIPTION
Tracker-only follow-up: record deletion of the stale symphony/BIG-PAR-224 remote branch after PR #159 merged.