### PR TITLE
BIG-PAR-237: emit queue-drained recovery hints in refill output

### DIFF
--- a/bigclaw-go/cmd/bigclawctl/main.go
+++ b/bigclaw-go/cmd/bigclawctl/main.go
@@ -924,6 +924,11 @@ func runRefillOnce(queue *refill.ParallelIssueQueue, client refillClient, apply 
 	payload["queue_drained"] = queueRunnable == 0
 	if queueRunnable == 0 {
 		payload["warning"] = "refill queue drained: no runnable identifiers in docs/parallel-refill-queue.json"
+		payload["next_steps"] = []string{
+			"Add the next BIG-PAR identifiers to docs/parallel-refill-queue.json (issue_order + issues[] records).",
+			"Ensure matching tracker entries exist in local-issues.json (e.g. `bash scripts/ops/bigclawctl local-issues ensure --local-issues local-issues.json --identifier BIG-PAR-XXX --state Todo --json`).",
+			"Optionally align queue metadata: `bash scripts/ops/bigclawctl refill --apply --local-issues local-issues.json --sync-queue-status`.",
+		}
 	}
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")

--- a/bigclaw-go/cmd/bigclawctl/main_test.go
+++ b/bigclaw-go/cmd/bigclawctl/main_test.go
@@ -304,6 +304,15 @@ func TestRunRefillOnceLocalIssueStoreDetectsQueueDrainedWhenMetadataStale(t *tes
 	if !bytes.Contains(output, []byte(`"queue_runnable": 0`)) {
 		t.Fatalf("expected runnable count 0, got %s", string(output))
 	}
+	if !bytes.Contains(output, []byte(`"next_steps": [`)) {
+		t.Fatalf("expected drained queue next_steps guidance, got %s", string(output))
+	}
+	if !bytes.Contains(output, []byte(`docs/parallel-refill-queue.json`)) {
+		t.Fatalf("expected queue recovery hint, got %s", string(output))
+	}
+	if !bytes.Contains(output, []byte(`local-issues ensure`)) {
+		t.Fatalf("expected local issue ensure hint, got %s", string(output))
+	}
 }
 
 func TestRunHelpAtRootPrintsUsageAndExitsZero(t *testing.T) {


### PR DESCRIPTION
## Summary
- when the refill queue is fully drained, `bigclawctl refill` now emits an actionable `next_steps` section in its JSON output
- add regression coverage for the drained queue guidance

## Validation
- `cd bigclaw-go && go test ./cmd/bigclawctl`
- `bash scripts/ops/bigclawctl refill --repo . --local-issues local-issues.json` (shows `next_steps` when drained)
