### PR TITLE
BIG-PAR-224: terminal audit note

### DIFF
--- a/local-issues.json
+++ b/local-issues.json
@@ -1417,6 +1417,11 @@
           "author": "codex",
           "body": "Final cleanup: deleted the stale remote branch `symphony/BIG-PAR-224` after PR #159 merged (no open PRs remained for that head).\n\nValidation:\n- `gh pr list --repo OpenAGIs/BigClaw --head symphony/BIG-PAR-224 --json url,state` -> `[]`\n- `git ls-remote --heads origin symphony/BIG-PAR-224` -> no output (branch deleted)\n\nTimestamp: 2026-03-22T12:31:14Z.",
           "created_at": "2026-03-22T12:31:14Z"
+        },
+        {
+          "author": "codex",
+          "body": "Terminal audit: `BIG-PAR-224` is fully reconciled across the repo-native tracker, refill queue, merged PR history, and remote branch state.\n\nWhat changed in the recovery tail:\n- PR #162 merged the missing post-merge tracker note for PR #159 onto `main`.\n- PR #163 recorded that PR #162 recovery merge in `local-issues.json`.\n- PR #164 recorded the deletion of the stale `symphony/BIG-PAR-224` remote branch.\n\nFinal validation:\n- `bash scripts/ops/bigclawctl refill --local-issues local-issues.json` -> `active_in_progress: []`, `candidates: []`\n- `git ls-remote --heads origin symphony/BIG-PAR-224` -> no output\n- `git rev-parse HEAD origin/main` -> both `a9703163ce2931e69d7a967d16cbb46a5ab556a9`\n- `bash scripts/ops/bigclawctl github-sync status --json` -> `status: ok`, `synced: true`, clean detached `HEAD`\n- `git log -1 --stat` -> captured for merge commit `a9703163ce2931e69d7a967d16cbb46a5ab556a9`\n\nCommit SHA: pending tracker-note commit.\nPR URL: pending.",
+          "created_at": "2026-03-22T12:40:47Z"
         }
       ],
       "created_at": "2026-03-22T09:40:00Z",
@@ -1431,7 +1436,7 @@
       "priority": 3,
       "state": "Done",
       "title": "Reconcile tracker and refill queue follow-up state",
-      "updated_at": "2026-03-22T12:31:14Z"
+      "updated_at": "2026-03-22T12:40:47Z"
     },
     {
       "assigned_to_worker": true,


### PR DESCRIPTION
Tracker-only follow-up: add a terminal audit comment to BIG-PAR-224 so the tracker includes the recovery PR chain and stale-branch deletion evidence.