### PR TITLE
BIG-PAR-236: harden local tracker recovery and serialization

### DIFF
--- a/bigclaw-go/internal/refill/local_store.go
+++ b/bigclaw-go/internal/refill/local_store.go
@@ -1,6 +1,7 @@
 package refill
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -302,8 +303,11 @@ func (s *LocalIssueStore) Save() error {
 		issues = []map[string]any{}
 	}
 	payload := map[string]any{"issues": issues}
-	body, err := json.MarshalIndent(payload, "", "  ")
-	if err != nil {
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(payload); err != nil {
 		return err
 	}
 	dir := filepath.Dir(s.path)
@@ -325,7 +329,7 @@ func (s *LocalIssueStore) Save() error {
 		_ = tmp.Close()
 		return err
 	}
-	if _, err := tmp.Write(append(body, '\n')); err != nil {
+	if _, err := tmp.Write(buf.Bytes()); err != nil {
 		_ = tmp.Close()
 		return err
 	}

--- a/bigclaw-go/internal/refill/local_store_test.go
+++ b/bigclaw-go/internal/refill/local_store_test.go
@@ -127,3 +127,42 @@ func TestLocalIssueStoreAddCommentAppendsAndUpdatesTimestamp(t *testing.T) {
 		t.Fatalf("expected updated_at refresh, got %s", text)
 	}
 }
+
+func TestLocalIssueStoreSaveDoesNotEscapeArrowTokens(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "local-issues.json")
+	if err := os.WriteFile(storePath, []byte(`{
+  "issues": [
+    {
+      "id": "big-gom-307",
+      "identifier": "BIG-GOM-307",
+      "title": "Toolchain migration",
+      "state": "Todo",
+      "comments": [
+        {"author": "codex", "created_at": "2026-03-18T09:00:00Z", "body": "seed -> ok"}
+      ]
+    }
+  ]
+}`), 0o644); err != nil {
+		t.Fatalf("write local issue store: %v", err)
+	}
+
+	store, err := LoadLocalIssueStore(storePath)
+	if err != nil {
+		t.Fatalf("load local issue store: %v", err)
+	}
+	if _, err := store.UpdateIssueState("BIG-GOM-307", "In Progress", time.Date(2026, 3, 18, 15, 0, 0, 0, time.UTC)); err != nil {
+		t.Fatalf("update issue state: %v", err)
+	}
+
+	body, err := os.ReadFile(storePath)
+	if err != nil {
+		t.Fatalf("read local issue store: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "seed -> ok") {
+		t.Fatalf("expected arrow token to persist, got %s", text)
+	}
+	if strings.Contains(text, `\\u003e`) {
+		t.Fatalf("expected no HTML escaping, got %s", text)
+	}
+}

--- a/docs/local-tracker-automation.md
+++ b/docs/local-tracker-automation.md
@@ -27,6 +27,19 @@ Guidance:
 - Prefer absolute repo roots in hook invocations so `--local-issues ../local-issues.json`
   resolves to the workspace tracker file (not a nested `bigclaw-go/local-issues.json`).
 
+## Rate-limit fallback
+
+If Symphony or Codex child-agent orchestration starts returning
+`429 Too Many Requests`:
+
+- stop spawning new child agents for the current batch;
+- keep the currently claimed issue in `In Progress` and continue the slice
+  locally in the existing workspace;
+- lower the workflow concurrency caps before re-enabling broad fanout so the
+  next polling cycle does not immediately re-trigger the same rate limit;
+- prefer one fresh issue branch at a time until GitHub sync, local validation,
+  and tracker updates are stable again.
+
 Examples:
 
 ```bash
@@ -45,4 +58,3 @@ bash scripts/ops/bigclawctl local-issues ensure \
   --set-state-if-exists \
   --json
 ```
-

--- a/docs/parallel-refill-queue.md
+++ b/docs/parallel-refill-queue.md
@@ -52,6 +52,10 @@ longer waits on Linear to keep issue execution moving.
   - `BIG-PAR-220`, `BIG-PAR-221`, `BIG-PAR-222`, `BIG-PAR-223`, `BIG-PAR-224`, `BIG-PAR-225`, `BIG-PAR-226`, `BIG-PAR-227`, `BIG-PAR-228`, `BIG-PAR-229`, `BIG-PAR-230`, and `BIG-PAR-231` are now closed in the repo-native tracker
   - `BIG-PAR-234` closed: `bigclawctl` now supports root and subcommand `--help` with exit 0
   - run `bash scripts/ops/bigclawctl refill --apply --local-issues local-issues.json` to confirm whether any additional `Todo` slices should be promoted
+- Queue drained recovery:
+  - if `bigclawctl refill` reports `queue_drained: true`, the queue has no runnable identifiers left in `docs/parallel-refill-queue.json`
+  - add the next `BIG-PAR-*` identifiers to `docs/parallel-refill-queue.json` (`issue_order` plus a matching `issues[]` record) and create matching `local-issues.json` tracker entries
+  - once the next batch exists, run `bash scripts/ops/bigclawctl refill --apply --local-issues local-issues.json --sync-queue-status` to align queue metadata with the local tracker state
 - Completed slices:
   - `BIG-GOM-301` — unified domain model and intake contract migration
   - `BIG-GOM-302` — risk, policy, and approval semantics migration


### PR DESCRIPTION
## Summary
- stop `LocalIssueStore.Save` from HTML-escaping tracker comment text so closeout notes keep readable `->` / shell snippets instead of `\u003e` noise
- add regression coverage for the local tracker save path
- document the recovery path for `429 Too Many Requests` fanout failures and fully drained refill queues

## Validation
- `cd bigclaw-go && go test ./internal/refill`
- `git diff --check`
